### PR TITLE
chore(cicd): auto-regenerate SBOMs on Renovate PRs (GH-36)

### DIFF
--- a/.github/workflows/conflict-labeler.yml
+++ b/.github/workflows/conflict-labeler.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Apply label
-        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
+        uses: SOPTIM/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
         with:
           dirtyLabel: "merge conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/renovate-sbom-autofix.yml
+++ b/.github/workflows/renovate-sbom-autofix.yml
@@ -1,0 +1,103 @@
+name: renovate-sbom-autofix
+
+# Renovate updates dependency manifests but cannot regenerate the committed
+# supply-chain artifacts (CycloneDX SBOMs + THIRD-PARTY attribution), so the
+# sbom drift gates in cimvocabcheck-ci / cimnotebook-ci would fail on every
+# dependency PR. On Renovate PRs this workflow reruns scripts/generate-sbom.sh
+# and pushes the regenerated files back to the PR branch.
+#
+#   * .github/renovate.json lists github-actions[bot] in gitIgnoredAuthors, so
+#     Renovate still treats the branch as unmodified and keeps rebasing it; a
+#     rebase drops the autofix commit, this workflow then re-adds it.
+#   * A push made with the default GITHUB_TOKEN does NOT retrigger the other
+#     CI workflows on the new head SHA (GitHub suppresses recursive workflow
+#     runs). Add the optional RENOVATE_AUTOFIX_TOKEN repository secret (a
+#     fine-grained PAT or GitHub App token with contents: read/write) to have
+#     the autofix commit re-run CI and turn the drift gates green.
+#   * The autofix commit only touches the sbom/ directories, which are not in
+#     the paths filter below — the workflow cannot retrigger itself.
+
+on:
+  pull_request:
+    paths:
+      - "pom.xml"
+      - "cimxml/pom.xml"
+      - "cimvocabcheck/pom.xml"
+      - "cimvocabcheck/core/pom.xml"
+      - "cimvocabcheck/cli/pom.xml"
+      - "cimvocabcheck/lsp/pom.xml"
+      - "cimnotebook/vscode/package.json"
+      - "cimnotebook/vscode/package-lock.json"
+      - "cimnotebook/intellij/build.gradle.kts"
+      - "cimnotebook/intellij/settings.gradle.kts"
+      - "cimnotebook/intellij/gradle.properties"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: renovate-sbom-autofix-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  regenerate-sboms:
+    # Same-repo Renovate branches only: forks cannot be pushed to with this
+    # token, and human PRs keep the strict drift gates instead.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.RENOVATE_AUTOFIX_TOKEN || github.token }}
+
+      - name: Setup Java 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          cache-dependency-path: |
+            pom.xml
+            cimxml/pom.xml
+            cimvocabcheck/core/pom.xml
+            cimvocabcheck/cli/pom.xml
+            cimvocabcheck/lsp/pom.xml
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: cimnotebook/vscode/package-lock.json
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          gradle-version: "9.5.0"
+          cache-read-only: true
+
+      # Regenerates all committed SBOMs / attribution files. Still FAILS the PR
+      # if a bumped dependency uses a license outside the reviewed allow-list —
+      # that always needs a human decision, never an auto-commit.
+      - name: Regenerate SBOMs + enforce license allow-list
+        env:
+          GRADLE: gradle
+        run: bash scripts/generate-sbom.sh maven vscode intellij
+
+      - name: Commit and push regenerated SBOMs
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet -- cimvocabcheck/sbom cimnotebook/sbom; then
+            echo "SBOMs already up to date — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add cimvocabcheck/sbom cimnotebook/sbom
+          git commit -m "chore(cicd): regenerate SBOMs for dependency updates"
+          git push origin "HEAD:${HEAD_REF}"


### PR DESCRIPTION
- New renovate-sbom-autofix workflow: on same-repo renovate/* PRs that touch
  dependency manifests, rerun scripts/generate-sbom.sh (maven, vscode,
  intellij) and push the regenerated SBOM/attribution files back to the PR
  branch as github-actions[bot] (already in renovate.json gitIgnoredAuthors).
- License allow-list violations still fail the workflow instead of being
  auto-committed.
- Optional RENOVATE_AUTOFIX_TOKEN secret makes the autofix commit retrigger
  CI (default GITHUB_TOKEN pushes do not re-run workflows).
- Updated Merge Conflict Labeling Action to SOPTIM fork

Closes #36