### PR TITLE
GH-1: CIMXML CI/CD

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "group:allNonMajor"
+  ],
+  "dependencyDashboard": true,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "12 hours"
+    }
+  ],
+  "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"]
+}

--- a/.github/workflows/cimxml-ci.yml
+++ b/.github/workflows/cimxml-ci.yml
@@ -7,8 +7,6 @@ on:
       - ".github/workflows/cimxml-ci.yml"
       - ".github/workflows/cimxml-release.yml"
   push:
-    branches:
-      - "main"
     paths:
       - "cimxml/**"
       - ".github/workflows/cimxml-ci.yml"

--- a/.github/workflows/cimxml-ci.yml
+++ b/.github/workflows/cimxml-ci.yml
@@ -1,0 +1,79 @@
+name: cimxml-ci
+
+on:
+  pull_request:
+    paths:
+      - "cimxml/**"
+      - ".github/workflows/cimxml-ci.yml"
+      - ".github/workflows/cimxml-release.yml"
+  push:
+    branches:
+      - "main"
+    paths:
+      - "cimxml/**"
+      - ".github/workflows/cimxml-ci.yml"
+      - ".github/workflows/cimxml-release.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cimxml-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Java 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          cache-dependency-path: cimxml/pom.xml
+
+      - name: Build and test
+        run: mvn -B -ntp -f cimxml/pom.xml clean verify
+
+  publish-snapshot-github-packages:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Java 21 for GitHub Packages
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          cache-dependency-path: cimxml/pom.xml
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Enforce snapshot version on main
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(mvn -q -f cimxml/pom.xml help:evaluate -Dexpression=project.version -DforceStdout)"
+          if [[ "${VERSION}" != *-SNAPSHOT ]]; then
+            echo "Expected cimxml version to end with -SNAPSHOT on main, found: ${VERSION}" >&2
+            exit 1
+          fi
+
+      - name: Deploy snapshot to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn -B -ntp -f cimxml/pom.xml clean deploy \
+            -DaltDeploymentRepository=github::https://maven.pkg.github.com/${{ github.repository }}

--- a/.github/workflows/cimxml-release.yml
+++ b/.github/workflows/cimxml-release.yml
@@ -1,0 +1,127 @@
+name: cimxml-release
+
+on:
+  push:
+    tags:
+      - "cimxml-v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cimxml-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.validate.outputs.release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate release tag and pom version
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "${TAG}" =~ ^cimxml-v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Invalid tag format '${TAG}'. Expected cimxml-vX.Y.Z" >&2
+            exit 1
+          fi
+
+          RELEASE_VERSION="${TAG#cimxml-v}"
+          POM_VERSION="$(mvn -q -f cimxml/pom.xml help:evaluate -Dexpression=project.version -DforceStdout)"
+          POM_BASE="${POM_VERSION%-SNAPSHOT}"
+
+          if [[ "${POM_BASE}" != "${RELEASE_VERSION}" ]]; then
+            echo "Tag version '${RELEASE_VERSION}' does not match pom base version '${POM_BASE}' (pom=${POM_VERSION})" >&2
+            exit 1
+          fi
+
+          echo "release_version=${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
+
+  publish-maven-central:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    env:
+      CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+      CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+      MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      RELEASE_VERSION: ${{ needs.validate-tag.outputs.release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate required secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "${CENTRAL_PORTAL_USERNAME}" ]] || (echo "CENTRAL_PORTAL_USERNAME is missing" >&2; exit 1)
+          [[ -n "${CENTRAL_PORTAL_PASSWORD}" ]] || (echo "CENTRAL_PORTAL_PASSWORD is missing" >&2; exit 1)
+          [[ -n "${MAVEN_GPG_PASSPHRASE}" ]] || (echo "MAVEN_GPG_PASSPHRASE is missing" >&2; exit 1)
+
+      - name: Setup Java 21 + Maven Central auth + GPG
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          cache-dependency-path: cimxml/pom.xml
+          server-id: central
+          server-username: CENTRAL_PORTAL_USERNAME
+          server-password: CENTRAL_PORTAL_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Set release version in CI workspace
+        run: |
+          mvn -B -ntp -f cimxml/pom.xml \
+            org.codehaus.mojo:versions-maven-plugin:2.21.0:set \
+            -DnewVersion="${RELEASE_VERSION}" \
+            -DgenerateBackupPoms=false
+
+      - name: Publish to Maven Central
+        run: mvn -B -ntp -f cimxml/pom.xml -Pcentral-release clean deploy
+
+  publish-github-packages-release:
+    needs:
+      - validate-tag
+      - publish-maven-central
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_VERSION: ${{ needs.validate-tag.outputs.release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Java 21 for GitHub Packages
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          cache-dependency-path: cimxml/pom.xml
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Set release version in CI workspace
+        run: |
+          mvn -B -ntp -f cimxml/pom.xml \
+            org.codehaus.mojo:versions-maven-plugin:2.21.0:set \
+            -DnewVersion="${RELEASE_VERSION}" \
+            -DgenerateBackupPoms=false
+
+      - name: Publish release to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn -B -ntp -f cimxml/pom.xml -DskipTests clean deploy \
+            -DaltDeploymentRepository=github::https://maven.pkg.github.com/${{ github.repository }}

--- a/.github/workflows/cimxml-release.yml
+++ b/.github/workflows/cimxml-release.yml
@@ -47,6 +47,7 @@ jobs:
   publish-maven-central:
     needs: validate-tag
     runs-on: ubuntu-latest
+    environment: Maven Central Deployment
     env:
       CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
       CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+target/
+.idea/

--- a/cimxml/README.md
+++ b/cimxml/README.md
@@ -284,8 +284,23 @@ The module includes comprehensive test coverage:
 
 Run tests with:
 ```bash
-mvn test -pl jena-iec61970-552
+mvn -f cimxml/pom.xml test
 ```
+
+## Release Process
+
+`cimxml` uses GitHub Actions for CI/CD.
+
+- Pull requests and pushes to `main` run build and tests.
+- Pushes to `main` also publish `-SNAPSHOT` artifacts to GitHub Packages.
+- Pushing a tag in the format `cimxml-vX.Y.Z` triggers a release:
+  - publish signed artifacts to Maven Central (Sonatype Central Portal)
+  - publish release artifacts to GitHub Packages
+
+Versioning model:
+- `cimxml/pom.xml` on `main` remains `X.Y.Z-SNAPSHOT`
+- release tag defines the release version (`X.Y.Z`)
+- CI sets that release version in the workflow workspace for deployment only
 
 ## Dependencies
 

--- a/cimxml/pom.xml
+++ b/cimxml/pom.xml
@@ -46,6 +46,16 @@
         <url>https://www.soptim.de/</url>
     </organization>
 
+    <developers>
+        <developer>
+            <id>soptim</id>
+            <name>SOPTIM AG</name>
+            <email>opencgmes@soptim.de</email>
+            <organization>SOPTIM AG</organization>
+            <organizationUrl>https://www.soptim.de/</organizationUrl>
+        </developer>
+    </developers>
+
     <scm>
         <connection>scm:git:https://github.com/SOPTIM/OpenCGMES.git</connection>
         <developerConnection>scm:git:https://github.com/SOPTIM/OpenCGMES.git</developerConnection>
@@ -84,6 +94,8 @@
         <ver.plugin.surefire>3.5.3</ver.plugin.surefire>
         <ver.plugin.source>3.3.1</ver.plugin.source>
         <ver.plugin.javadoc>3.11.3</ver.plugin.javadoc>
+        <ver.plugin.gpg>3.2.8</ver.plugin.gpg>
+        <ver.plugin.central-publishing>0.10.0</ver.plugin.central-publishing>
     </properties>
 
     <dependencies>
@@ -227,4 +239,46 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>central-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${ver.plugin.central-publishing}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${ver.plugin.gpg}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Added CI/CD pipelines for CIMXML library.

- Added CI (building & testing) for cimxml.
- Commits to branch `main` are publishing artifacts to GitHub Packages
- `cimxml-vX.Y.Z` tags publish signed release artifacts to Maven Central and GitHub Packages.
- Version for releases comes from release tag, Snapshot versions (`main` branch) from `pom.xml`