### PR TITLE
chore(cicd): group renovate deps updates per project (GH-40)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,11 +16,17 @@
       "enabled": false
     },
     {
-      "description": "Group non-major updates per project so each gets its own PR",
+      "description": "Group updates per project — one non-major and one major PR each",
       "matchFileNames": ["cimxml/**"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "cimxml non-major dependencies",
       "groupSlug": "cimxml-non-major"
+    },
+    {
+      "matchFileNames": ["cimxml/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "cimxml major dependencies",
+      "groupSlug": "cimxml-major"
     },
     {
       "matchFileNames": ["cimvocabcheck/**"],
@@ -29,10 +35,22 @@
       "groupSlug": "cimvocabcheck-non-major"
     },
     {
+      "matchFileNames": ["cimvocabcheck/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "cimvocabcheck major dependencies",
+      "groupSlug": "cimvocabcheck-major"
+    },
+    {
       "matchFileNames": ["cimnotebook/**"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "cimnotebook non-major dependencies",
       "groupSlug": "cimnotebook-non-major"
+    },
+    {
+      "matchFileNames": ["cimnotebook/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "cimnotebook major dependencies",
+      "groupSlug": "cimnotebook-major"
     },
     {
       "matchFileNames": ["docs/**"],
@@ -41,16 +59,34 @@
       "groupSlug": "docs-non-major"
     },
     {
+      "matchFileNames": ["docs/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "docs major dependencies",
+      "groupSlug": "docs-major"
+    },
+    {
       "matchFileNames": ["pom.xml"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "maven parent non-major dependencies",
       "groupSlug": "maven-parent-non-major"
     },
     {
+      "matchFileNames": ["pom.xml"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "maven parent major dependencies",
+      "groupSlug": "maven-parent-major"
+    },
+    {
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "github actions non-major dependencies",
       "groupSlug": "github-actions-non-major"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "github actions major dependencies",
+      "groupSlug": "github-actions-major"
     }
   ],
   "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "group:allNonMajor"
+    "config:recommended"
   ],
   "dependencyDashboard": true,
   "labels": ["dependencies"],
@@ -15,6 +14,43 @@
       "description": "In-repo modules are pinned to the 0.0.0-SNAPSHOT placeholder (versions come from git tags at release time) — never update them",
       "matchPackageNames": ["de.soptim.opencgmes:*"],
       "enabled": false
+    },
+    {
+      "description": "Group non-major updates per project so each gets its own PR",
+      "matchFileNames": ["cimxml/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "cimxml non-major dependencies",
+      "groupSlug": "cimxml-non-major"
+    },
+    {
+      "matchFileNames": ["cimvocabcheck/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "cimvocabcheck non-major dependencies",
+      "groupSlug": "cimvocabcheck-non-major"
+    },
+    {
+      "matchFileNames": ["cimnotebook/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "cimnotebook non-major dependencies",
+      "groupSlug": "cimnotebook-non-major"
+    },
+    {
+      "matchFileNames": ["docs/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "docs non-major dependencies",
+      "groupSlug": "docs-non-major"
+    },
+    {
+      "matchFileNames": ["pom.xml"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "maven parent non-major dependencies",
+      "groupSlug": "maven-parent-non-major"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "github actions non-major dependencies",
+      "groupSlug": "github-actions-non-major"
     }
   ],
   "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"]


### PR DESCRIPTION
Group renovate dependency updates per project, so each project gets separate pull requests for depenencies.

This allows more control for releases and separated versions inside this OpenCGMES monorepo.

Closes #40