### PR TITLE
chore(cicd): stop renovate from bumping in-repo de.soptim.opencgmes deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,11 @@
     {
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "12 hours"
+    },
+    {
+      "description": "In-repo modules are pinned to the 0.0.0-SNAPSHOT placeholder (versions come from git tags at release time) — never update them",
+      "matchPackageNames": ["de.soptim.opencgmes:*"],
+      "enabled": false
     }
   ],
   "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"]


### PR DESCRIPTION
Cross-module dependencies (cimvocabcheck-core, cimxml) are intentionally pinned to the 0.0.0-SNAPSHOT placeholder; real versions are applied from git tags at build/release time, so renovate must not touch them.