### PR TITLE
docs(cimnotebook): add marketplace links and install badges (GH-30)

### DIFF
--- a/cimnotebook/intellij/README.md
+++ b/cimnotebook/intellij/README.md
@@ -17,11 +17,15 @@
 -->
 # CIMNotebook for IntelliJ
 
+[![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/32789?label=JetBrains%20Marketplace&logo=intellijidea)](https://plugins.jetbrains.com/plugin/32789-cimnotebook)
+
 Real-time SPARQL and SHACL validation against CIM/CGMES schema profiles, directly in IntelliJ-based IDEs.
 
 Write a SPARQL query or SHACL shape and get immediate feedback: unknown classes and properties are underlined, syntax errors are highlighted, and semantic issues like domain/range mismatches are flagged as you type — all resolved against your actual RDFS profile files.
 
 The plugin is a thin client around the CIMLangServer (`cimvocabcheck-lsp`), wired into the IDE through the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) LSP client.
+
+**Install** from the [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/32789-cimnotebook) — search for **CIMNotebook** under **Settings → Plugins → Marketplace**. LSP4IJ is pulled in automatically.
 
 > 📖 **Full documentation:** <https://opencgmes.soptim.de/cimnotebook/intellij> — including the
 > [`opencgmes.jsonc` configuration reference](https://opencgmes.soptim.de/cimvocabcheck/configuration),

--- a/cimnotebook/vscode/README.md
+++ b/cimnotebook/vscode/README.md
@@ -1,8 +1,12 @@
 # CIMNotebook
 
+[![Visual Studio Marketplace](https://vsmarketplacebadges.dev/version-short/soptim-ag.cimnotebook.svg)](https://marketplace.visualstudio.com/items?itemName=soptim-ag.cimnotebook)
+
 Real-time SPARQL and SHACL validation against CIM/CGMES schema profiles, directly in VS Code.
 
 Write a SPARQL query or SHACL shape and get immediate feedback: unknown classes and properties are underlined, syntax errors are highlighted, and semantic issues like domain/range mismatches are flagged as you type — all resolved against your actual RDFS profile files.
+
+**Install** from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=soptim-ag.cimnotebook) — search for **CIMNotebook** in the Extensions view, or run `code --install-extension soptim-ag.cimnotebook`.
 
 > 📖 **Full documentation:** <https://opencgmes.soptim.de/cimnotebook/vscode> — including the
 > [`opencgmes.jsonc` configuration reference](https://opencgmes.soptim.de/cimvocabcheck/configuration),

--- a/docs/content/cimnotebook/intellij.md
+++ b/docs/content/cimnotebook/intellij.md
@@ -20,8 +20,10 @@ profiles directly in IntelliJ-platform IDEs. It is a thin client around
 
 ## Install
 
-Install **CIMNotebook** from the Marketplace (**Settings → Plugins → Marketplace**). LSP4IJ is a
-required dependency, and IntelliJ installs it automatically as part of a Marketplace install.
+Install **CIMNotebook** from the
+[**JetBrains Marketplace**](https://plugins.jetbrains.com/plugin/32789-cimnotebook) — inside the IDE
+open **Settings → Plugins → Marketplace**, search for **CIMNotebook**, and click **Install**. LSP4IJ
+is a required dependency, and IntelliJ installs it automatically as part of a Marketplace install.
 
 :::warning Installing from disk
 If you install CIMNotebook from a downloaded `.zip` (**Install Plugin from Disk**), IntelliJ does

--- a/docs/content/cimnotebook/intellij.md
+++ b/docs/content/cimnotebook/intellij.md
@@ -3,6 +3,8 @@ title: IntelliJ
 sidebar_position: 3
 ---
 
+import JetBrainsInstall from '@site/src/components/MarketplaceInstall/JetBrainsInstall';
+
 # CIMNotebook for IntelliJ
 
 The IntelliJ plugin gives you real-time SPARQL and SHACL validation against CIM / CGMES schema
@@ -24,6 +26,8 @@ Install **CIMNotebook** from the
 [**JetBrains Marketplace**](https://plugins.jetbrains.com/plugin/32789-cimnotebook) — inside the IDE
 open **Settings → Plugins → Marketplace**, search for **CIMNotebook**, and click **Install**. LSP4IJ
 is a required dependency, and IntelliJ installs it automatically as part of a Marketplace install.
+
+<JetBrainsInstall pluginId={32789} />
 
 :::warning Installing from disk
 If you install CIMNotebook from a downloaded `.zip` (**Install Plugin from Disk**), IntelliJ does

--- a/docs/content/cimnotebook/overview.md
+++ b/docs/content/cimnotebook/overview.md
@@ -82,9 +82,12 @@ canonically, on the [Configuration](/cimvocabcheck/configuration) page.
 
 ## Pick your editor
 
-- **[VS Code](/cimnotebook/vscode)** — install the VSIX, configure a schema, and validate `.rq`,
-  `.sparql`, `.ttl`, `.shacl` files plus [SPARQL Notebook cells](/cimnotebook/sparql-notebooks).
-- **[IntelliJ](/cimnotebook/intellij)** — install the plugin (and LSP4IJ) and validate the same
-  file types inside any IntelliJ-platform IDE.
+- **[VS Code](/cimnotebook/vscode)** — install from the
+  [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=soptim-ag.cimnotebook),
+  configure a schema, and validate `.rq`, `.sparql`, `.ttl`, `.shacl` files plus
+  [SPARQL Notebook cells](/cimnotebook/sparql-notebooks).
+- **[IntelliJ](/cimnotebook/intellij)** — install from the
+  [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/32789-cimnotebook) (LSP4IJ is pulled
+  in automatically) and validate the same file types inside any IntelliJ-platform IDE.
 
 Hitting a problem? See [Troubleshooting](/cimnotebook/troubleshooting).

--- a/docs/content/cimnotebook/vscode.md
+++ b/docs/content/cimnotebook/vscode.md
@@ -18,7 +18,16 @@ settings, and the server provides every diagnostic, hover, completion, and defin
 
 ## Install
 
-Install from a packaged `.vsix`:
+Install from the
+[**Visual Studio Marketplace**](https://marketplace.visualstudio.com/items?itemName=soptim-ag.cimnotebook):
+open the **Extensions** view, search for **CIMNotebook**, and click **Install** — or from the
+command line:
+
+```bash
+code --install-extension soptim-ag.cimnotebook
+```
+
+Alternatively, install from a packaged `.vsix`:
 
 ```bash
 code --install-extension cimnotebook-<version>.vsix

--- a/docs/content/cimnotebook/vscode.md
+++ b/docs/content/cimnotebook/vscode.md
@@ -3,6 +3,8 @@ title: VS Code
 sidebar_position: 2
 ---
 
+import VSCodeInstall from '@site/src/components/MarketplaceInstall/VSCodeInstall';
+
 # CIMNotebook for VS Code
 
 The VS Code extension gives you real-time SPARQL and SHACL validation against CIM / CGMES schema
@@ -17,6 +19,8 @@ settings, and the server provides every diagnostic, hover, completion, and defin
 - **VS Code 1.75** or later.
 
 ## Install
+
+<VSCodeInstall />
 
 Install from the
 [**Visual Studio Marketplace**](https://marketplace.visualstudio.com/items?itemName=soptim-ag.cimnotebook):

--- a/docs/src/components/MarketplaceInstall/JetBrainsInstall.jsx
+++ b/docs/src/components/MarketplaceInstall/JetBrainsInstall.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import MarketplaceCard from './MarketplaceCard';
+
+/**
+ * Install card for the CIMNotebook JetBrains plugin. Styled identically to the
+ * VS Code card; the action links to the JetBrains Marketplace listing (from
+ * where the IDE's "Install to IDE" flow takes over).
+ *
+ * @param {number|string} pluginId numeric Marketplace plugin id (CIMNotebook = 32789)
+ * @param {string} [slug]          Marketplace URL slug
+ */
+export default function JetBrainsInstall({pluginId = 32789, slug = 'cimnotebook'}) {
+  const marketplaceUrl = `https://plugins.jetbrains.com/plugin/${pluginId}-${slug}`;
+  return (
+    <MarketplaceCard
+      name="CIMNotebook"
+      marketplace="SOPTIM AG · JetBrains Marketplace"
+      badgeSrc={`https://img.shields.io/jetbrains/plugin/v/${pluginId}?label=JetBrains%20Marketplace&color=%234c8eda`}
+      badgeAlt="CIMNotebook version on the JetBrains Marketplace"
+      actions={[{label: 'Get from Marketplace', href: marketplaceUrl, primary: true, external: true}]}
+    />
+  );
+}

--- a/docs/src/components/MarketplaceInstall/MarketplaceCard.jsx
+++ b/docs/src/components/MarketplaceInstall/MarketplaceCard.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+/**
+ * Presentational install card shared by the VS Code and JetBrains widgets so
+ * both marketplaces render with an identical look: name, marketplace line,
+ * a version badge, and one or more call-to-action links.
+ *
+ * @param {string} name         product name shown as the card title
+ * @param {string} marketplace  publisher / marketplace line
+ * @param {string} [badgeSrc]   URL of a version badge image
+ * @param {string} [badgeAlt]   alt text for the badge
+ * @param {Array<{label: string, href: string, primary?: boolean, external?: boolean}>} actions
+ */
+export default function MarketplaceCard({name, marketplace, badgeSrc, badgeAlt, actions = []}) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.body}>
+        <span className={styles.title}>{name}</span>
+        <span className={styles.publisher}>{marketplace}</span>
+        {badgeSrc && <img className={styles.badge} src={badgeSrc} alt={badgeAlt} />}
+      </div>
+      <div className={styles.actions}>
+        {actions.map((action) => (
+          <a
+            key={action.href + action.label}
+            className={action.primary ? styles.primary : styles.secondary}
+            href={action.href}
+            {...(action.external ? {target: '_blank', rel: 'noopener noreferrer'} : {})}
+          >
+            {action.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/MarketplaceInstall/VSCodeInstall.jsx
+++ b/docs/src/components/MarketplaceInstall/VSCodeInstall.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import MarketplaceCard from './MarketplaceCard';
+
+const EXTENSION_ID = 'soptim-ag.cimnotebook';
+
+/**
+ * Install card for the CIMNotebook VS Code extension. The primary action uses a
+ * `vscode:` deep link that opens the extension page inside a local VS Code.
+ */
+export default function VSCodeInstall() {
+  return (
+    <MarketplaceCard
+      name="CIMNotebook"
+      marketplace="SOPTIM AG · Visual Studio Marketplace"
+      badgeSrc="https://vsmarketplacebadges.dev/version-short/soptim-ag.cimnotebook.svg"
+      badgeAlt="CIMNotebook version on the Visual Studio Marketplace"
+      actions={[
+        {label: 'Install in VS Code', href: `vscode:extension/${EXTENSION_ID}`, primary: true},
+        {
+          label: 'View on Marketplace',
+          href: `https://marketplace.visualstudio.com/items?itemName=${EXTENSION_ID}`,
+          external: true,
+        },
+      ]}
+    />
+  );
+}

--- a/docs/src/components/MarketplaceInstall/styles.module.css
+++ b/docs/src/components/MarketplaceInstall/styles.module.css
@@ -1,0 +1,86 @@
+/*
+ * Shared styling for the CIMNotebook marketplace install widgets
+ * (VS Code custom card + JetBrains official widget wrapper).
+ */
+
+.card {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+  padding: 1.25rem 1.5rem;
+  margin: 1rem 0 1.75rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  background: var(--ifm-background-surface-color);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 12rem;
+}
+
+.title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.publisher {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.9rem;
+}
+
+.badge {
+  /* align-self keeps the badge at its intrinsic size — without it the flex
+     column would stretch the image to full width and distort it. */
+  align-self: flex-start;
+  margin-top: 0.35rem;
+  height: 20px;
+  width: auto;
+  max-width: 100%;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.primary,
+.secondary {
+  display: inline-block;
+  padding: 0.55rem 1.15rem;
+  border-radius: 8px;
+  font-weight: 600;
+  white-space: nowrap;
+  text-decoration: none;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.primary {
+  background: var(--ifm-color-primary);
+  color: #fff;
+}
+
+.primary:hover {
+  background: var(--ifm-color-primary-dark);
+  color: #fff;
+  text-decoration: none;
+}
+
+.secondary {
+  border: 1px solid var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.secondary:hover {
+  background: var(--ifm-color-primary);
+  color: #fff;
+  text-decoration: none;
+}


### PR DESCRIPTION
- Link the VS Code extension to the Visual Studio Marketplace and the
  IntelliJ plugin to the JetBrains Marketplace from the docs Install
  sections and the overview "Pick your editor" list.
- Add marketplace version badges + Install lines to both editor READMEs
  (which double as the Marketplace/JetBrains listing pages). Use
  vsmarketplacebadges.dev for VS Code since shields.io retired its
  Visual Studio Marketplace endpoint.
- Add a shared MarketplaceCard component rendering a consistent install
  card (name, marketplace, version badge, action buttons) for both
  editors, wired into the VS Code and IntelliJ docs Install sections.
- VS Code card offers a `vscode:` deep-link install plus a Marketplace
  link; IntelliJ card links to the JetBrains Marketplace listing. Both
  render server-side, so they work without JavaScript.

Closes #30