### PR TITLE
feat(cimnotebook): native SPARQL/SHACL notebook support (GH-44)

### DIFF
--- a/cimnotebook/sbom/vscode/THIRD-PARTY.txt
+++ b/cimnotebook/sbom/vscode/THIRD-PARTY.txt
@@ -1,8 +1,9 @@
-Third-party dependencies for CIMNotebook VS Code extension (9 component(s)).
+Third-party dependencies for CIMNotebook VS Code extension (10 component(s)).
 Generated from the committed CycloneDX SBOM by scripts/check-sbom-licenses.py — do not edit by hand.
 
      (MIT) balanced-match:4.0.4 (pkg:npm/balanced-match@4.0.4)
      (MIT) brace-expansion:5.0.7 (pkg:npm/brace-expansion@5.0.7)
+     (MIT) jsonc-parser:3.3.1 (pkg:npm/jsonc-parser@3.3.1)
      (BlueOak-1.0.0) minimatch:10.2.5 (pkg:npm/minimatch@10.2.5)
      (ISC) semver:7.8.1 (pkg:npm/semver@7.8.1)
      (MIT) vscode-jsonrpc:9.0.1 (pkg:npm/vscode-jsonrpc@9.0.1)

--- a/cimnotebook/sbom/vscode/bom.json
+++ b/cimnotebook/sbom/vscode/bom.json
@@ -193,6 +193,40 @@
     },
     {
       "type": "library",
+      "name": "jsonc-parser",
+      "version": "3.3.1",
+      "bom-ref": "cimnotebook@0.0.0|jsonc-parser@3.3.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/jsonc-parser@3.3.1",
+      "externalReferences": [
+        {
+          "url": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+          "type": "distribution",
+          "hashes": [
+            {
+              "alg": "SHA-512",
+              "content": "1d4807eb92b27a3ad414fbc714f6ea398d2bb058a9dc1a39c1be2782f762d44a426165100c2e55f98ee6670b3e0cb92be0cfffcd02686a7bb548ffbcec3bf5a1"
+            }
+          ],
+          "comment": "as detected from npm-ls property \"resolved\" and property \"integrity\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:path",
+          "value": "node_modules/jsonc-parser"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "minimatch",
       "version": "10.2.5",
       "bom-ref": "cimnotebook@0.0.0|minimatch@10.2.5",
@@ -434,6 +468,7 @@
     {
       "ref": "cimnotebook@0.0.0",
       "dependsOn": [
+        "cimnotebook@0.0.0|jsonc-parser@3.3.1",
         "cimnotebook@0.0.0|vscode-languageclient@10.1.0"
       ]
     },
@@ -445,6 +480,9 @@
       "dependsOn": [
         "cimnotebook@0.0.0|balanced-match@4.0.4"
       ]
+    },
+    {
+      "ref": "cimnotebook@0.0.0|jsonc-parser@3.3.1"
     },
     {
       "ref": "cimnotebook@0.0.0|minimatch@10.2.5",

--- a/cimnotebook/vscode/.gitignore
+++ b/cimnotebook/vscode/.gitignore
@@ -2,3 +2,4 @@ out/
 node_modules/
 *.vsix
 server/sparql-validate-lsp.jar
+out-test/

--- a/cimnotebook/vscode/.prettierignore
+++ b/cimnotebook/vscode/.prettierignore
@@ -8,3 +8,4 @@ syntaxes/
 schemas/
 *.png
 *.svg
+out-test/

--- a/cimnotebook/vscode/.vscodeignore
+++ b/cimnotebook/vscode/.vscodeignore
@@ -7,3 +7,5 @@ esbuild.js
 .vscode/**
 **/*.ts
 **/*.map
+out-test/
+tsconfig.test.json

--- a/cimnotebook/vscode/esbuild.js
+++ b/cimnotebook/vscode/esbuild.js
@@ -26,6 +26,12 @@ esbuild
         bundle: true,
         outfile: "out/extension.js",
         external: ["vscode"], // provided by VS Code at runtime — never bundle
+        // jsonc-parser's CJS entry is a UMD wrapper that passes `require` into its
+        // factory as a plain function parameter; esbuild cannot statically follow the
+        // factory's internal require("./impl/…") calls and leaves them in the bundle as
+        // runtime requires, which crash extension activation with "Cannot find module
+        // './impl/format'". Bundling its ESM build instead makes every import static.
+        alias: { "jsonc-parser": "jsonc-parser/lib/esm/main.js" },
         format: "cjs",
         platform: "node",
         target: "node20",

--- a/cimnotebook/vscode/eslint.config.mjs
+++ b/cimnotebook/vscode/eslint.config.mjs
@@ -25,7 +25,7 @@ import soptim from "./eslint-rules/index.mjs";
 
 export default tseslint.config(
     {
-        ignores: ["out/**", "dist/**", "node_modules/**", "server/**", "*.vsix"],
+        ignores: ["out/**", "out-test/**", "dist/**", "node_modules/**", "server/**", "*.vsix"],
     },
 
     // TypeScript extension sources: full recommended rule set + license header.

--- a/cimnotebook/vscode/media/activity-icon.svg
+++ b/cimnotebook/vscode/media/activity-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 112 112">
+  <!-- Activity-bar icon: VS Code uses the SVG's alpha channel as a mask, so this is the
+       CIMNotebook logo's checkmark-with-nodes motif on a transparent background (the
+       marketplace icon's filled canvas would mask to a solid square). -->
+  <path d="M22.22,61.26l23.05,23.05,46.1-52.69" fill="none" stroke="currentColor" stroke-width="13.17" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="19.04" cy="57.96" r="11.5" fill="currentColor"/>
+  <circle cx="45.27" cy="84.31" r="11.5" fill="currentColor"/>
+  <circle cx="91.37" cy="31.62" r="11.5" fill="currentColor"/>
+</svg>

--- a/cimnotebook/vscode/package-lock.json
+++ b/cimnotebook/vscode/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "jsonc-parser": "^3.3.1",
                 "vscode-languageclient": "^10.0.0"
             },
             "devDependencies": {
@@ -1430,6 +1431,12 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsonc-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
             "license": "MIT"
         },
         "node_modules/keyv": {

--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -142,6 +142,21 @@
                 "command": "cimnotebook.notebook.convert",
                 "title": "Convert Notebook (Markdown ⇔ SPARQL Book)",
                 "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.notebook.setEndpoint",
+                "title": "Set Cell Endpoint…",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.notebook.setCredentials",
+                "title": "Set Connection Credentials…",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.notebook.clearCredentials",
+                "title": "Clear Connection Credentials…",
+                "category": "CIMNotebook"
             }
         ],
         "menus": {
@@ -163,6 +178,16 @@
                 {
                     "command": "cimnotebook.notebook.convert",
                     "when": "activeNotebookType =~ /^cimnotebook/"
+                },
+                {
+                    "command": "cimnotebook.notebook.setEndpoint",
+                    "when": "activeNotebookType =~ /^cimnotebook/"
+                },
+                {
+                    "command": "cimnotebook.notebook.setCredentials"
+                },
+                {
+                    "command": "cimnotebook.notebook.clearCredentials"
                 }
             ]
         },

--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -113,6 +113,51 @@
                 ]
             }
         ],
+        "viewsContainers": {
+            "activitybar": [
+                {
+                    "id": "cimnotebook",
+                    "title": "CIMNotebook",
+                    "icon": "media/activity-icon.svg"
+                }
+            ]
+        },
+        "views": {
+            "cimnotebook": [
+                {
+                    "id": "cimnotebook.connectionsView",
+                    "name": "Connections",
+                    "contextualTitle": "OpenCGMES Connections"
+                },
+                {
+                    "id": "cimnotebook.validationView",
+                    "name": "Validation",
+                    "contextualTitle": "OpenCGMES Validation"
+                },
+                {
+                    "id": "cimnotebook.executionView",
+                    "name": "Notebook Execution",
+                    "contextualTitle": "OpenCGMES Notebook Execution"
+                }
+            ]
+        },
+        "viewsWelcome": [
+            {
+                "view": "cimnotebook.connectionsView",
+                "contents": "No `opencgmes.jsonc` was found for this workspace.\n[Create Config File](command:cimnotebook.createConfig)",
+                "when": "!cimnotebook.hasConfig"
+            },
+            {
+                "view": "cimnotebook.validationView",
+                "contents": "Validation settings appear once an `opencgmes.jsonc` exists.\n[Create Config File](command:cimnotebook.createConfig)",
+                "when": "!cimnotebook.hasConfig"
+            },
+            {
+                "view": "cimnotebook.executionView",
+                "contents": "Notebook execution settings appear once an `opencgmes.jsonc` exists.\n[Create Config File](command:cimnotebook.createConfig)",
+                "when": "!cimnotebook.hasConfig"
+            }
+        ],
         "jsonValidation": [
             {
                 "fileMatch": [
@@ -157,6 +202,79 @@
                 "command": "cimnotebook.notebook.clearCredentials",
                 "title": "Clear Connection Credentials…",
                 "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.connections.add",
+                "title": "Add Connection",
+                "category": "CIMNotebook",
+                "icon": "$(add)"
+            },
+            {
+                "command": "cimnotebook.connections.edit",
+                "title": "Edit Connection",
+                "category": "CIMNotebook",
+                "icon": "$(edit)"
+            },
+            {
+                "command": "cimnotebook.connections.remove",
+                "title": "Remove Connection",
+                "category": "CIMNotebook",
+                "icon": "$(trash)"
+            },
+            {
+                "command": "cimnotebook.connections.toggleDefault",
+                "title": "Set/Unset as Default Connection",
+                "category": "CIMNotebook",
+                "icon": "$(star)"
+            },
+            {
+                "command": "cimnotebook.connections.credentials",
+                "title": "Set/Clear Connection Credentials",
+                "category": "CIMNotebook",
+                "icon": "$(key)"
+            },
+            {
+                "command": "cimnotebook.config.openFile",
+                "title": "Open opencgmes.jsonc",
+                "category": "CIMNotebook",
+                "icon": "$(go-to-file)"
+            },
+            {
+                "command": "cimnotebook.config.editStrictness",
+                "title": "Edit Strictness",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.config.editStandardVocabulary",
+                "title": "Edit Standard Vocabulary Check",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.config.editSchemasDirectory",
+                "title": "Edit Schemas Directory",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.config.addSchemaFile",
+                "title": "Add Schema File",
+                "category": "CIMNotebook",
+                "icon": "$(add)"
+            },
+            {
+                "command": "cimnotebook.config.removeSchemaFile",
+                "title": "Remove Schema File",
+                "category": "CIMNotebook",
+                "icon": "$(trash)"
+            },
+            {
+                "command": "cimnotebook.config.editQueryTimeout",
+                "title": "Edit Query Timeout",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.config.editMaxRows",
+                "title": "Edit Max Rows",
+                "category": "CIMNotebook"
             }
         ],
         "menus": {
@@ -188,6 +306,102 @@
                 },
                 {
                     "command": "cimnotebook.notebook.clearCredentials"
+                },
+                {
+                    "command": "cimnotebook.connections.add",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.connections.edit",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.connections.remove",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.connections.toggleDefault",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.connections.credentials",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.openFile",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editStrictness",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editStandardVocabulary",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editSchemasDirectory",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.addSchemaFile",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.removeSchemaFile",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editQueryTimeout",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editMaxRows",
+                    "when": "false"
+                }
+            ],
+            "view/title": [
+                {
+                    "command": "cimnotebook.connections.add",
+                    "when": "view == cimnotebook.connectionsView && cimnotebook.hasConfig",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "cimnotebook.config.openFile",
+                    "when": "view == cimnotebook.connectionsView",
+                    "group": "navigation@2"
+                }
+            ],
+            "view/item/context": [
+                {
+                    "command": "cimnotebook.connections.edit",
+                    "when": "view == cimnotebook.connectionsView && viewItem =~ /^connection\\b/",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "cimnotebook.connections.credentials",
+                    "when": "view == cimnotebook.connectionsView && viewItem =~ /\\bbasic\\b/",
+                    "group": "inline@2"
+                },
+                {
+                    "command": "cimnotebook.connections.toggleDefault",
+                    "when": "view == cimnotebook.connectionsView && viewItem =~ /^connection\\b/",
+                    "group": "inline@3"
+                },
+                {
+                    "command": "cimnotebook.connections.remove",
+                    "when": "view == cimnotebook.connectionsView && viewItem =~ /^connection\\b/",
+                    "group": "inline@4"
+                },
+                {
+                    "command": "cimnotebook.config.addSchemaFile",
+                    "when": "view == cimnotebook.validationView && viewItem == schemasParent",
+                    "group": "inline"
+                },
+                {
+                    "command": "cimnotebook.config.removeSchemaFile",
+                    "when": "view == cimnotebook.validationView && viewItem == schemaFile",
+                    "group": "inline"
                 }
             ]
         },
@@ -260,15 +474,16 @@
         "copy-jar": "cp ../../cimvocabcheck/lsp/target/cimvocabcheck-lsp-*.jar server/cimvocabcheck-lsp.jar"
     },
     "dependencies": {
+        "jsonc-parser": "^3.3.1",
         "vscode-languageclient": "^10.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^24.0.0",
         "@types/vscode": "^1.75.0",
+        "esbuild": "^0.28.0",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
-        "esbuild": "^0.28.0",
         "prettier": "^3.8.4",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.61.1"

--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -31,7 +31,9 @@
         "onLanguage:turtle",
         "workspaceContains:**/*.ttl",
         "workspaceContains:**/*.shacl",
-        "onNotebook:sparql-notebook"
+        "onNotebook:sparql-notebook",
+        "onNotebook:cimnotebook",
+        "onNotebook:cimnotebook-markdown"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -74,6 +76,30 @@
                 "embeddedLanguages": {
                     "meta.embedded.block.sparql": "sparql"
                 }
+            }
+        ],
+        "notebooks": [
+            {
+                "type": "cimnotebook",
+                "displayName": "CIM Notebook",
+                "selector": [
+                    {
+                        "filenamePattern": "*.cimnb.md"
+                    }
+                ]
+            },
+            {
+                "type": "cimnotebook-markdown",
+                "displayName": "CIM Notebook (Markdown)",
+                "priority": "option",
+                "selector": [
+                    {
+                        "filenamePattern": "*.md"
+                    },
+                    {
+                        "filenamePattern": "*.markdown"
+                    }
+                ]
             }
         ],
         "jsonValidation": [
@@ -180,6 +206,7 @@
         "vscode:prepublish": "node esbuild.js --production",
         "bundle": "node esbuild.js",
         "compile": "tsc --noEmit",
+        "test": "tsc -p tsconfig.test.json && node --test \"out-test/**/*.test.js\"",
         "watch": "node esbuild.js --watch",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",

--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -295,11 +295,11 @@
                 },
                 {
                     "command": "cimnotebook.notebook.convert",
-                    "when": "activeNotebookType =~ /^cimnotebook/"
+                    "when": "notebookType =~ /^cimnotebook/"
                 },
                 {
                     "command": "cimnotebook.notebook.setEndpoint",
-                    "when": "activeNotebookType =~ /^cimnotebook/"
+                    "when": "notebookType =~ /^cimnotebook/"
                 },
                 {
                     "command": "cimnotebook.notebook.setCredentials"

--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -33,7 +33,8 @@
         "workspaceContains:**/*.shacl",
         "onNotebook:sparql-notebook",
         "onNotebook:cimnotebook",
-        "onNotebook:cimnotebook-markdown"
+        "onNotebook:cimnotebook-markdown",
+        "onNotebook:cimnotebook-sparqlbook"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -100,6 +101,16 @@
                         "filenamePattern": "*.markdown"
                     }
                 ]
+            },
+            {
+                "type": "cimnotebook-sparqlbook",
+                "displayName": "CIM Notebook (SPARQL Book)",
+                "priority": "option",
+                "selector": [
+                    {
+                        "filenamePattern": "*.sparqlbook"
+                    }
+                ]
             }
         ],
         "jsonValidation": [
@@ -126,6 +137,11 @@
                 "command": "cimnotebook.createConfig",
                 "title": "Create Config File (opencgmes.jsonc)",
                 "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.notebook.convert",
+                "title": "Convert Notebook (Markdown ⇔ SPARQL Book)",
+                "category": "CIMNotebook"
             }
         ],
         "menus": {
@@ -143,6 +159,10 @@
                 },
                 {
                     "command": "cimnotebook.createConfig"
+                },
+                {
+                    "command": "cimnotebook.notebook.convert",
+                    "when": "activeNotebookType =~ /^cimnotebook/"
                 }
             ]
         },

--- a/cimnotebook/vscode/schemas/validation.schema.json
+++ b/cimnotebook/vscode/schemas/validation.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "OpenCGMES Configuration (opencgmes.jsonc)",
-    "description": "Configuration for OpenCGMES tools. CIMVocabCheck reads the \"cimvocabcheck\" section. Place this file at the root of your project (or any parent directory of your queries); CIMVocabCheck discovers the nearest one walking up the tree. The file is optional — without it, validation uses the bundled CGMES 3.0 schemas.",
+    "description": "Configuration for OpenCGMES tools. CIMVocabCheck reads the \"cimvocabcheck\" section. Place this file at the root of your project (or any parent directory of your queries); CIMVocabCheck discovers the nearest one walking up the tree. The file is optional — but without a configured schema, validation is syntax-only (there is no bundled default schema).",
     "type": "object",
     "additionalProperties": true,
     "properties": {
@@ -60,16 +60,16 @@
         },
         "cimvocabcheck": {
             "type": "object",
-            "description": "CIMVocabCheck SPARQL/SHACL validation settings. All fields are optional; when neither \"schemas\" nor \"schemasDirectory\" is set, the bundled CGMES 3.0 profiles are used.",
+            "description": "CIMVocabCheck SPARQL/SHACL validation settings. All fields are optional; when neither \"schemas\" nor \"schemasDirectory\" is set, no schema is loaded and validation is syntax-only (there is no bundled default schema).",
             "additionalProperties": false,
             "properties": {
                 "schemasDirectory": {
                     "type": "string",
-                    "description": "Path to a directory containing RDFS profile files (.rdf, .ttl, .owl). All files in the directory are loaded as schema profiles. Path is resolved relative to this config file. Omit to use the bundled CGMES 3.0 schemas."
+                    "description": "Path to a directory containing RDFS profile files (.rdf, .ttl, .owl). All files in the directory are loaded as schema profiles. Path is resolved relative to this config file. Without this (and without \"schemas\"), validation is syntax-only."
                 },
                 "schemas": {
                     "type": "array",
-                    "description": "List of individual RDFS profile files to load. Each entry is a path relative to this config file. Omit to use the bundled CGMES 3.0 schemas.",
+                    "description": "List of individual RDFS profile files to load. Each entry is a path relative to this config file. Without this (and without \"schemasDirectory\"), validation is syntax-only.",
                     "items": {
                         "type": "string",
                         "description": "Path to an RDFS profile file (.rdf, .ttl, or .owl), relative to this config file."

--- a/cimnotebook/vscode/schemas/validation.schema.json
+++ b/cimnotebook/vscode/schemas/validation.schema.json
@@ -5,6 +5,59 @@
     "type": "object",
     "additionalProperties": true,
     "properties": {
+        "cimnotebook": {
+            "type": "object",
+            "description": "CIM Notebook execution settings (VS Code). Named connections referenced by # [endpoint=<name>] directives, plus workspace defaults for running cells. Passwords are NEVER stored here — declare \"authType\": \"basic\" and CIMNotebook keeps the credentials in VS Code secret storage.",
+            "additionalProperties": false,
+            "properties": {
+                "connections": {
+                    "type": "array",
+                    "description": "Named SPARQL endpoint connections for notebook cells.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["name", "url"],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The connection's name — cells reference it with # [endpoint=<name>]. Use letters, digits, dashes and underscores (no dots or slashes, which would read as a file path)."
+                            },
+                            "url": {
+                                "type": "string",
+                                "description": "SPARQL query endpoint URL, e.g. http://localhost:3030/dataset/query."
+                            },
+                            "updateUrl": {
+                                "type": "string",
+                                "description": "SPARQL Update endpoint URL. Omit to derive it from \"url\" (Fuseki-style …/query → …/update)."
+                            },
+                            "shaclUrl": {
+                                "type": "string",
+                                "description": "SHACL validation service URL. Omit to derive it from \"url\" (…/query → …/shacl?graph=default)."
+                            },
+                            "authType": {
+                                "type": "string",
+                                "enum": ["none", "basic"],
+                                "description": "Authentication scheme. With \"basic\", CIMNotebook prompts once for username/password and stores them in VS Code secret storage — never in this file."
+                            },
+                            "default": {
+                                "type": "boolean",
+                                "description": "Cells without a # [endpoint=...] directive run against this connection."
+                            }
+                        }
+                    }
+                },
+                "queryTimeoutSeconds": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Default timeout for notebook cell executions, in seconds (built-in default: 30)."
+                },
+                "maxRows": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Default cap on returned rows/triples per execution (built-in default: 10000)."
+                }
+            }
+        },
         "cimvocabcheck": {
             "type": "object",
             "description": "CIMVocabCheck SPARQL/SHACL validation settings. All fields are optional; when neither \"schemas\" nor \"schemasDirectory\" is set, the bundled CGMES 3.0 profiles are used.",

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -27,6 +27,7 @@ import {
 } from "vscode-languageclient/node";
 
 import { registerNotebookSerializers } from "./notebook/serializers";
+import { registerNotebookControllers } from "./notebook/controller";
 import { registerConvertCommand } from "./notebook/convert";
 
 const CHANNEL = "CIMNotebook";
@@ -59,8 +60,10 @@ export function activate(context: vscode.ExtensionContext): void {
     );
 
     // Native CIM Notebooks (markdown + .sparqlbook formats; cells are validated through
-    // the vscode-notebook-cell entries of the LSP documentSelector below).
+    // the vscode-notebook-cell entries of the LSP documentSelector below and executed
+    // via the server's cimvocabcheck.notebook.execute command).
     registerNotebookSerializers(context);
+    registerNotebookControllers(context, () => client);
     registerConvertCommand(context);
 
     try {

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -26,6 +26,8 @@ import {
     TransportKind,
 } from "vscode-languageclient/node";
 
+import { registerNotebookSerializers } from "./notebook/serializers";
+
 const CHANNEL = "CIMNotebook";
 
 let client: LanguageClient | undefined;
@@ -54,6 +56,10 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand("cimnotebook.createConfig", createConfig),
     );
+
+    // Native CIM Notebooks (markdown format; cells are validated through the
+    // vscode-notebook-cell entries of the LSP documentSelector below).
+    registerNotebookSerializers(context);
 
     try {
         doActivate(context);

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -27,6 +27,7 @@ import {
 } from "vscode-languageclient/node";
 
 import { registerNotebookSerializers } from "./notebook/serializers";
+import { registerConvertCommand } from "./notebook/convert";
 
 const CHANNEL = "CIMNotebook";
 
@@ -57,9 +58,10 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand("cimnotebook.createConfig", createConfig),
     );
 
-    // Native CIM Notebooks (markdown format; cells are validated through the
-    // vscode-notebook-cell entries of the LSP documentSelector below).
+    // Native CIM Notebooks (markdown + .sparqlbook formats; cells are validated through
+    // the vscode-notebook-cell entries of the LSP documentSelector below).
     registerNotebookSerializers(context);
+    registerConvertCommand(context);
 
     try {
         doActivate(context);

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -32,6 +32,7 @@ import { registerConvertCommand } from "./notebook/convert";
 import { ConnectionStore } from "./notebook/connections";
 import { registerEndpointCommands } from "./notebook/endpointCommands";
 import { registerCellStatusBar } from "./notebook/statusBar";
+import { registerConfigTreeViews } from "./sidebar/treeViews";
 
 const CHANNEL = "CIMNotebook";
 
@@ -71,6 +72,7 @@ export function activate(context: vscode.ExtensionContext): void {
     registerConvertCommand(context);
     registerEndpointCommands(context, connectionStore);
     registerCellStatusBar(context, connectionStore);
+    registerConfigTreeViews(context, connectionStore);
 
     try {
         doActivate(context, connectionStore);

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -29,6 +29,9 @@ import {
 import { registerNotebookSerializers } from "./notebook/serializers";
 import { registerNotebookControllers } from "./notebook/controller";
 import { registerConvertCommand } from "./notebook/convert";
+import { ConnectionStore } from "./notebook/connections";
+import { registerEndpointCommands } from "./notebook/endpointCommands";
+import { registerCellStatusBar } from "./notebook/statusBar";
 
 const CHANNEL = "CIMNotebook";
 
@@ -63,11 +66,14 @@ export function activate(context: vscode.ExtensionContext): void {
     // the vscode-notebook-cell entries of the LSP documentSelector below and executed
     // via the server's cimvocabcheck.notebook.execute command).
     registerNotebookSerializers(context);
-    registerNotebookControllers(context, () => client);
+    const connectionStore = new ConnectionStore(context, () => client);
+    registerNotebookControllers(context, () => client, connectionStore);
     registerConvertCommand(context);
+    registerEndpointCommands(context, connectionStore);
+    registerCellStatusBar(context, connectionStore);
 
     try {
-        doActivate(context);
+        doActivate(context, connectionStore);
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         out.appendLine(`FATAL during activation: ${msg}`);
@@ -76,7 +82,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
 }
 
-function doActivate(context: vscode.ExtensionContext): void {
+function doActivate(context: vscode.ExtensionContext, connectionStore: ConnectionStore): void {
     const serverJar = resolveServerJar(context);
     if (!serverJar) {
         const hint =
@@ -91,7 +97,17 @@ function doActivate(context: vscode.ExtensionContext): void {
     }
 
     client = buildClient(serverJar, context);
-    client.start();
+    client.start().then(
+        () => {
+            // The notebook defaults live in workspace state, so a freshly started server knows
+            // none of them — replay them, or directive-less cells would validate syntax-only.
+            void connectionStore.syncNotebookDefaults();
+        },
+        (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            out.appendLine(`Language server failed to start: ${msg}`);
+        },
+    );
     out.appendLine("Language client started — waiting for server handshake.");
 
     // Offer a reload when the user changes launch settings.

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -141,8 +141,8 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 /**
- * Scaffolds an `opencgmes.jsonc` in the workspace root. CIMNotebook works without it (validating against
- * the bundled CGMES 3.0 schemas); the generated file is fully commented and exists for customisation.
+ * Scaffolds an `opencgmes.jsonc` in the workspace root. CIMNotebook works without it, but there is no
+ * bundled default schema, so validation stays syntax-only until the file points at CGMES profiles.
  * The template text comes from the language server's `cimvocabcheck.createConfig` command so the CLI and
  * editors stay in sync. A plain `opencgmes.json` (no comments) is also recognised by CIMNotebook — if one
  * already exists, it is treated as the existing config instead of creating a second `opencgmes.jsonc`

--- a/cimnotebook/vscode/src/notebook/cells.ts
+++ b/cimnotebook/vscode/src/notebook/cells.ts
@@ -17,9 +17,9 @@
  */
 
 /**
- * Editor-independent notebook cell model used by the markdown serializer. Deliberately
- * free of any `vscode` import so the format logic can be unit-tested with plain
- * `node --test`.
+ * Editor-independent notebook cell model shared by the markdown and .sparqlbook
+ * serializers. Deliberately free of any `vscode` import so the format logic can be
+ * unit-tested with plain `node --test`.
  */
 
 /** Cell languages that CIMNotebook treats as executable code cells. */
@@ -30,7 +30,7 @@ export interface RawCell {
     /** Language id for code cells (usually "sparql" or "shacl"); absent for markdown. */
     language?: string;
     value: string;
-    /** Opaque per-cell metadata, passed through untouched by the serializers. */
+    /** Opaque per-cell metadata (only round-tripped by the .sparqlbook format). */
     metadata?: Record<string, unknown>;
 }
 

--- a/cimnotebook/vscode/src/notebook/cells.ts
+++ b/cimnotebook/vscode/src/notebook/cells.ts
@@ -1,0 +1,42 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Editor-independent notebook cell model used by the markdown serializer. Deliberately
+ * free of any `vscode` import so the format logic can be unit-tested with plain
+ * `node --test`.
+ */
+
+/** Cell languages that CIMNotebook treats as executable code cells. */
+export const CODE_CELL_LANGUAGES = ["sparql", "shacl"] as const;
+
+export interface RawCell {
+    kind: "markdown" | "code";
+    /** Language id for code cells (usually "sparql" or "shacl"); absent for markdown. */
+    language?: string;
+    value: string;
+    /** Opaque per-cell metadata, passed through untouched by the serializers. */
+    metadata?: Record<string, unknown>;
+}
+
+/** A parsed notebook: its cells plus document-level facts needed for faithful saving. */
+export interface RawNotebook {
+    cells: RawCell[];
+    /** Line ending of the source file, preserved on serialization. */
+    eol: "\n" | "\r\n";
+}

--- a/cimnotebook/vscode/src/notebook/connections.ts
+++ b/cimnotebook/vscode/src/notebook/connections.ts
@@ -25,6 +25,7 @@
  * to validate those cells against the same endpoint they run against.
  */
 
+import * as path from "path";
 import * as vscode from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 
@@ -49,6 +50,9 @@ export class ConnectionStore {
      */
     private readonly cache = new Map<string, Promise<ListConnectionsResponse>>();
     private readonly changeEmitter = new vscode.EventEmitter<void>();
+
+    /** Out-of-workspace config files already covered by a dedicated watcher (fsPath). */
+    private readonly watchedConfigs = new Set<string>();
 
     /** Fires when connections or notebook defaults may have changed (config edit, command). */
     readonly onDidChange = this.changeEmitter.event;
@@ -83,7 +87,10 @@ export class ConnectionStore {
                 command: LIST_CONNECTIONS_COMMAND,
                 arguments: [{ notebookUri: key }],
             })
-            .then((response) => response ?? EMPTY)
+            .then((response) => {
+                this.watchConfigOutsideWorkspace(response?.configPath);
+                return response ?? EMPTY;
+            })
             .catch(() => {
                 // Server not ready or command failed — behave as "no connections", and drop the
                 // entry so the next call retries. Only evict our own: invalidate() may already
@@ -166,6 +173,35 @@ export class ConnectionStore {
             // Server not ready or command unsupported (an older server jar): execution still works
             // — only the cell's schema-based validation keeps using the workspace schema.
         }
+    }
+
+    /**
+     * Watches a server-reported config file that lies outside every workspace folder. The
+     * server's nearest-config discovery walks the whole directory hierarchy, so the applicable
+     * `opencgmes.jsonc` can sit above the workspace root where the constructor's glob watcher
+     * cannot see it — without this, edits to that file would never invalidate the cache.
+     */
+    private watchConfigOutsideWorkspace(configPath: string | null | undefined): void {
+        if (!configPath) {
+            return;
+        }
+        const uri = vscode.Uri.file(configPath);
+        if (vscode.workspace.getWorkspaceFolder(uri) || this.watchedConfigs.has(uri.fsPath)) {
+            return;
+        }
+        this.watchedConfigs.add(uri.fsPath);
+        const watcher = vscode.workspace.createFileSystemWatcher(
+            new vscode.RelativePattern(
+                vscode.Uri.file(path.dirname(uri.fsPath)),
+                path.basename(uri.fsPath),
+            ),
+        );
+        this.context.subscriptions.push(
+            watcher,
+            watcher.onDidChange(() => this.invalidate()),
+            watcher.onDidCreate(() => this.invalidate()),
+            watcher.onDidDelete(() => this.invalidate()),
+        );
     }
 
     /** Drops all cached config responses (config file changed). */

--- a/cimnotebook/vscode/src/notebook/connections.ts
+++ b/cimnotebook/vscode/src/notebook/connections.ts
@@ -1,0 +1,176 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Client-side view of a notebook's named connections: fetches the `cimnotebook` config
+ * section from the language server (`listConnections`, nearest-config discovery happens
+ * there), caches it per notebook, and invalidates the cache when any `opencgmes.jsonc`
+ * changes. Also holds the per-notebook default directive (workspaceState) that cells
+ * without their own directive fall back to — and pushes it to the server, which needs it
+ * to validate those cells against the same endpoint they run against.
+ */
+
+import * as vscode from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+import {
+    CellResolution,
+    LIST_CONNECTIONS_COMMAND,
+    ListConnectionsResponse,
+    resolveCellTarget,
+    SET_DEFAULT_ENDPOINT_COMMAND,
+    SetDefaultEndpointRequest,
+} from "./endpoint";
+
+const EMPTY: ListConnectionsResponse = { connections: [] };
+
+const DEFAULT_DIRECTIVE_KEY = "cimnotebook.defaultEndpoint";
+
+export class ConnectionStore {
+    /**
+     * Keyed by notebook URI. Holds the *in-flight* request, not just its result: the cell
+     * status-bar provider resolves every visible cell, so a cold cache would otherwise fire one
+     * `listConnections` per cell instead of one per notebook.
+     */
+    private readonly cache = new Map<string, Promise<ListConnectionsResponse>>();
+    private readonly changeEmitter = new vscode.EventEmitter<void>();
+
+    /** Fires when connections or notebook defaults may have changed (config edit, command). */
+    readonly onDidChange = this.changeEmitter.event;
+
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly getClient: () => LanguageClient | undefined,
+    ) {
+        const watcher = vscode.workspace.createFileSystemWatcher("**/opencgmes.{jsonc,json}");
+        context.subscriptions.push(
+            watcher,
+            watcher.onDidChange(() => this.invalidate()),
+            watcher.onDidCreate(() => this.invalidate()),
+            watcher.onDidDelete(() => this.invalidate()),
+            this.changeEmitter,
+        );
+    }
+
+    /** The connections config applying to a notebook; empty when unavailable. */
+    forNotebook(notebook: vscode.NotebookDocument): Promise<ListConnectionsResponse> {
+        const key = notebook.uri.toString();
+        const cached = this.cache.get(key);
+        if (cached) {
+            return cached;
+        }
+        const client = this.getClient();
+        if (!client) {
+            return Promise.resolve(EMPTY);
+        }
+        const pending = client
+            .sendRequest<ListConnectionsResponse | null>("workspace/executeCommand", {
+                command: LIST_CONNECTIONS_COMMAND,
+                arguments: [{ notebookUri: key }],
+            })
+            .then((response) => response ?? EMPTY)
+            .catch(() => {
+                // Server not ready or command failed — behave as "no connections", and drop the
+                // entry so the next call retries. Only evict our own: invalidate() may already
+                // have replaced it with a newer request.
+                if (this.cache.get(key) === pending) {
+                    this.cache.delete(key);
+                }
+                return EMPTY;
+            });
+        this.cache.set(key, pending);
+        return pending;
+    }
+
+    /** Full resolution for a cell, including notebook default and config default. */
+    async resolveCell(cell: vscode.NotebookCell): Promise<CellResolution> {
+        const { connections } = await this.forNotebook(cell.notebook);
+        return resolveCellTarget(
+            cell.document.getText(),
+            connections,
+            this.notebookDefault(cell.notebook),
+        );
+    }
+
+    /** The notebook's stored default directive (URL, file, or connection name), if any. */
+    notebookDefault(notebook: vscode.NotebookDocument): string | undefined {
+        const all = this.context.workspaceState.get<Record<string, string>>(
+            DEFAULT_DIRECTIVE_KEY,
+            {},
+        );
+        return all[notebook.uri.toString()];
+    }
+
+    /** Stores (or clears, with undefined) the notebook's default directive. */
+    async setNotebookDefault(
+        notebook: vscode.NotebookDocument,
+        directive: string | undefined,
+    ): Promise<void> {
+        const all = {
+            ...this.context.workspaceState.get<Record<string, string>>(DEFAULT_DIRECTIVE_KEY, {}),
+        };
+        if (directive === undefined) {
+            delete all[notebook.uri.toString()];
+        } else {
+            all[notebook.uri.toString()] = directive;
+        }
+        await this.context.workspaceState.update(DEFAULT_DIRECTIVE_KEY, all);
+        await this.pushNotebookDefault(notebook.uri.toString(), directive ?? null);
+        this.changeEmitter.fire();
+    }
+
+    /**
+     * Re-sends every stored notebook default to the language server. The defaults live in workspace
+     * state, so the server — which validates cells and has no notion of notebooks — starts out
+     * knowing none of them: without this, a directive-less cell would be validated syntax-only
+     * (no completion, no hover, no go-to-definition) until the user picked its endpoint again.
+     * Called once the client is running, and on every restart.
+     */
+    async syncNotebookDefaults(): Promise<void> {
+        const all = this.context.workspaceState.get<Record<string, string>>(
+            DEFAULT_DIRECTIVE_KEY,
+            {},
+        );
+        for (const [notebookUri, directive] of Object.entries(all)) {
+            await this.pushNotebookDefault(notebookUri, directive);
+        }
+    }
+
+    private async pushNotebookDefault(notebookUri: string, endpoint: string | null): Promise<void> {
+        const client = this.getClient();
+        if (!client) {
+            return; // Server not up yet; syncNotebookDefaults() replays the state when it is.
+        }
+        const request: SetDefaultEndpointRequest = { notebookUri, endpoint };
+        try {
+            await client.sendRequest("workspace/executeCommand", {
+                command: SET_DEFAULT_ENDPOINT_COMMAND,
+                arguments: [request],
+            });
+        } catch {
+            // Server not ready or command unsupported (an older server jar): execution still works
+            // — only the cell's schema-based validation keeps using the workspace schema.
+        }
+    }
+
+    /** Drops all cached config responses (config file changed). */
+    invalidate(): void {
+        this.cache.clear();
+        this.changeEmitter.fire();
+    }
+}

--- a/cimnotebook/vscode/src/notebook/controller.ts
+++ b/cimnotebook/vscode/src/notebook/controller.ts
@@ -1,0 +1,58 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Notebook controllers (kernels) for the three CIM Notebook types. VS Code binds a
+ * controller to exactly one notebook type, so each type gets its own controller instance;
+ * they share one {@link CellExecutor}. Cancellation uses the per-cell execution token
+ * (no `interruptHandler`), which the executor forwards to the language-server request.
+ */
+
+import * as vscode from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+import { CellExecutor } from "./executor";
+import { NOTEBOOK_TYPES } from "./serializers";
+
+export function registerNotebookControllers(
+    context: vscode.ExtensionContext,
+    getClient: () => LanguageClient | undefined,
+): void {
+    const executor = new CellExecutor(getClient);
+    let executionOrder = 0;
+
+    for (const notebookType of NOTEBOOK_TYPES) {
+        const controller = vscode.notebooks.createNotebookController(
+            `${notebookType}.controller`,
+            notebookType,
+            "CIM Notebook",
+        );
+        // SPARQL only until SHACL execution lands; the LSP still validates shacl cells.
+        controller.supportedLanguages = ["sparql"];
+        controller.supportsExecutionOrder = true;
+        controller.description = "Runs SPARQL cells via CIMLangServer";
+        controller.executeHandler = async (cells) => {
+            for (const cell of cells) {
+                const execution = controller.createNotebookCellExecution(cell);
+                execution.executionOrder = ++executionOrder;
+                await executor.execute(cell, execution);
+            }
+        };
+        context.subscriptions.push(controller);
+    }
+}

--- a/cimnotebook/vscode/src/notebook/controller.ts
+++ b/cimnotebook/vscode/src/notebook/controller.ts
@@ -26,14 +26,16 @@
 import * as vscode from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 
+import { ConnectionStore } from "./connections";
 import { CellExecutor } from "./executor";
 import { NOTEBOOK_TYPES } from "./serializers";
 
 export function registerNotebookControllers(
     context: vscode.ExtensionContext,
     getClient: () => LanguageClient | undefined,
+    store: ConnectionStore,
 ): void {
-    const executor = new CellExecutor(getClient);
+    const executor = new CellExecutor(getClient, store, context.secrets);
     let executionOrder = 0;
 
     for (const notebookType of NOTEBOOK_TYPES) {

--- a/cimnotebook/vscode/src/notebook/controller.ts
+++ b/cimnotebook/vscode/src/notebook/controller.ts
@@ -42,10 +42,9 @@ export function registerNotebookControllers(
             notebookType,
             "CIM Notebook",
         );
-        // SPARQL only until SHACL execution lands; the LSP still validates shacl cells.
-        controller.supportedLanguages = ["sparql"];
+        controller.supportedLanguages = ["sparql", "shacl"];
         controller.supportsExecutionOrder = true;
-        controller.description = "Runs SPARQL cells via CIMLangServer";
+        controller.description = "Runs SPARQL and SHACL cells via CIMLangServer";
         controller.executeHandler = async (cells) => {
             for (const cell of cells) {
                 const execution = controller.createNotebookCellExecution(cell);

--- a/cimnotebook/vscode/src/notebook/convert.ts
+++ b/cimnotebook/vscode/src/notebook/convert.ts
@@ -1,0 +1,124 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * "CIMNotebook: Convert Notebook" — writes the active notebook in the other format
+ * (markdown `*.cimnb.md` ⇔ Zazuko `*.sparqlbook`) as a sibling file and opens it.
+ * Converting never touches the source file.
+ */
+
+import * as vscode from "vscode";
+
+import { serializeMarkdownNotebook } from "./markdown";
+import { serializeSparqlBook } from "./sparqlbook";
+import {
+    notebookDocumentToRaw,
+    NOTEBOOK_TYPE_DEFAULT,
+    NOTEBOOK_TYPE_SPARQLBOOK,
+    NOTEBOOK_TYPES,
+} from "./serializers";
+
+export const CONVERT_COMMAND = "cimnotebook.notebook.convert";
+
+export function registerConvertCommand(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(CONVERT_COMMAND, convertActiveNotebook),
+    );
+}
+
+interface TargetFormat {
+    label: string;
+    description: string;
+    serialize: (notebook: ReturnType<typeof notebookDocumentToRaw>) => string;
+    targetUri: (source: vscode.Uri) => vscode.Uri;
+    openAsType: string;
+}
+
+const TO_MARKDOWN: TargetFormat = {
+    label: "Markdown notebook (*.cimnb.md)",
+    description: "Git-friendly markdown with ```sparql / ```shacl cells",
+    serialize: serializeMarkdownNotebook,
+    targetUri: (source) =>
+        siblingUri(source, [".cimnb.md", ".sparqlbook", ".md", ".markdown"], ".cimnb.md"),
+    openAsType: NOTEBOOK_TYPE_DEFAULT,
+};
+
+const TO_SPARQLBOOK: TargetFormat = {
+    label: "SPARQL Book (*.sparqlbook)",
+    description: "JSON format of the Zazuko SPARQL Notebook extension",
+    serialize: serializeSparqlBook,
+    targetUri: (source) => siblingUri(source, [".cimnb.md", ".md", ".markdown"], ".sparqlbook"),
+    openAsType: NOTEBOOK_TYPE_SPARQLBOOK,
+};
+
+async function convertActiveNotebook(): Promise<void> {
+    const notebook = vscode.window.activeNotebookEditor?.notebook;
+    if (!notebook || !(NOTEBOOK_TYPES as readonly string[]).includes(notebook.notebookType)) {
+        vscode.window.showWarningMessage("CIMNotebook: open a CIM Notebook to convert it.");
+        return;
+    }
+
+    const source = notebook.uri;
+    const target = await vscode.window.showQuickPick(
+        (source.path.endsWith(".sparqlbook") ? [TO_MARKDOWN] : [TO_SPARQLBOOK, TO_MARKDOWN]).map(
+            (format) => ({ ...format, detail: format.targetUri(source).path }),
+        ),
+        { title: "Convert notebook to" },
+    );
+    if (!target) {
+        return;
+    }
+
+    const targetUri = target.targetUri(source);
+    if (targetUri.toString() === source.toString()) {
+        vscode.window.showInformationMessage("CIMNotebook: notebook is already in that format.");
+        return;
+    }
+    if (await fileExists(targetUri)) {
+        const choice = await vscode.window.showWarningMessage(
+            `CIMNotebook: ${vscode.workspace.asRelativePath(targetUri)} already exists.`,
+            "Overwrite",
+        );
+        if (choice !== "Overwrite") {
+            return;
+        }
+    }
+
+    const content = target.serialize(notebookDocumentToRaw(notebook));
+    await vscode.workspace.fs.writeFile(targetUri, Buffer.from(content, "utf8"));
+    await vscode.commands.executeCommand("vscode.openWith", targetUri, target.openAsType);
+}
+
+/** Strips the first matching suffix (longest first) and appends the target suffix. */
+function siblingUri(source: vscode.Uri, strip: string[], suffix: string): vscode.Uri {
+    const name = source.path.slice(source.path.lastIndexOf("/") + 1);
+    const match = strip
+        .filter((s) => name.toLowerCase().endsWith(s))
+        .sort((a, b) => b.length - a.length)[0];
+    const base = match ? name.slice(0, name.length - match.length) : name;
+    return source.with({ path: source.path.slice(0, -name.length) + base + suffix });
+}
+
+async function fileExists(uri: vscode.Uri): Promise<boolean> {
+    try {
+        await vscode.workspace.fs.stat(uri);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/cimnotebook/vscode/src/notebook/credentials.ts
+++ b/cimnotebook/vscode/src/notebook/credentials.ts
@@ -91,6 +91,29 @@ export async function clearCredentials(
     await secrets.delete(secretKey(connectionName));
 }
 
+/**
+ * Runs one set/clear credentials action including the confirmation message — the shared tail of
+ * the palette commands and the connections-view context menu.
+ */
+export async function runCredentialsAction(
+    secrets: vscode.SecretStorage,
+    connectionName: string,
+    action: "set" | "clear",
+): Promise<void> {
+    if (action === "set") {
+        if (await setCredentials(secrets, connectionName)) {
+            vscode.window.showInformationMessage(
+                `CIMNotebook: credentials for "${connectionName}" stored in VS Code secret storage.`,
+            );
+        }
+        return;
+    }
+    await clearCredentials(secrets, connectionName);
+    vscode.window.showInformationMessage(
+        `CIMNotebook: credentials for "${connectionName}" cleared.`,
+    );
+}
+
 async function promptForCredentials(connectionName: string): Promise<ExecAuth | undefined> {
     const username = await vscode.window.showInputBox({
         title: `Username for connection "${connectionName}"`,

--- a/cimnotebook/vscode/src/notebook/credentials.ts
+++ b/cimnotebook/vscode/src/notebook/credentials.ts
@@ -1,0 +1,122 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Credentials for `authType: "basic"` connections. Stored exclusively in VS Code
+ * SecretStorage (key `cimnotebook.auth.<connectionName>`) — never in `opencgmes.jsonc`,
+ * never in settings, never in git. They leave the client only inside an execute request
+ * to the local language server, which turns them into the HTTP Authorization header.
+ */
+
+import * as vscode from "vscode";
+
+import { ConnectionInfo, ExecAuth } from "./endpoint";
+
+function secretKey(connectionName: string): string {
+    return `cimnotebook.auth.${connectionName}`;
+}
+
+/**
+ * The credentials to attach for a connection: stored ones when present, otherwise (when
+ * `interactive`) a one-time prompt with an offer to save. Returns undefined for
+ * connections without basic auth, or when the user cancels the prompt — execution then
+ * proceeds anonymously and surfaces the endpoint's 401 as AUTH_FAILED.
+ */
+export async function authFor(
+    secrets: vscode.SecretStorage,
+    connection: ConnectionInfo,
+    interactive: boolean,
+): Promise<ExecAuth | undefined> {
+    if (connection.authType?.toLowerCase() !== "basic") {
+        return undefined;
+    }
+    const stored = await secrets.get(secretKey(connection.name));
+    if (stored) {
+        try {
+            const parsed = JSON.parse(stored) as { username: string; password: string };
+            return { type: "basic", username: parsed.username, password: parsed.password };
+        } catch {
+            await secrets.delete(secretKey(connection.name));
+        }
+    }
+    if (!interactive) {
+        return undefined;
+    }
+    const entered = await promptForCredentials(connection.name);
+    if (!entered) {
+        return undefined;
+    }
+    const save = await vscode.window.showQuickPick(["Yes", "No"], {
+        title: `Save credentials for "${connection.name}" in VS Code secret storage?`,
+    });
+    if (save === "Yes") {
+        await storeCredentials(secrets, connection.name, entered);
+    }
+    return entered;
+}
+
+/** Prompts for and stores credentials (the *Set Connection Credentials* command). */
+export async function setCredentials(
+    secrets: vscode.SecretStorage,
+    connectionName: string,
+): Promise<boolean> {
+    const entered = await promptForCredentials(connectionName);
+    if (!entered) {
+        return false;
+    }
+    await storeCredentials(secrets, connectionName, entered);
+    return true;
+}
+
+/** Deletes stored credentials (the *Clear Connection Credentials* command). */
+export async function clearCredentials(
+    secrets: vscode.SecretStorage,
+    connectionName: string,
+): Promise<void> {
+    await secrets.delete(secretKey(connectionName));
+}
+
+async function promptForCredentials(connectionName: string): Promise<ExecAuth | undefined> {
+    const username = await vscode.window.showInputBox({
+        title: `Username for connection "${connectionName}"`,
+        ignoreFocusOut: true,
+    });
+    if (username === undefined || username === "") {
+        return undefined;
+    }
+    const password = await vscode.window.showInputBox({
+        title: `Password for "${username}" @ "${connectionName}"`,
+        password: true,
+        ignoreFocusOut: true,
+    });
+    if (password === undefined) {
+        return undefined;
+    }
+    return { type: "basic", username, password };
+}
+
+async function storeCredentials(
+    secrets: vscode.SecretStorage,
+    connectionName: string,
+    auth: ExecAuth,
+): Promise<void> {
+    await secrets.store(
+        secretKey(connectionName),
+        JSON.stringify({ username: auth.username, password: auth.password }),
+    );
+}

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -245,6 +245,26 @@ describe("applyEndpointDirective", () => {
         const text = "# just a comment\nASK {}";
         assert.equal(applyEndpointDirective(text, null), text);
     });
+
+    it("writes one directive line per array entry, in order", () => {
+        assert.equal(
+            applyEndpointDirective("ASK {}", ["a.ttl", "b.ttl"]),
+            "# [endpoint=a.ttl]\n# [endpoint=b.ttl]\nASK {}",
+        );
+    });
+
+    it("replaces every existing directive with the new array at the first one's position", () => {
+        const text = "# [endpoint=./a.ttl]\nASK {}\n# [endpoint=./b.ttl]";
+        assert.equal(
+            applyEndpointDirective(text, ["x.ttl", "y.ttl", "z.ttl"]),
+            "# [endpoint=x.ttl]\n# [endpoint=y.ttl]\n# [endpoint=z.ttl]\nASK {}",
+        );
+    });
+
+    it("treats an empty array like clearing", () => {
+        const text = "# [endpoint=./a.ttl]\nASK {}";
+        assert.equal(applyEndpointDirective(text, []), "ASK {}");
+    });
 });
 
 describe("deriveShaclUrl", () => {

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -1,0 +1,91 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { deriveUpdateUrl, parseEndpointDirectives, resolveTarget } from "./endpoint";
+
+describe("parseEndpointDirectives", () => {
+    it("finds every directive, in order, with flexible spacing", () => {
+        const text = [
+            "# [endpoint=http://localhost:3030/ds/query]",
+            "#[endpoint=./local.ttl]",
+            "  #  [ endpoint = http://other/sparql ]",
+            "SELECT * WHERE { ?s ?p ?o }",
+        ].join("\n");
+        assert.deepEqual(parseEndpointDirectives(text), [
+            "http://localhost:3030/ds/query",
+            "./local.ttl",
+            "http://other/sparql",
+        ]);
+    });
+
+    it("ignores non-directive comments and directive-like text mid-line", () => {
+        assert.deepEqual(
+            parseEndpointDirectives("# endpoint=http://x\nSELECT 1 # [endpoint=http://y]"),
+            [],
+        );
+    });
+});
+
+describe("resolveTarget", () => {
+    it("returns none without a directive", () => {
+        assert.deepEqual(resolveTarget("SELECT * WHERE { ?s ?p ?o }"), { type: "none" });
+    });
+
+    it("picks the first http(s) directive and derives the update sibling", () => {
+        const target = resolveTarget("# [endpoint=https://host/ds/query]\nASK {}");
+        assert.deepEqual(target, {
+            type: "http",
+            url: "https://host/ds/query",
+            updateUrl: "https://host/ds/update",
+        });
+    });
+
+    it("reports non-URL directives as unsupported (files come later)", () => {
+        assert.deepEqual(resolveTarget("# [endpoint=./data.ttl]\nASK {}"), {
+            type: "unsupported",
+            directive: "./data.ttl",
+        });
+    });
+
+    it("skips file directives when an http one is also present", () => {
+        const target = resolveTarget(
+            "# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}",
+        );
+        assert.equal(target.type, "http");
+    });
+});
+
+describe("deriveUpdateUrl", () => {
+    it("maps Fuseki-style query/sparql services to the update sibling", () => {
+        assert.equal(deriveUpdateUrl("http://h:3030/ds/query"), "http://h:3030/ds/update");
+        assert.equal(deriveUpdateUrl("http://h/ds/sparql"), "http://h/ds/update");
+        assert.equal(deriveUpdateUrl("http://h/ds/QUERY"), "http://h/ds/update");
+    });
+
+    it("drops the query string when deriving the sibling", () => {
+        assert.equal(deriveUpdateUrl("http://h/ds/query?graph=urn:x"), "http://h/ds/update");
+    });
+
+    it("keeps other URLs unchanged (updates POST to the same endpoint)", () => {
+        assert.equal(deriveUpdateUrl("http://h/ds"), "http://h/ds");
+        assert.equal(deriveUpdateUrl("http://h/api/sparql-proxy"), "http://h/api/sparql-proxy");
+    });
+});

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -19,7 +19,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { deriveUpdateUrl, parseEndpointDirectives, resolveTarget } from "./endpoint";
+import {
+    deriveShaclUrl,
+    deriveUpdateUrl,
+    parseEndpointDirectives,
+    resolveTarget,
+} from "./endpoint";
 
 describe("parseEndpointDirectives", () => {
     it("finds every directive, in order, with flexible spacing", () => {
@@ -49,12 +54,13 @@ describe("resolveTarget", () => {
         assert.deepEqual(resolveTarget("SELECT * WHERE { ?s ?p ?o }"), { type: "none" });
     });
 
-    it("picks the first http(s) directive and derives the update sibling", () => {
+    it("picks the first http(s) directive and derives the update and shacl siblings", () => {
         const target = resolveTarget("# [endpoint=https://host/ds/query]\nASK {}");
         assert.deepEqual(target, {
             type: "http",
             url: "https://host/ds/query",
             updateUrl: "https://host/ds/update",
+            shaclUrl: "https://host/ds/shacl?graph=default",
         });
     });
 
@@ -80,6 +86,32 @@ describe("resolveTarget", () => {
             "# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}",
         );
         assert.equal(target.type, "http");
+    });
+});
+
+describe("deriveShaclUrl", () => {
+    it("maps Fuseki-style query/sparql services to the shacl sibling with a default graph", () => {
+        assert.equal(
+            deriveShaclUrl("http://h:3030/ds/query"),
+            "http://h:3030/ds/shacl?graph=default",
+        );
+        assert.equal(deriveShaclUrl("http://h/ds/sparql"), "http://h/ds/shacl?graph=default");
+    });
+
+    it("appends /shacl to dataset-style URLs", () => {
+        assert.equal(deriveShaclUrl("http://h/ds"), "http://h/ds/shacl?graph=default");
+        assert.equal(deriveShaclUrl("http://h/ds/"), "http://h/ds/shacl?graph=default");
+    });
+
+    it("keeps an explicit shacl service and preserves an existing query string", () => {
+        assert.equal(
+            deriveShaclUrl("http://h/ds/shacl?graph=urn:x"),
+            "http://h/ds/shacl?graph=urn:x",
+        );
+        assert.equal(
+            deriveShaclUrl("http://h/ds/query?graph=urn:x"),
+            "http://h/ds/shacl?graph=urn:x",
+        );
     });
 });
 

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -63,6 +63,14 @@ describe("classifyDirective", () => {
         assert.equal(classifyDirective("model.xml"), "file");
         assert.equal(classifyDirective("sub/dir"), "file");
     });
+
+    it("treats glob patterns as files, never connection names", () => {
+        assert.equal(classifyDirective("./rdf/*.ttl"), "file");
+        assert.equal(classifyDirective("./rdf/{a,b}.ttl"), "file");
+        assert.equal(classifyDirective("{a,b}"), "file");
+        assert.equal(classifyDirective("data-?"), "file");
+        assert.equal(classifyDirective("[ab]"), "file");
+    });
 });
 
 describe("resolveCellTarget", () => {
@@ -105,6 +113,18 @@ describe("resolveCellTarget", () => {
         assert.deepEqual(res.kind === "target" && res.target, {
             type: "files",
             files: ["./model.xml", "extra.ttl"],
+        });
+    });
+
+    it("passes glob patterns through as file targets for the server to expand", () => {
+        const res = resolveCellTarget(
+            "# [endpoint=./rdf/{a,b}.ttl]\n# [endpoint=./more/*.ttl]\nASK {}",
+            [],
+        );
+        assert.equal(res.kind, "target");
+        assert.deepEqual(res.kind === "target" && res.target, {
+            type: "files",
+            files: ["./rdf/{a,b}.ttl", "./more/*.ttl"],
         });
     });
 

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -58,14 +58,24 @@ describe("resolveTarget", () => {
         });
     });
 
-    it("reports non-URL directives as unsupported (files come later)", () => {
+    it("resolves a non-URL directive to a local-files target", () => {
         assert.deepEqual(resolveTarget("# [endpoint=./data.ttl]\nASK {}"), {
-            type: "unsupported",
-            directive: "./data.ttl",
+            type: "files",
+            files: ["./data.ttl"],
         });
     });
 
-    it("skips file directives when an http one is also present", () => {
+    it("collects every file directive into one union target, in order", () => {
+        assert.deepEqual(
+            resolveTarget("# [endpoint=./model.xml]\n# [endpoint=extra.ttl]\nASK {}"),
+            {
+                type: "files",
+                files: ["./model.xml", "extra.ttl"],
+            },
+        );
+    });
+
+    it("prefers the http directive when files are also present", () => {
         const target = resolveTarget(
             "# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}",
         );

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -20,10 +20,14 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+    applyEndpointDirective,
+    classifyDirective,
+    ConnectionInfo,
     deriveShaclUrl,
     deriveUpdateUrl,
     parseEndpointDirectives,
-    resolveTarget,
+    resolveCellTarget,
+    statusBarText,
 } from "./endpoint";
 
 describe("parseEndpointDirectives", () => {
@@ -49,43 +53,197 @@ describe("parseEndpointDirectives", () => {
     });
 });
 
-describe("resolveTarget", () => {
-    it("returns none without a directive", () => {
-        assert.deepEqual(resolveTarget("SELECT * WHERE { ?s ?p ?o }"), { type: "none" });
+describe("classifyDirective", () => {
+    it("splits URLs, connection names, and file paths like the server does", () => {
+        assert.equal(classifyDirective("http://host/ds/query"), "url");
+        assert.equal(classifyDirective("HTTPS://host"), "url");
+        assert.equal(classifyDirective("local-fuseki"), "name");
+        assert.equal(classifyDirective("prod"), "name");
+        assert.equal(classifyDirective("./data.ttl"), "file");
+        assert.equal(classifyDirective("model.xml"), "file");
+        assert.equal(classifyDirective("sub/dir"), "file");
     });
+});
 
-    it("picks the first http(s) directive and derives the update and shacl siblings", () => {
-        const target = resolveTarget("# [endpoint=https://host/ds/query]\nASK {}");
-        assert.deepEqual(target, {
-            type: "http",
-            url: "https://host/ds/query",
-            updateUrl: "https://host/ds/update",
-            shaclUrl: "https://host/ds/shacl?graph=default",
+describe("resolveCellTarget", () => {
+    const CONNECTIONS: ConnectionInfo[] = [
+        {
+            name: "local-fuseki",
+            url: "http://localhost:3030/cgmes/query",
+            updateUrl: "http://localhost:3030/cgmes/upd",
+            authType: "basic",
+        },
+        { name: "prod", url: "https://sparql.example.org/query", default: true },
+    ];
+
+    it("returns none without directives, defaults, or a default connection", () => {
+        assert.deepEqual(resolveCellTarget("SELECT * WHERE { ?s ?p ?o }", []), {
+            kind: "none",
         });
     });
 
-    it("resolves a non-URL directive to a local-files target", () => {
-        assert.deepEqual(resolveTarget("# [endpoint=./data.ttl]\nASK {}"), {
-            type: "files",
-            files: ["./data.ttl"],
+    it("picks the first http(s) directive and derives the update and shacl siblings", () => {
+        const res = resolveCellTarget("# [endpoint=https://host/ds/query]\nASK {}", []);
+        assert.deepEqual(res, {
+            kind: "target",
+            label: "https://host/ds/query",
+            target: {
+                type: "http",
+                url: "https://host/ds/query",
+                updateUrl: "https://host/ds/update",
+                shaclUrl: "https://host/ds/shacl?graph=default",
+            },
         });
     });
 
     it("collects every file directive into one union target, in order", () => {
+        const res = resolveCellTarget(
+            "# [endpoint=./model.xml]\n# [endpoint=extra.ttl]\nASK {}",
+            [],
+        );
+        assert.equal(res.kind, "target");
+        assert.deepEqual(res.kind === "target" && res.target, {
+            type: "files",
+            files: ["./model.xml", "extra.ttl"],
+        });
+    });
+
+    it("reports directives of mixed kinds instead of silently picking one", () => {
         assert.deepEqual(
-            resolveTarget("# [endpoint=./model.xml]\n# [endpoint=extra.ttl]\nASK {}"),
+            resolveCellTarget("# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}", []),
             {
-                type: "files",
-                files: ["./model.xml", "extra.ttl"],
+                kind: "ambiguous-directives",
+                directives: ["./a.ttl", "http://host/sparql"],
+            },
+        );
+        assert.deepEqual(
+            resolveCellTarget(
+                "# [endpoint=./a.ttl]\n# [endpoint=local-fuseki]\nASK {}",
+                CONNECTIONS,
+            ),
+            {
+                kind: "ambiguous-directives",
+                directives: ["./a.ttl", "local-fuseki"],
             },
         );
     });
 
-    it("prefers the http directive when files are also present", () => {
-        const target = resolveTarget(
-            "# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}",
+    it("reports repeated URL or connection directives — only files union", () => {
+        assert.equal(
+            resolveCellTarget("# [endpoint=http://a/q]\n# [endpoint=http://b/q]\nASK {}", []).kind,
+            "ambiguous-directives",
         );
-        assert.equal(target.type, "http");
+        assert.equal(
+            resolveCellTarget("# [endpoint=local-fuseki]\n# [endpoint=prod]\nASK {}", CONNECTIONS)
+                .kind,
+            "ambiguous-directives",
+        );
+    });
+
+    it("resolves a connection name, keeping its explicit URLs and deriving the rest", () => {
+        const res = resolveCellTarget("# [endpoint=local-fuseki]\nASK {}", CONNECTIONS);
+        assert.ok(res.kind === "target");
+        if (res.kind === "target") {
+            assert.equal(res.label, "local-fuseki");
+            assert.deepEqual(res.target, {
+                type: "http",
+                url: "http://localhost:3030/cgmes/query",
+                updateUrl: "http://localhost:3030/cgmes/upd",
+                shaclUrl: "http://localhost:3030/cgmes/shacl?graph=default",
+            });
+            assert.equal(res.authConnection?.name, "local-fuseki");
+        }
+    });
+
+    it("reports an unknown connection name with the known ones", () => {
+        assert.deepEqual(resolveCellTarget("# [endpoint=nope]\nASK {}", CONNECTIONS), {
+            kind: "unknown-connection",
+            name: "nope",
+            known: ["local-fuseki", "prod"],
+        });
+    });
+
+    it("falls back to the notebook default directive, then the default connection", () => {
+        const viaDefault = resolveCellTarget("ASK {}", CONNECTIONS, "./model.xml");
+        assert.ok(viaDefault.kind === "target" && viaDefault.target.type === "files");
+
+        const viaConfig = resolveCellTarget("ASK {}", CONNECTIONS);
+        assert.ok(viaConfig.kind === "target");
+        if (viaConfig.kind === "target") {
+            assert.equal(viaConfig.label, "prod");
+            assert.equal(viaConfig.authConnection, undefined);
+        }
+    });
+
+    it("cell directives beat the notebook default", () => {
+        const res = resolveCellTarget(
+            "# [endpoint=./cell.ttl]\nASK {}",
+            CONNECTIONS,
+            "local-fuseki",
+        );
+        assert.ok(res.kind === "target" && res.target.type === "files");
+    });
+});
+
+describe("statusBarText", () => {
+    it("labels each resolution kind distinctly", () => {
+        assert.equal(
+            statusBarText({
+                kind: "target",
+                label: "local-fuseki",
+                target: { type: "http", url: "http://h/q" },
+            }),
+            "$(plug) local-fuseki",
+        );
+        assert.equal(
+            statusBarText({
+                kind: "target",
+                label: "http://h:3030/ds/query?x=1",
+                target: { type: "http", url: "http://h:3030/ds/query?x=1" },
+            }),
+            "$(globe) h:3030/ds/query",
+        );
+        assert.equal(
+            statusBarText({
+                kind: "target",
+                label: "./a/model.xml, b.ttl",
+                target: { type: "files", files: ["./a/model.xml", "b.ttl"] },
+            }),
+            "$(file) model.xml (+1)",
+        );
+        assert.equal(
+            statusBarText({ kind: "unknown-connection", name: "x", known: [] }),
+            "$(warning) unknown connection: x",
+        );
+        assert.equal(
+            statusBarText({ kind: "ambiguous-directives", directives: ["a.ttl", "http://h/q"] }),
+            "$(warning) conflicting endpoint directives",
+        );
+        assert.equal(statusBarText({ kind: "none" }), "$(warning) no endpoint");
+    });
+});
+
+describe("applyEndpointDirective", () => {
+    it("inserts a directive as the first line when none exists", () => {
+        assert.equal(
+            applyEndpointDirective("ASK {}", "local-fuseki"),
+            "# [endpoint=local-fuseki]\nASK {}",
+        );
+    });
+
+    it("replaces the first directive and drops any further ones", () => {
+        const text = "# [endpoint=./a.ttl]\nASK {}\n# [endpoint=./b.ttl]";
+        assert.equal(applyEndpointDirective(text, "http://h/q"), "# [endpoint=http://h/q]\nASK {}");
+    });
+
+    it("removes all directive lines when clearing", () => {
+        const text = "# [endpoint=./a.ttl]\nASK {}\n# [endpoint=./b.ttl]";
+        assert.equal(applyEndpointDirective(text, null), "ASK {}");
+    });
+
+    it("leaves ordinary comments alone", () => {
+        const text = "# just a comment\nASK {}";
+        assert.equal(applyEndpointDirective(text, null), text);
     });
 });
 

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -281,12 +281,14 @@ export interface ConnectionInfo {
     default?: boolean;
 }
 
-/** Result of `cimvocabcheck.notebook.listConnections`. */
+/**
+ * Result of `cimvocabcheck.notebook.listConnections`. Execution defaults
+ * (queryTimeoutSeconds/maxRows) are applied server-side and deliberately not part of the wire.
+ */
 export interface ListConnectionsResponse {
+    /** The config file the connections came from — watched for changes when outside the workspace. */
     configPath?: string | null;
     connections: ConnectionInfo[];
-    queryTimeoutSeconds?: number | null;
-    maxRows?: number | null;
 }
 
 export interface ExecuteTarget {
@@ -305,7 +307,6 @@ export interface ExecuteRequest {
     languageId: string;
     text: string;
     target: ExecuteTarget;
-    options?: { timeoutMs?: number; maxRows?: number };
 }
 
 export type QueryKind = "SELECT" | "ASK" | "CONSTRUCT" | "DESCRIBE" | "UPDATE" | "SHACL";

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -36,15 +36,16 @@ export function parseEndpointDirectives(text: string): string[] {
 
 /**
  * What one directive value means: an endpoint URL, a named connection from the config's
- * `cimnotebook.connections`, or a file path. Mirrors the server's heuristic — a
- * connection name has no path separators and no extension dot, files virtually always
- * have one ("model.xml" is a file, "local-fuseki" a name).
+ * `cimnotebook.connections`, or a file path / glob pattern. Mirrors the server's
+ * heuristic — a connection name has no path separators, no extension dot, and no glob
+ * metacharacters ("model.xml" and "*.ttl" are files, "local-fuseki" a name). Glob
+ * patterns (`./rdf/*.ttl`, `./rdf/{a,b}.ttl`) are expanded server-side.
  */
 export function classifyDirective(directive: string): "url" | "name" | "file" {
     if (/^https?:\/\//i.test(directive)) {
         return "url";
     }
-    if (!/[/\\.]/.test(directive)) {
+    if (!/[/\\.*?{[]/.test(directive)) {
         return "name";
     }
     return "file";

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -184,29 +184,31 @@ function shortUrl(url: string): string {
 }
 
 /**
- * Returns the cell text with its endpoint directive set to `value` (replacing the first
- * existing directive line and dropping any further ones), or with all directive lines
- * removed when `value` is null. Used by the *Set Cell Endpoint* command — the directive
- * stays the portable source of truth inside the file.
+ * Returns the cell text with its endpoint directive(s) set to `value` (replacing the
+ * first existing directive line with one line per value and dropping any further ones),
+ * or with all directive lines removed when `value` is null. An array writes one line per
+ * entry, in order — the *Set Cell Endpoint* command uses this for a multi-file union
+ * target (M3). The directive stays the portable source of truth inside the file.
  */
-export function applyEndpointDirective(cellText: string, value: string | null): string {
+export function applyEndpointDirective(cellText: string, value: string | string[] | null): string {
+    const values = value === null ? [] : Array.isArray(value) ? value : [value];
     const directiveLine = /^\s*#\s*\[\s*endpoint\s*=\s*[^\]\s]+\s*\][^\n]*$/;
     const lines = cellText.split("\n");
     const kept: string[] = [];
-    let replaced = false;
+    let inserted = false;
     for (const line of lines) {
         if (!directiveLine.test(line)) {
             kept.push(line);
             continue;
         }
-        if (value !== null && !replaced) {
-            kept.push(`# [endpoint=${value}]`);
-            replaced = true;
+        if (values.length > 0 && !inserted) {
+            kept.push(...values.map((v) => `# [endpoint=${v}]`));
+            inserted = true;
         }
         // Further directive lines (and all of them when clearing) are dropped.
     }
-    if (value !== null && !replaced) {
-        kept.unshift(`# [endpoint=${value}]`);
+    if (values.length > 0 && !inserted) {
+        kept.unshift(...values.map((v) => `# [endpoint=${v}]`));
     }
     return kept.join("\n");
 }

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -36,13 +36,14 @@ export function parseEndpointDirectives(text: string): string[] {
 
 export type ResolvedTarget =
     | { type: "http"; url: string; updateUrl: string }
-    | { type: "unsupported"; directive: string }
+    | { type: "files"; files: string[] }
     | { type: "none" };
 
 /**
- * Resolves the target for a cell: the first `http(s)://` directive wins. Non-URL
- * directives (file paths, names) are recognised but not yet executable — they resolve to
- * `unsupported` so the cell can show a precise message instead of a parse error.
+ * Resolves the target for a cell: the first `http(s)://` directive wins; otherwise every
+ * directive is taken as a local file path and the cell queries their union. The server
+ * resolves relative paths against the notebook's directory — the same base validation
+ * uses — so one directive means one file for both.
  */
 export function resolveTarget(cellText: string): ResolvedTarget {
     const directives = parseEndpointDirectives(cellText);
@@ -51,7 +52,7 @@ export function resolveTarget(cellText: string): ResolvedTarget {
     }
     const url = directives.find((d) => /^https?:\/\//i.test(d));
     if (url === undefined) {
-        return { type: "unsupported", directive: directives[0] };
+        return { type: "files", files: directives };
     }
     return { type: "http", url, updateUrl: deriveUpdateUrl(url) };
 }
@@ -73,13 +74,16 @@ export function deriveUpdateUrl(url: string): string {
 export const EXECUTE_COMMAND = "cimvocabcheck.notebook.execute";
 
 export interface ExecuteTarget {
-    type: "http";
-    url: string;
+    type: "http" | "files";
+    url?: string;
     updateUrl?: string;
+    files?: string[];
 }
 
 export interface ExecuteRequest {
     cellUri: string;
+    /** Base for resolving relative file paths server-side; omitted for untitled notebooks. */
+    notebookUri?: string;
     languageId: string;
     text: string;
     target: ExecuteTarget;

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -1,0 +1,113 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resolves a cell's execution target from its `# [endpoint=...]` directives — the same
+ * magic-comment syntax the language server reads to pick the validation schema, so one
+ * directive drives both "validate against" and "run against".
+ *
+ * Pure module (no `vscode` import); the LSP wire types for the
+ * `cimvocabcheck.notebook.execute` command live here too, mirroring the server's records
+ * in `cimvocabcheck/lsp/.../notebook/`.
+ */
+
+/** Same pattern as the server's `EndpointDirective` (value has no spaces or `]`). */
+const DIRECTIVE = /^\s*#\s*\[\s*endpoint\s*=\s*([^\]\s]+)\s*\]/gm;
+
+/** Returns every `# [endpoint=...]` value in the cell text, in order. */
+export function parseEndpointDirectives(text: string): string[] {
+    return [...text.matchAll(DIRECTIVE)].map((m) => m[1].trim());
+}
+
+export type ResolvedTarget =
+    | { type: "http"; url: string; updateUrl: string }
+    | { type: "unsupported"; directive: string }
+    | { type: "none" };
+
+/**
+ * Resolves the target for a cell: the first `http(s)://` directive wins. Non-URL
+ * directives (file paths, names) are recognised but not yet executable — they resolve to
+ * `unsupported` so the cell can show a precise message instead of a parse error.
+ */
+export function resolveTarget(cellText: string): ResolvedTarget {
+    const directives = parseEndpointDirectives(cellText);
+    if (directives.length === 0) {
+        return { type: "none" };
+    }
+    const url = directives.find((d) => /^https?:\/\//i.test(d));
+    if (url === undefined) {
+        return { type: "unsupported", directive: directives[0] };
+    }
+    return { type: "http", url, updateUrl: deriveUpdateUrl(url) };
+}
+
+/**
+ * Best-effort update endpoint for a query endpoint URL: Fuseki-style `…/query` or
+ * `…/sparql` services get their `…/update` sibling (dropping any query string); anything
+ * else is assumed to accept updates on the same URL. The server stays strict — it only
+ * executes updates against an explicit `updateUrl` — so this derivation is the client's
+ * deliberate choice, not a hidden server fallback.
+ */
+export function deriveUpdateUrl(url: string): string {
+    const sibling = /^(.*\/)(?:query|sparql)(?:\?.*)?$/i.exec(url);
+    return sibling ? sibling[1] + "update" : url;
+}
+
+// ---- Wire types for cimvocabcheck.notebook.execute (mirror the server's records) ----
+
+export const EXECUTE_COMMAND = "cimvocabcheck.notebook.execute";
+
+export interface ExecuteTarget {
+    type: "http";
+    url: string;
+    updateUrl?: string;
+}
+
+export interface ExecuteRequest {
+    cellUri: string;
+    languageId: string;
+    text: string;
+    target: ExecuteTarget;
+    options?: { timeoutMs?: number; maxRows?: number };
+}
+
+export type QueryKind = "SELECT" | "ASK" | "CONSTRUCT" | "DESCRIBE" | "UPDATE";
+
+export interface ExecError {
+    code: string;
+    message: string;
+    detail?: string | null;
+    line?: number | null;
+    column?: number | null;
+}
+
+export interface ExecStats {
+    durationMs: number;
+    rowCount?: number | null;
+    truncated: boolean;
+    resolvedTarget?: string | null;
+}
+
+export interface ExecuteResponse {
+    status: "SUCCESS" | "ERROR" | "CANCELLED";
+    queryKind?: QueryKind | null;
+    resultsJson?: string | null;
+    turtle?: string | null;
+    stats?: ExecStats | null;
+    error?: ExecError | null;
+}

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -34,27 +34,181 @@ export function parseEndpointDirectives(text: string): string[] {
     return [...text.matchAll(DIRECTIVE)].map((m) => m[1].trim());
 }
 
-export type ResolvedTarget =
-    | { type: "http"; url: string; updateUrl: string; shaclUrl: string }
-    | { type: "files"; files: string[] }
-    | { type: "none" };
+/**
+ * What one directive value means: an endpoint URL, a named connection from the config's
+ * `cimnotebook.connections`, or a file path. Mirrors the server's heuristic — a
+ * connection name has no path separators and no extension dot, files virtually always
+ * have one ("model.xml" is a file, "local-fuseki" a name).
+ */
+export function classifyDirective(directive: string): "url" | "name" | "file" {
+    if (/^https?:\/\//i.test(directive)) {
+        return "url";
+    }
+    if (!/[/\\.]/.test(directive)) {
+        return "name";
+    }
+    return "file";
+}
 
 /**
- * Resolves the target for a cell: the first `http(s)://` directive wins; otherwise every
- * directive is taken as a local file path and the cell queries their union. The server
- * resolves relative paths against the notebook's directory — the same base validation
- * uses — so one directive means one file for both.
+ * How a cell's execution target was resolved. `authConnection` is set when the target
+ * came from a connection declaring `authType: "basic"` — the executor then attaches
+ * stored credentials before sending the request.
  */
-export function resolveTarget(cellText: string): ResolvedTarget {
+export type CellResolution =
+    | { kind: "target"; target: ExecuteTarget; label: string; authConnection?: ConnectionInfo }
+    | { kind: "unknown-connection"; name: string; known: string[] }
+    | { kind: "ambiguous-directives"; directives: string[] }
+    | { kind: "none" };
+
+/**
+ * Resolves a cell's execution target with the full precedence chain: the cell's own
+ * directives → the notebook's default directive (set via the *Set Cell Endpoint*
+ * command) → the config connection marked `"default": true` → none. Pure — the caller
+ * supplies the config connections (from `listConnections`) and the stored notebook
+ * default.
+ */
+export function resolveCellTarget(
+    cellText: string,
+    connections: ConnectionInfo[],
+    notebookDefaultDirective?: string,
+): CellResolution {
     const directives = parseEndpointDirectives(cellText);
-    if (directives.length === 0) {
-        return { type: "none" };
+    if (directives.length > 0) {
+        return resolveDirectives(directives, connections);
     }
-    const url = directives.find((d) => /^https?:\/\//i.test(d));
-    if (url === undefined) {
-        return { type: "files", files: directives };
+    if (notebookDefaultDirective) {
+        return resolveDirectives([notebookDefaultDirective], connections);
     }
-    return { type: "http", url, updateUrl: deriveUpdateUrl(url), shaclUrl: deriveShaclUrl(url) };
+    const defaultConnection = connections.find((c) => c.default === true);
+    if (defaultConnection) {
+        return connectionResolution(defaultConnection, connections);
+    }
+    return { kind: "none" };
+}
+
+/**
+ * One target per cell. Several *file* directives are a union (the M3 multi-file target),
+ * but any other repetition — two URLs, two connection names, or a mix of kinds — has no
+ * single meaning, and quietly running the cell against whichever one came first would
+ * send the query somewhere the author didn't ask for. Those are reported instead.
+ */
+function resolveDirectives(directives: string[], connections: ConnectionInfo[]): CellResolution {
+    const kinds = new Set(directives.map(classifyDirective));
+    if (kinds.size > 1 || (directives.length > 1 && !kinds.has("file"))) {
+        return { kind: "ambiguous-directives", directives };
+    }
+
+    if (kinds.has("url")) {
+        const url = directives[0];
+        return {
+            kind: "target",
+            target: {
+                type: "http",
+                url,
+                updateUrl: deriveUpdateUrl(url),
+                shaclUrl: deriveShaclUrl(url),
+            },
+            label: url,
+        };
+    }
+    if (kinds.has("name")) {
+        const name = directives[0];
+        const connection = connections.find((c) => c.name === name);
+        if (!connection) {
+            return {
+                kind: "unknown-connection",
+                name,
+                known: connections.map((c) => c.name),
+            };
+        }
+        return connectionResolution(connection, connections);
+    }
+    return {
+        kind: "target",
+        target: { type: "files", files: directives },
+        label: directives.join(", "),
+    };
+}
+
+function connectionResolution(
+    connection: ConnectionInfo,
+    connections: ConnectionInfo[],
+): CellResolution {
+    if (!connection.url) {
+        return {
+            kind: "unknown-connection",
+            name: connection.name,
+            known: connections.filter((c) => c.url).map((c) => c.name),
+        };
+    }
+    return {
+        kind: "target",
+        target: {
+            type: "http",
+            url: connection.url,
+            updateUrl: connection.updateUrl || deriveUpdateUrl(connection.url),
+            shaclUrl: connection.shaclUrl || deriveShaclUrl(connection.url),
+        },
+        label: connection.name,
+        authConnection: connection.authType?.toLowerCase() === "basic" ? connection : undefined,
+    };
+}
+
+/** Short status-bar text for a cell's resolution, with a codicon hinting the kind. */
+export function statusBarText(resolution: CellResolution): string {
+    switch (resolution.kind) {
+        case "target": {
+            const target = resolution.target;
+            if (target.type === "files") {
+                const files = target.files ?? [];
+                const first = files[0]?.replace(/^.*[/\\]/, "") ?? "?";
+                return `$(file) ${first}${files.length > 1 ? ` (+${files.length - 1})` : ""}`;
+            }
+            const viaConnection = resolution.label !== target.url;
+            return viaConnection
+                ? `$(plug) ${resolution.label}`
+                : `$(globe) ${shortUrl(target.url ?? "")}`;
+        }
+        case "unknown-connection":
+            return `$(warning) unknown connection: ${resolution.name}`;
+        case "ambiguous-directives":
+            return "$(warning) conflicting endpoint directives";
+        case "none":
+            return "$(warning) no endpoint";
+    }
+}
+
+function shortUrl(url: string): string {
+    return url.replace(/^https?:\/\//i, "").replace(/\?.*$/, "");
+}
+
+/**
+ * Returns the cell text with its endpoint directive set to `value` (replacing the first
+ * existing directive line and dropping any further ones), or with all directive lines
+ * removed when `value` is null. Used by the *Set Cell Endpoint* command — the directive
+ * stays the portable source of truth inside the file.
+ */
+export function applyEndpointDirective(cellText: string, value: string | null): string {
+    const directiveLine = /^\s*#\s*\[\s*endpoint\s*=\s*[^\]\s]+\s*\][^\n]*$/;
+    const lines = cellText.split("\n");
+    const kept: string[] = [];
+    let replaced = false;
+    for (const line of lines) {
+        if (!directiveLine.test(line)) {
+            kept.push(line);
+            continue;
+        }
+        if (value !== null && !replaced) {
+            kept.push(`# [endpoint=${value}]`);
+            replaced = true;
+        }
+        // Further directive lines (and all of them when clearing) are dropped.
+    }
+    if (value !== null && !replaced) {
+        kept.unshift(`# [endpoint=${value}]`);
+    }
+    return kept.join("\n");
 }
 
 /**
@@ -89,9 +243,49 @@ export function deriveShaclUrl(url: string): string {
     return shaclPath + (query || "?graph=default");
 }
 
-// ---- Wire types for cimvocabcheck.notebook.execute (mirror the server's records) ----
+// ---- Wire types for the cimvocabcheck.notebook.* commands (mirror the server's records) ----
 
 export const EXECUTE_COMMAND = "cimvocabcheck.notebook.execute";
+export const LIST_CONNECTIONS_COMMAND = "cimvocabcheck.notebook.listConnections";
+export const SET_DEFAULT_ENDPOINT_COMMAND = "cimvocabcheck.notebook.setDefaultEndpoint";
+
+/**
+ * Tells the server which endpoint a notebook's directive-less cells use, so they validate against
+ * what they run against. The default lives in the client's workspace state (not in the notebook
+ * file), hence this push; `endpoint: null` clears it.
+ */
+export interface SetDefaultEndpointRequest {
+    notebookUri: string;
+    endpoint: string | null;
+}
+
+/**
+ * Credentials attached to an execute request. They come from VS Code SecretStorage —
+ * never from the config file — and travel only inside this request.
+ */
+export interface ExecAuth {
+    type: "basic";
+    username: string;
+    password: string;
+}
+
+/** One connection from the config's `cimnotebook.connections`, as the server lists it. */
+export interface ConnectionInfo {
+    name: string;
+    url?: string;
+    updateUrl?: string;
+    shaclUrl?: string;
+    authType?: string;
+    default?: boolean;
+}
+
+/** Result of `cimvocabcheck.notebook.listConnections`. */
+export interface ListConnectionsResponse {
+    configPath?: string | null;
+    connections: ConnectionInfo[];
+    queryTimeoutSeconds?: number | null;
+    maxRows?: number | null;
+}
 
 export interface ExecuteTarget {
     type: "http" | "files";
@@ -99,6 +293,7 @@ export interface ExecuteTarget {
     updateUrl?: string;
     shaclUrl?: string;
     files?: string[];
+    auth?: ExecAuth;
 }
 
 export interface ExecuteRequest {

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -35,7 +35,7 @@ export function parseEndpointDirectives(text: string): string[] {
 }
 
 export type ResolvedTarget =
-    | { type: "http"; url: string; updateUrl: string }
+    | { type: "http"; url: string; updateUrl: string; shaclUrl: string }
     | { type: "files"; files: string[] }
     | { type: "none" };
 
@@ -54,7 +54,7 @@ export function resolveTarget(cellText: string): ResolvedTarget {
     if (url === undefined) {
         return { type: "files", files: directives };
     }
-    return { type: "http", url, updateUrl: deriveUpdateUrl(url) };
+    return { type: "http", url, updateUrl: deriveUpdateUrl(url), shaclUrl: deriveShaclUrl(url) };
 }
 
 /**
@@ -69,6 +69,26 @@ export function deriveUpdateUrl(url: string): string {
     return sibling ? sibling[1] + "update" : url;
 }
 
+/**
+ * Best-effort SHACL service URL for a query endpoint URL: Fuseki-style `…/query` or
+ * `…/sparql` services get their `…/shacl` sibling, a URL already ending in `/shacl` is
+ * kept, and anything else gets `/shacl` appended. Fuseki's SHACL operation requires a
+ * `?graph=` selector, so an existing query string is preserved and `?graph=default`
+ * (the default graph) is added when there is none. As with updates, the server never
+ * derives this — an explicit `shaclUrl` is required there.
+ */
+export function deriveShaclUrl(url: string): string {
+    const query = /\?.*$/.exec(url)?.[0] ?? "";
+    const path = query ? url.slice(0, -query.length) : url;
+    const sibling = /^(.*\/)(?:query|sparql)$/i.exec(path);
+    const shaclPath = sibling
+        ? sibling[1] + "shacl"
+        : /\/shacl$/i.test(path)
+          ? path
+          : path.replace(/\/+$/, "") + "/shacl";
+    return shaclPath + (query || "?graph=default");
+}
+
 // ---- Wire types for cimvocabcheck.notebook.execute (mirror the server's records) ----
 
 export const EXECUTE_COMMAND = "cimvocabcheck.notebook.execute";
@@ -77,6 +97,7 @@ export interface ExecuteTarget {
     type: "http" | "files";
     url?: string;
     updateUrl?: string;
+    shaclUrl?: string;
     files?: string[];
 }
 
@@ -90,7 +111,14 @@ export interface ExecuteRequest {
     options?: { timeoutMs?: number; maxRows?: number };
 }
 
-export type QueryKind = "SELECT" | "ASK" | "CONSTRUCT" | "DESCRIBE" | "UPDATE";
+export type QueryKind = "SELECT" | "ASK" | "CONSTRUCT" | "DESCRIBE" | "UPDATE" | "SHACL";
+
+export interface ShaclSummary {
+    conforms: boolean;
+    violations: number;
+    warnings: number;
+    infos: number;
+}
 
 export interface ExecError {
     code: string;
@@ -112,6 +140,7 @@ export interface ExecuteResponse {
     queryKind?: QueryKind | null;
     resultsJson?: string | null;
     turtle?: string | null;
+    shaclSummary?: ShaclSummary | null;
     stats?: ExecStats | null;
     error?: ExecError | null;
 }

--- a/cimnotebook/vscode/src/notebook/endpointCommands.ts
+++ b/cimnotebook/vscode/src/notebook/endpointCommands.ts
@@ -29,13 +29,22 @@
 
 import * as vscode from "vscode";
 
+import { validateRequiredUrl } from "../sidebar/treeItems";
 import { ConnectionStore } from "./connections";
 import { clearCredentials, setCredentials } from "./credentials";
 import { applyEndpointDirective, ConnectionInfo } from "./endpoint";
+import { pickWorkspaceFiles } from "./filePicker";
 
 export const SET_ENDPOINT_COMMAND = "cimnotebook.notebook.setEndpoint";
 export const SET_CREDENTIALS_COMMAND = "cimnotebook.notebook.setCredentials";
 export const CLEAR_CREDENTIALS_COMMAND = "cimnotebook.notebook.clearCredentials";
+
+/** Data file extensions offered by the "Enter data file path…" picker. */
+const DATA_FILE_PATTERN = "**/*.{xml,ttl,rdf,owl,nt,nq,trig}";
+
+/** Workspace-scoped memory of recently used endpoint URLs (most recent first). */
+const RECENT_URLS_KEY = "cimnotebook.recentEndpointUrls";
+const MAX_RECENT_URLS = 5;
 
 export function registerEndpointCommands(
     context: vscode.ExtensionContext,
@@ -43,7 +52,7 @@ export function registerEndpointCommands(
 ): void {
     context.subscriptions.push(
         vscode.commands.registerCommand(SET_ENDPOINT_COMMAND, (cell?: vscode.NotebookCell) =>
-            setEndpoint(store, cell),
+            setEndpoint(context, store, cell),
         ),
         vscode.commands.registerCommand(SET_CREDENTIALS_COMMAND, () =>
             manageCredentials(context, store, "set"),
@@ -61,7 +70,11 @@ interface EndpointPick extends vscode.QuickPickItem {
     connection?: ConnectionInfo;
 }
 
-async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): Promise<void> {
+async function setEndpoint(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+    cell?: vscode.NotebookCell,
+): Promise<void> {
     const target = cell ?? activeCell();
     if (!target) {
         vscode.window.showWarningMessage("CIMNotebook: no notebook cell is active.");
@@ -104,18 +117,13 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
         return;
     }
 
-    let directive: string | null;
+    let directive: string | string[] | null;
     switch (pick.action) {
         case "connection":
             directive = pick.connection?.name ?? null;
             break;
         case "url": {
-            const url = await vscode.window.showInputBox({
-                title: "SPARQL endpoint URL",
-                placeHolder: "http://localhost:3030/dataset/query",
-                validateInput: (v) =>
-                    /^https?:\/\/\S+$/i.test(v) ? undefined : "Enter an http(s):// URL",
-            });
+            const url = await pickEndpointUrl(context);
             if (url === undefined) {
                 return;
             }
@@ -123,14 +131,21 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
             break;
         }
         case "file": {
-            const file = await vscode.window.showInputBox({
-                title: "Data file path (relative to the notebook)",
-                placeHolder: "./model.xml",
+            const files = await pickWorkspaceFiles({
+                pattern: DATA_FILE_PATTERN,
+                baseUri: vscode.Uri.joinPath(target.notebook.uri, ".."),
+                title: "Data file(s) to run this cell against",
+                placeHolder: "Search by file name — pick one or more (Tab to multi-select)",
+                canPickMany: true,
+                allowManualEntry: true,
             });
-            if (file === undefined || file === "") {
+            const usable = filterDirectiveSafePaths(files);
+            if (!usable || usable.length === 0) {
                 return;
             }
-            directive = file;
+            // A notebook-wide default is a single stored directive (connections.ts), so a
+            // multi-file union — the M3 target — only makes sense written into the cell.
+            directive = usable.length > 1 ? usable : usable[0];
             break;
         }
         case "clear":
@@ -138,8 +153,9 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
             break;
     }
 
+    // "clear" (null) and multi-file (string[]) both apply to the cell only.
     const scope =
-        directive === null
+        directive === null || Array.isArray(directive)
             ? "This cell"
             : await vscode.window.showQuickPick(["This cell", "Notebook default"], {
                   title: "Apply where?",
@@ -150,8 +166,8 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
     if (scope === undefined) {
         return;
     }
-    if (scope === "Notebook default") {
-        await store.setNotebookDefault(target.notebook, directive ?? undefined);
+    if (scope === "Notebook default" && typeof directive === "string") {
+        await store.setNotebookDefault(target.notebook, directive);
         return;
     }
 
@@ -165,6 +181,72 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
         );
         await vscode.workspace.applyEdit(edit);
     }
+}
+
+/**
+ * A small QuickPick history of recently used URLs (workspaceState, last {@link
+ * MAX_RECENT_URLS}) above a plain "Enter new URL…" input box — skipped entirely the
+ * first time, when there is nothing to recall yet.
+ */
+async function pickEndpointUrl(context: vscode.ExtensionContext): Promise<string | undefined> {
+    const recent = context.workspaceState.get<string[]>(RECENT_URLS_KEY, []);
+    let url: string | undefined;
+    if (recent.length === 0) {
+        url = await promptForUrl();
+    } else {
+        interface UrlPick extends vscode.QuickPickItem {
+            url?: string;
+            enterNew?: boolean;
+        }
+        const items: UrlPick[] = recent.map((u) => ({ label: `$(history) ${u}`, url: u }));
+        items.push({ label: "$(edit) Enter new URL…", enterNew: true });
+        const pick = await vscode.window.showQuickPick(items, {
+            title: "SPARQL endpoint URL",
+            placeHolder: "Pick a recent URL or enter a new one",
+        });
+        if (!pick) {
+            return undefined;
+        }
+        url = pick.enterNew ? await promptForUrl() : pick.url;
+    }
+    if (url === undefined) {
+        return undefined;
+    }
+    await rememberRecentUrl(context, url);
+    return url;
+}
+
+function promptForUrl(): Thenable<string | undefined> {
+    return vscode.window.showInputBox({
+        title: "SPARQL endpoint URL",
+        placeHolder: "http://localhost:3030/dataset/query",
+        validateInput: validateRequiredUrl,
+    });
+}
+
+/**
+ * Drops picked paths that a `# [endpoint=...]` directive cannot express — its value ends
+ * at the first whitespace character (see `parseEndpointDirectives`) — and tells the user
+ * why. Returns `undefined` when the pick itself was cancelled.
+ */
+function filterDirectiveSafePaths(files: string[] | undefined): string[] | undefined {
+    if (!files) {
+        return undefined;
+    }
+    const unusable = files.filter((f) => /\s/.test(f));
+    if (unusable.length > 0) {
+        vscode.window.showErrorMessage(
+            `CIMNotebook: ${unusable.join(", ")} can't be used in a # [endpoint=…] directive — ` +
+                "paths containing whitespace aren't supported. Rename the file or folder to use it here.",
+        );
+    }
+    return files.filter((f) => !/\s/.test(f));
+}
+
+async function rememberRecentUrl(context: vscode.ExtensionContext, url: string): Promise<void> {
+    const recent = context.workspaceState.get<string[]>(RECENT_URLS_KEY, []);
+    const next = [url, ...recent.filter((u) => u !== url)].slice(0, MAX_RECENT_URLS);
+    await context.workspaceState.update(RECENT_URLS_KEY, next);
 }
 
 function activeCell(): vscode.NotebookCell | undefined {

--- a/cimnotebook/vscode/src/notebook/endpointCommands.ts
+++ b/cimnotebook/vscode/src/notebook/endpointCommands.ts
@@ -31,7 +31,7 @@ import * as vscode from "vscode";
 
 import { validateRequiredUrl } from "../sidebar/treeItems";
 import { ConnectionStore } from "./connections";
-import { clearCredentials, setCredentials } from "./credentials";
+import { runCredentialsAction } from "./credentials";
 import { applyEndpointDirective, ConnectionInfo } from "./endpoint";
 import { pickWorkspaceFiles } from "./filePicker";
 
@@ -272,16 +272,7 @@ async function manageCredentials(
     if (!name) {
         return;
     }
-    if (mode === "set") {
-        if (await setCredentials(context.secrets, name)) {
-            vscode.window.showInformationMessage(
-                `CIMNotebook: credentials for "${name}" stored in VS Code secret storage.`,
-            );
-        }
-    } else {
-        await clearCredentials(context.secrets, name);
-        vscode.window.showInformationMessage(`CIMNotebook: credentials for "${name}" cleared.`);
-    }
+    await runCredentialsAction(context.secrets, name, mode);
 }
 
 async function pickConnectionName(store: ConnectionStore): Promise<string | undefined> {

--- a/cimnotebook/vscode/src/notebook/endpointCommands.ts
+++ b/cimnotebook/vscode/src/notebook/endpointCommands.ts
@@ -1,0 +1,222 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Commands for endpoints and credentials:
+ *
+ * - *Set Cell Endpoint* — QuickPick over the config's connections plus free-form URL /
+ *   file input; writes a `# [endpoint=…]` directive into the cell (the directive is the
+ *   portable source of truth, versioned with the file), or stores a notebook-wide
+ *   default in workspaceState without touching the file.
+ * - *Set / Clear Connection Credentials* — manage the SecretStorage entries for
+ *   `authType: "basic"` connections.
+ */
+
+import * as vscode from "vscode";
+
+import { ConnectionStore } from "./connections";
+import { clearCredentials, setCredentials } from "./credentials";
+import { applyEndpointDirective, ConnectionInfo } from "./endpoint";
+
+export const SET_ENDPOINT_COMMAND = "cimnotebook.notebook.setEndpoint";
+export const SET_CREDENTIALS_COMMAND = "cimnotebook.notebook.setCredentials";
+export const CLEAR_CREDENTIALS_COMMAND = "cimnotebook.notebook.clearCredentials";
+
+export function registerEndpointCommands(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(SET_ENDPOINT_COMMAND, (cell?: vscode.NotebookCell) =>
+            setEndpoint(store, cell),
+        ),
+        vscode.commands.registerCommand(SET_CREDENTIALS_COMMAND, () =>
+            manageCredentials(context, store, "set"),
+        ),
+        vscode.commands.registerCommand(CLEAR_CREDENTIALS_COMMAND, () =>
+            manageCredentials(context, store, "clear"),
+        ),
+    );
+}
+
+// ---- Set Cell Endpoint -----------------------------------------------------------------------
+
+interface EndpointPick extends vscode.QuickPickItem {
+    action: "connection" | "url" | "file" | "clear" | "clear-default";
+    connection?: ConnectionInfo;
+}
+
+async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): Promise<void> {
+    const target = cell ?? activeCell();
+    if (!target) {
+        vscode.window.showWarningMessage("CIMNotebook: no notebook cell is active.");
+        return;
+    }
+
+    const { connections } = await store.forNotebook(target.notebook);
+    const notebookDefault = store.notebookDefault(target.notebook);
+    const items: EndpointPick[] = connections.map((connection) => ({
+        action: "connection",
+        connection,
+        label: `$(plug) ${connection.name}`,
+        description: connection.url,
+        detail: connection.default ? "workspace default connection" : undefined,
+    }));
+    items.push(
+        { action: "url", label: "$(globe) Enter endpoint URL…" },
+        { action: "file", label: "$(file) Enter data file path…" },
+        { action: "clear", label: "$(clear-all) Remove the cell's endpoint directive" },
+    );
+    if (notebookDefault) {
+        items.push({
+            action: "clear-default",
+            label: "$(circle-slash) Clear the notebook default",
+            description: notebookDefault,
+        });
+    }
+
+    const pick = await vscode.window.showQuickPick(items, {
+        title: notebookDefault
+            ? `Where should this cell run? (notebook default: ${notebookDefault})`
+            : "Where should this cell run?",
+        placeHolder: "Connection, URL, or local data file",
+    });
+    if (!pick) {
+        return;
+    }
+    if (pick.action === "clear-default") {
+        await store.setNotebookDefault(target.notebook, undefined);
+        return;
+    }
+
+    let directive: string | null;
+    switch (pick.action) {
+        case "connection":
+            directive = pick.connection?.name ?? null;
+            break;
+        case "url": {
+            const url = await vscode.window.showInputBox({
+                title: "SPARQL endpoint URL",
+                placeHolder: "http://localhost:3030/dataset/query",
+                validateInput: (v) =>
+                    /^https?:\/\/\S+$/i.test(v) ? undefined : "Enter an http(s):// URL",
+            });
+            if (url === undefined) {
+                return;
+            }
+            directive = url;
+            break;
+        }
+        case "file": {
+            const file = await vscode.window.showInputBox({
+                title: "Data file path (relative to the notebook)",
+                placeHolder: "./model.xml",
+            });
+            if (file === undefined || file === "") {
+                return;
+            }
+            directive = file;
+            break;
+        }
+        case "clear":
+            directive = null;
+            break;
+    }
+
+    const scope =
+        directive === null
+            ? "This cell"
+            : await vscode.window.showQuickPick(["This cell", "Notebook default"], {
+                  title: "Apply where?",
+                  placeHolder:
+                      "This cell = write a # [endpoint=…] directive; Notebook default = " +
+                      "remember for all directive-less cells (workspace state, not the file)",
+              });
+    if (scope === undefined) {
+        return;
+    }
+    if (scope === "Notebook default") {
+        await store.setNotebookDefault(target.notebook, directive ?? undefined);
+        return;
+    }
+
+    const newText = applyEndpointDirective(target.document.getText(), directive);
+    if (newText !== target.document.getText()) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(
+            target.document.uri,
+            new vscode.Range(0, 0, target.document.lineCount, 0),
+            newText,
+        );
+        await vscode.workspace.applyEdit(edit);
+    }
+}
+
+function activeCell(): vscode.NotebookCell | undefined {
+    const editor = vscode.window.activeNotebookEditor;
+    if (!editor) {
+        return undefined;
+    }
+    const range = editor.selections[0];
+    if (!range || range.isEmpty) {
+        return undefined;
+    }
+    return editor.notebook.cellAt(range.start);
+}
+
+// ---- credentials ------------------------------------------------------------------------------
+
+async function manageCredentials(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+    mode: "set" | "clear",
+): Promise<void> {
+    const name = await pickConnectionName(store);
+    if (!name) {
+        return;
+    }
+    if (mode === "set") {
+        if (await setCredentials(context.secrets, name)) {
+            vscode.window.showInformationMessage(
+                `CIMNotebook: credentials for "${name}" stored in VS Code secret storage.`,
+            );
+        }
+    } else {
+        await clearCredentials(context.secrets, name);
+        vscode.window.showInformationMessage(`CIMNotebook: credentials for "${name}" cleared.`);
+    }
+}
+
+async function pickConnectionName(store: ConnectionStore): Promise<string | undefined> {
+    const notebook = vscode.window.activeNotebookEditor?.notebook;
+    const connections = notebook ? (await store.forNotebook(notebook)).connections : [];
+    const basicConnections = connections.filter((c) => c.authType?.toLowerCase() === "basic");
+    if (basicConnections.length > 0) {
+        const pick = await vscode.window.showQuickPick(
+            basicConnections.map((c) => ({ label: c.name, description: c.url })),
+            { title: "Connection" },
+        );
+        return pick?.label;
+    }
+    // No notebook open (or no basic-auth connections declared): fall back to free input so
+    // credentials can still be managed.
+    return vscode.window.showInputBox({
+        title: "Connection name",
+        placeHolder: "as declared in opencgmes.jsonc → cimnotebook.connections",
+    });
+}

--- a/cimnotebook/vscode/src/notebook/executor.ts
+++ b/cimnotebook/vscode/src/notebook/executor.ts
@@ -1,0 +1,173 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Executes one notebook cell through the language server's
+ * `cimvocabcheck.notebook.execute` workspace command and turns the response into cell
+ * outputs. Which MIME types those outputs carry — and, crucially, which one VS Code then
+ * picks to render — is decided in {@link outputItemsFor}.
+ */
+
+import * as vscode from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+import {
+    EXECUTE_COMMAND,
+    ExecError,
+    ExecuteRequest,
+    ExecuteResponse,
+    resolveTarget,
+} from "./endpoint";
+import { errorSummary, MIME_MARKDOWN, outputItemsFor } from "./outputs";
+
+export class CellExecutor {
+    constructor(private readonly getClient: () => LanguageClient | undefined) {}
+
+    async execute(
+        cell: vscode.NotebookCell,
+        execution: vscode.NotebookCellExecution,
+    ): Promise<void> {
+        execution.start(Date.now());
+        try {
+            const ok = await this.run(cell, execution);
+            execution.end(ok, Date.now());
+        } catch (err) {
+            if (execution.token.isCancellationRequested) {
+                // The request was torn down by the Stop button; no error to report.
+                await replaceMarkdown(execution, "*Execution cancelled.*");
+                execution.end(false, Date.now());
+                return;
+            }
+            const message = err instanceof Error ? err.message : String(err);
+            await execution.replaceOutput(
+                new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.error(new Error(message)),
+                ]),
+            );
+            execution.end(false, Date.now());
+        }
+    }
+
+    private async run(
+        cell: vscode.NotebookCell,
+        execution: vscode.NotebookCellExecution,
+    ): Promise<boolean> {
+        const client = this.getClient();
+        if (!client) {
+            await replaceMarkdown(
+                execution,
+                "**Language server is not running.** Reload the window or check the CIMNotebook output channel.",
+            );
+            return false;
+        }
+
+        const text = cell.document.getText();
+        const target = resolveTarget(text);
+        if (target.type === "none") {
+            await replaceMarkdown(
+                execution,
+                "**No endpoint configured.** Add a directive to the cell, e.g.\n\n" +
+                    "```\n# [endpoint=http://localhost:3030/dataset/query]\n```",
+            );
+            return false;
+        }
+        if (target.type === "unsupported") {
+            await replaceMarkdown(
+                execution,
+                `**Unsupported endpoint \`${target.directive}\`.** Only \`http(s)://\` URLs can ` +
+                    "be executed in this version; local files are used for validation only.",
+            );
+            return false;
+        }
+
+        const request: ExecuteRequest = {
+            cellUri: cell.document.uri.toString(),
+            languageId: cell.document.languageId,
+            text,
+            target: { type: "http", url: target.url, updateUrl: target.updateUrl },
+        };
+        const response = await client.sendRequest<ExecuteResponse>(
+            "workspace/executeCommand",
+            { command: EXECUTE_COMMAND, arguments: [request] },
+            execution.token,
+        );
+        return renderResponse(response, execution);
+    }
+}
+
+async function renderResponse(
+    response: ExecuteResponse | null | undefined,
+    execution: vscode.NotebookCellExecution,
+): Promise<boolean> {
+    if (!response) {
+        await replaceMarkdown(execution, "**No response from the language server.**");
+        return false;
+    }
+
+    if (response.status === "CANCELLED") {
+        await replaceMarkdown(execution, "*Execution cancelled.*");
+        return false;
+    }
+
+    if (response.status === "ERROR" || response.error) {
+        const error = response.error ?? { code: "INTERNAL", message: "Unknown error" };
+        await execution.replaceOutput(
+            new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.error(toError(error))]),
+        );
+        return false;
+    }
+
+    const items = outputItemsFor(response);
+    if (items.length === 0) {
+        await replaceMarkdown(
+            execution,
+            `**Unexpected result kind \`${response.queryKind ?? "?"}\`.**`,
+        );
+        return false;
+    }
+    await execution.replaceOutput(
+        new vscode.NotebookCellOutput(
+            items.map((item) => vscode.NotebookCellOutputItem.text(item.text, item.mime)),
+        ),
+    );
+    return true;
+}
+
+/**
+ * The error VS Code renders in its red output box. The server's `detail` (an endpoint's
+ * response body, a Jena message) goes into `stack`, which the renderer prints below the
+ * message — an accompanying markdown item would never be seen, since the items of one
+ * output are alternatives and the error MIME type outranks markdown.
+ */
+function toError(error: ExecError): Error {
+    const err = new Error(errorSummary(error));
+    err.name = "CIMNotebook";
+    err.stack = error.detail?.trimEnd() ?? "";
+    return err;
+}
+
+function markdownItem(markdown: string): vscode.NotebookCellOutputItem {
+    return vscode.NotebookCellOutputItem.text(markdown, MIME_MARKDOWN);
+}
+
+async function replaceMarkdown(
+    execution: vscode.NotebookCellExecution,
+    markdown: string,
+): Promise<void> {
+    await execution.replaceOutput(new vscode.NotebookCellOutput([markdownItem(markdown)]));
+}

--- a/cimnotebook/vscode/src/notebook/executor.ts
+++ b/cimnotebook/vscode/src/notebook/executor.ts
@@ -26,17 +26,17 @@
 import * as vscode from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 
-import {
-    EXECUTE_COMMAND,
-    ExecError,
-    ExecuteRequest,
-    ExecuteResponse,
-    resolveTarget,
-} from "./endpoint";
+import { ConnectionStore } from "./connections";
+import { authFor } from "./credentials";
+import { EXECUTE_COMMAND, ExecError, ExecuteRequest, ExecuteResponse } from "./endpoint";
 import { errorSummary, MIME_MARKDOWN, outputItemsFor } from "./outputs";
 
 export class CellExecutor {
-    constructor(private readonly getClient: () => LanguageClient | undefined) {}
+    constructor(
+        private readonly getClient: () => LanguageClient | undefined,
+        private readonly store: ConnectionStore,
+        private readonly secrets: vscode.SecretStorage,
+    ) {}
 
     async execute(
         cell: vscode.NotebookCell,
@@ -77,27 +77,50 @@ export class CellExecutor {
         }
 
         const text = cell.document.getText();
-        const target = resolveTarget(text);
-        if (target.type === "none") {
+        const resolution = await this.store.resolveCell(cell);
+        if (resolution.kind === "none") {
             await replaceMarkdown(
                 execution,
                 "**No endpoint configured.** Add a directive to the cell, e.g.\n\n" +
                     "```\n# [endpoint=http://localhost:3030/dataset/query]\n```\n\n" +
-                    "or point it at a local RDF or CIMXML file:\n\n" +
-                    "```\n# [endpoint=./model.xml]\n```",
+                    "point it at a local RDF or CIMXML file (`# [endpoint=./model.xml]`), " +
+                    "name a connection from `opencgmes.jsonc`, or use the cell's endpoint " +
+                    "status-bar button.",
+            );
+            return false;
+        }
+        if (resolution.kind === "ambiguous-directives") {
+            await replaceMarkdown(
+                execution,
+                "**Conflicting `# [endpoint=…]` directives.** This cell declares " +
+                    resolution.directives.map((d) => `\`${d}\``).join(", ") +
+                    " — a cell runs against one endpoint. Keep a single URL or connection name " +
+                    "(several *file* paths are allowed: they are queried as one union).",
+            );
+            return false;
+        }
+        if (resolution.kind === "unknown-connection") {
+            const known =
+                resolution.known.length > 0
+                    ? `Known connections: ${resolution.known.map((n) => `\`${n}\``).join(", ")}.`
+                    : "The applicable `opencgmes.jsonc` declares no connections.";
+            await replaceMarkdown(
+                execution,
+                `**Unknown connection \`${resolution.name}\`.** ${known}`,
             );
             return false;
         }
 
+        const target = resolution.target;
+        if (resolution.authConnection) {
+            target.auth = await authFor(this.secrets, resolution.authConnection, true);
+        }
         const request: ExecuteRequest = {
             cellUri: cell.document.uri.toString(),
             notebookUri: cell.notebook.uri.toString(),
             languageId: cell.document.languageId,
             text,
-            target:
-                target.type === "http"
-                    ? { type: "http", url: target.url, updateUrl: target.updateUrl }
-                    : { type: "files", files: target.files },
+            target,
         };
         const response = await client.sendRequest<ExecuteResponse>(
             "workspace/executeCommand",

--- a/cimnotebook/vscode/src/notebook/executor.ts
+++ b/cimnotebook/vscode/src/notebook/executor.ts
@@ -82,24 +82,22 @@ export class CellExecutor {
             await replaceMarkdown(
                 execution,
                 "**No endpoint configured.** Add a directive to the cell, e.g.\n\n" +
-                    "```\n# [endpoint=http://localhost:3030/dataset/query]\n```",
-            );
-            return false;
-        }
-        if (target.type === "unsupported") {
-            await replaceMarkdown(
-                execution,
-                `**Unsupported endpoint \`${target.directive}\`.** Only \`http(s)://\` URLs can ` +
-                    "be executed in this version; local files are used for validation only.",
+                    "```\n# [endpoint=http://localhost:3030/dataset/query]\n```\n\n" +
+                    "or point it at a local RDF or CIMXML file:\n\n" +
+                    "```\n# [endpoint=./model.xml]\n```",
             );
             return false;
         }
 
         const request: ExecuteRequest = {
             cellUri: cell.document.uri.toString(),
+            notebookUri: cell.notebook.uri.toString(),
             languageId: cell.document.languageId,
             text,
-            target: { type: "http", url: target.url, updateUrl: target.updateUrl },
+            target:
+                target.type === "http"
+                    ? { type: "http", url: target.url, updateUrl: target.updateUrl }
+                    : { type: "files", files: target.files },
         };
         const response = await client.sendRequest<ExecuteResponse>(
             "workspace/executeCommand",

--- a/cimnotebook/vscode/src/notebook/filePicker.ts
+++ b/cimnotebook/vscode/src/notebook/filePicker.ts
@@ -1,0 +1,142 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * File search / autocomplete for the sidebar's schema-file fields and the *Set Cell
+ * Endpoint* command: a QuickPick over `workspace.findFiles`, whose built-in fuzzy
+ * filtering is the search-as-you-type behaviour, with a `showOpenDialog` fallback for
+ * files outside the workspace (e.g. multi-root setups, or files under an excluded
+ * folder). Paths are returned relative to a caller-supplied base directory, matching how
+ * `opencgmes.jsonc` paths and `# [endpoint=...]` directives are resolved.
+ */
+
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { relativizePath } from "./relativizePath";
+
+/** Keeps the picker responsive and avoids listing generated/vendor trees. */
+const DEFAULT_EXCLUDES = "**/{node_modules,.git,out,out-test,dist,build,target}/**";
+const MAX_RESULTS = 2000;
+
+interface FileQuickPickItem extends vscode.QuickPickItem {
+    uri?: vscode.Uri;
+    browse?: boolean;
+    manual?: boolean;
+}
+
+export interface PickWorkspaceFilesOptions {
+    /** Glob passed to `workspace.findFiles`, e.g. `"**\/*.{rdf,ttl,owl}"`. */
+    pattern: string;
+    /** Directory the returned paths are relativized against. */
+    baseUri: vscode.Uri;
+    title: string;
+    placeHolder?: string;
+    canPickMany?: boolean;
+    /**
+     * Adds an "Enter path manually…" item for paths the picker can't offer — typically a
+     * file that doesn't exist yet. The typed path is returned verbatim (it is already
+     * relative to `baseUri` by convention), so no existence check is applied.
+     */
+    allowManualEntry?: boolean;
+}
+
+/**
+ * QuickPick over the workspace files matching `pattern`. Returns paths relative to
+ * `baseUri` in `./...` form, or `undefined` if the user cancelled. The last item,
+ * "Browse…", opens a native file dialog for files the glob can't reach (excluded
+ * folders, other drives, …) — picking it takes over the whole selection, since the
+ * dialog has its own multi-select UI.
+ */
+export async function pickWorkspaceFiles(
+    options: PickWorkspaceFilesOptions,
+): Promise<string[] | undefined> {
+    const { pattern, baseUri, title, placeHolder, canPickMany, allowManualEntry } = options;
+    const found = await vscode.workspace.findFiles(pattern, DEFAULT_EXCLUDES, MAX_RESULTS);
+    const items: FileQuickPickItem[] = found
+        .slice()
+        .sort((a, b) => a.fsPath.localeCompare(b.fsPath))
+        .map((uri) => ({
+            label: `$(file) ${path.basename(uri.fsPath)}`,
+            description: vscode.workspace.asRelativePath(path.dirname(uri.fsPath), false),
+            uri,
+        }));
+    items.push({ label: "$(folder-opened) Browse…", browse: true });
+    if (allowManualEntry) {
+        items.push({ label: "$(edit) Enter path manually…", manual: true });
+    }
+
+    const picked = await vscode.window.showQuickPick(items, {
+        title,
+        placeHolder: placeHolder ?? "Type to search files by name",
+        canPickMany,
+        matchOnDescription: true,
+    });
+    if (!picked) {
+        return undefined;
+    }
+    const selections = Array.isArray(picked) ? picked : [picked];
+    if (selections.length === 0) {
+        return undefined;
+    }
+    // Like Browse…, manual entry takes over the whole selection: it is an escape hatch,
+    // not one pick among many.
+    if (selections.some((s) => s.manual)) {
+        const typed = await vscode.window.showInputBox({
+            title,
+            placeHolder: "./model.xml",
+            prompt: "Relative paths are resolved against the notebook / config file directory.",
+        });
+        const trimmed = typed?.trim();
+        return trimmed ? [trimmed] : undefined;
+    }
+    if (selections.some((s) => s.browse)) {
+        const uris = await vscode.window.showOpenDialog({
+            title,
+            canSelectMany: canPickMany,
+            canSelectFolders: false,
+            canSelectFiles: true,
+        });
+        if (!uris || uris.length === 0) {
+            return undefined;
+        }
+        return uris.map((uri) => relativizePath(baseUri.fsPath, uri.fsPath));
+    }
+    return selections
+        .filter((s): s is FileQuickPickItem & { uri: vscode.Uri } => s.uri !== undefined)
+        .map((s) => relativizePath(baseUri.fsPath, s.uri.fsPath));
+}
+
+export interface PickWorkspaceFolderOptions {
+    baseUri: vscode.Uri;
+    title: string;
+}
+
+/** Native folder dialog, returning the picked folder relative to `baseUri`. */
+export async function pickWorkspaceFolder(
+    options: PickWorkspaceFolderOptions,
+): Promise<string | undefined> {
+    const uris = await vscode.window.showOpenDialog({
+        title: options.title,
+        canSelectMany: false,
+        canSelectFolders: true,
+        canSelectFiles: false,
+    });
+    const uri = uris?.[0];
+    return uri ? relativizePath(options.baseUri.fsPath, uri.fsPath) : undefined;
+}

--- a/cimnotebook/vscode/src/notebook/markdown.test.ts
+++ b/cimnotebook/vscode/src/notebook/markdown.test.ts
@@ -1,0 +1,223 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseMarkdownNotebook, serializeMarkdownNotebook } from "./markdown";
+
+/** Asserts that serialize(parse(text)) is a fixed point after one normalization pass. */
+function assertRoundTripStable(text: string): string {
+    const once = serializeMarkdownNotebook(parseMarkdownNotebook(text));
+    const twice = serializeMarkdownNotebook(parseMarkdownNotebook(once));
+    assert.equal(twice, once, "serialize(parse(x)) must be idempotent");
+    return once;
+}
+
+describe("parseMarkdownNotebook", () => {
+    it("turns sparql and shacl fences into code cells, keeps prose as markdown", () => {
+        const text = [
+            "# Title",
+            "",
+            "Some prose.",
+            "",
+            "```sparql",
+            "SELECT * WHERE { ?s ?p ?o }",
+            "```",
+            "",
+            "More prose.",
+            "",
+            "```shacl",
+            "ex:Shape a sh:NodeShape .",
+            "```",
+            "",
+        ].join("\n");
+
+        const { cells } = parseMarkdownNotebook(text);
+        assert.deepEqual(
+            cells.map((c) => [c.kind, c.language]),
+            [
+                ["markdown", undefined],
+                ["code", "sparql"],
+                ["markdown", undefined],
+                ["code", "shacl"],
+            ],
+        );
+        assert.equal(cells[0].value, "# Title\n\nSome prose.");
+        assert.equal(cells[1].value, "SELECT * WHERE { ?s ?p ?o }");
+        assert.equal(cells[3].value, "ex:Shape a sh:NodeShape .");
+    });
+
+    it("keeps other fence languages as markdown, verbatim", () => {
+        const text = "```turtle\nex:a ex:b ex:c .\n```\n";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+        assert.equal(cells[0].value, "```turtle\nex:a ex:b ex:c .\n```");
+    });
+
+    it("treats the info string case-insensitively", () => {
+        const { cells } = parseMarkdownNotebook("```SPARQL\nASK {}\n```\n");
+        assert.equal(cells[0].kind, "code");
+        assert.equal(cells[0].language, "sparql");
+    });
+
+    it("does not open code cells inside longer fences", () => {
+        const text = ["````markdown", "```sparql", "SELECT 1", "```", "````", ""].join("\n");
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+    });
+
+    it("does not open code cells inside tilde fences", () => {
+        const text = "~~~\n```sparql\nSELECT 1\n```\n~~~\n";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+    });
+
+    it("keeps indented sparql fences as markdown", () => {
+        const text = "  ```sparql\n  SELECT 1\n  ```\n";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+    });
+
+    it("keeps an unclosed sparql fence at EOF as markdown", () => {
+        const text = "prose\n\n```sparql\nSELECT * WHERE { ?s ?p ?o }";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.deepEqual(
+            cells.map((c) => c.kind),
+            ["markdown", "markdown"],
+        );
+        assert.equal(cells[1].value, "```sparql\nSELECT * WHERE { ?s ?p ?o }");
+        assertRoundTripStable(text);
+    });
+
+    it("supports empty code cells", () => {
+        const { cells } = parseMarkdownNotebook("```sparql\n```\n");
+        assert.deepEqual(cells, [{ kind: "code", language: "sparql", value: "" }]);
+    });
+
+    it("allows closing fences longer than three backticks", () => {
+        const { cells } = parseMarkdownNotebook("```sparql\nASK {}\n`````\nafter\n");
+        assert.equal(cells[0].kind, "code");
+        assert.equal(cells[0].value, "ASK {}");
+        assert.equal(cells[1].value, "after");
+    });
+
+    it("ignores fence-like inline code (backtick info strings)", () => {
+        const text = "``` ```code``` ```\n";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+    });
+
+    it("detects CRLF line endings", () => {
+        const { eol, cells } = parseMarkdownNotebook("# Hi\r\n\r\n```sparql\r\nASK {}\r\n```\r\n");
+        assert.equal(eol, "\r\n");
+        assert.equal(cells[1].value, "ASK {}");
+    });
+
+    it("returns no cells for empty input", () => {
+        assert.deepEqual(parseMarkdownNotebook("").cells, []);
+        assert.deepEqual(parseMarkdownNotebook("\n\n\n").cells, []);
+    });
+});
+
+describe("serializeMarkdownNotebook", () => {
+    it("separates cells with exactly one blank line and ends with a newline", () => {
+        const text = serializeMarkdownNotebook({
+            eol: "\n",
+            cells: [
+                { kind: "markdown", value: "# Title" },
+                { kind: "code", language: "sparql", value: "ASK {}" },
+            ],
+        });
+        assert.equal(text, "# Title\n\n```sparql\nASK {}\n```\n");
+    });
+
+    it("restores CRLF line endings", () => {
+        const text = serializeMarkdownNotebook({
+            eol: "\r\n",
+            cells: [{ kind: "code", language: "sparql", value: "ASK {}" }],
+        });
+        assert.equal(text, "```sparql\r\nASK {}\r\n```\r\n");
+    });
+
+    it("defaults code cells without a language to sparql", () => {
+        const text = serializeMarkdownNotebook({
+            eol: "\n",
+            cells: [{ kind: "code", value: "ASK {}" }],
+        });
+        assert.ok(text.startsWith("```sparql\n"));
+    });
+
+    it("drops empty markdown cells", () => {
+        const text = serializeMarkdownNotebook({
+            eol: "\n",
+            cells: [
+                { kind: "markdown", value: "   \n  " },
+                { kind: "code", language: "sparql", value: "ASK {}" },
+            ],
+        });
+        assert.equal(text, "```sparql\nASK {}\n```\n");
+    });
+});
+
+describe("round trip", () => {
+    it("is byte-stable for an already-normalized document", () => {
+        const text = [
+            "# CGMES exploration",
+            "",
+            "Query the model:",
+            "",
+            "```sparql",
+            "# [endpoint=http://localhost:3030/ds/query]",
+            "SELECT * WHERE { ?s ?p ?o } LIMIT 10",
+            "```",
+            "",
+            "```shacl",
+            "ex:Shape a sh:NodeShape ;",
+            "  sh:targetClass cim:Switch .",
+            "```",
+            "",
+        ].join("\n");
+        assert.equal(serializeMarkdownNotebook(parseMarkdownNotebook(text)), text);
+    });
+
+    it("is idempotent for messy input (extra blank lines, trailing spaces)", () => {
+        const messy = "# Title\n\n\n\nprose   \n\n\n```sparql\n\nASK {}\n\n```\n\n\n";
+        const normalized = assertRoundTripStable(messy);
+        const { cells } = parseMarkdownNotebook(normalized);
+        assert.deepEqual(
+            cells.map((c) => c.kind),
+            ["markdown", "code"],
+        );
+    });
+
+    it("is idempotent for CRLF documents and preserves CRLF", () => {
+        const crlf = "# Hi\r\n\r\n```sparql\r\nASK {}\r\n```\r\n";
+        assert.equal(serializeMarkdownNotebook(parseMarkdownNotebook(crlf)), crlf);
+    });
+
+    it("is idempotent for documents that are all markdown", () => {
+        const text = "# Only prose\n\nNothing to run here.\n";
+        assert.equal(serializeMarkdownNotebook(parseMarkdownNotebook(text)), text);
+    });
+});

--- a/cimnotebook/vscode/src/notebook/markdown.ts
+++ b/cimnotebook/vscode/src/notebook/markdown.ts
@@ -1,0 +1,145 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Markdown notebook format: a plain markdown document whose top-level ```sparql and
+ * ```shacl fenced code blocks are executable cells; everything else stays markdown.
+ *
+ * Design rules (git-friendliness first):
+ * - Only unindented, exactly-three-backtick fences with the info string `sparql` or
+ *   `shacl` become code cells. Longer/indented/`~~~` fences and other languages stay
+ *   markdown verbatim, but are still tracked so fence markers inside them never open
+ *   a code cell. When in doubt, content stays markdown.
+ * - Serialization is normalizing but idempotent: cells are separated by exactly one
+ *   blank line, trailing whitespace-only lines are dropped, and the file ends with a
+ *   single newline. `serialize(parse(x))` reaches a fixed point after one pass.
+ * - The source file's line ending (LF/CRLF) is detected on parse and restored on
+ *   serialization, so saving never rewrites every line of a CRLF file.
+ */
+
+import { CODE_CELL_LANGUAGES, RawCell, RawNotebook } from "./cells";
+
+/** Opening fence: 3+ backticks or tildes, up to 3 leading spaces (CommonMark). */
+const FENCE_OPEN = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+/** Closing fence for a code cell: 3+ backticks on their own line, no indentation. */
+const CODE_CELL_CLOSE = /^`{3,}\s*$/;
+
+export function parseMarkdownNotebook(text: string): RawNotebook {
+    const eol: RawNotebook["eol"] = text.includes("\r\n") ? "\r\n" : "\n";
+    const lines = text.split(/\r?\n/);
+
+    const cells: RawCell[] = [];
+    let markdown: string[] = [];
+    let code: string[] = [];
+
+    type State =
+        | { name: "outside" }
+        | { name: "codeCell"; language: string }
+        | { name: "otherFence"; marker: string; length: number };
+    let state: State = { name: "outside" };
+
+    const flushMarkdown = (): void => {
+        const value = trimBlankEdges(markdown).join("\n");
+        if (value.length > 0) {
+            cells.push({ kind: "markdown", value });
+        }
+        markdown = [];
+    };
+
+    for (const line of lines) {
+        if (state.name === "codeCell") {
+            if (CODE_CELL_CLOSE.test(line)) {
+                cells.push({ kind: "code", language: state.language, value: code.join("\n") });
+                code = [];
+                state = { name: "outside" };
+            } else {
+                code.push(line);
+            }
+            continue;
+        }
+
+        if (state.name === "otherFence") {
+            markdown.push(line);
+            // CommonMark closer: same marker char, at least as long, nothing else on the line.
+            const close = new RegExp(`^ {0,3}\\${state.marker}{${state.length},}\\s*$`);
+            if (close.test(line)) {
+                state = { name: "outside" };
+            }
+            continue;
+        }
+
+        const fence = FENCE_OPEN.exec(line);
+        if (fence) {
+            const [, indent, marker, rest] = fence;
+            const info = rest.trim().toLowerCase();
+            const isCodeCellFence =
+                indent.length === 0 &&
+                marker === "```" &&
+                (CODE_CELL_LANGUAGES as readonly string[]).includes(info);
+            if (isCodeCellFence) {
+                flushMarkdown();
+                state = { name: "codeCell", language: info };
+            } else if (marker[0] === "`" && rest.includes("`")) {
+                // Not a valid fence opener (info strings of backtick fences must not
+                // contain backticks, e.g. inline code like ```` ```code``` ````).
+                markdown.push(line);
+            } else {
+                markdown.push(line);
+                state = { name: "otherFence", marker: marker[0], length: marker.length };
+            }
+            continue;
+        }
+
+        markdown.push(line);
+    }
+
+    if (state.name === "codeCell") {
+        // Unclosed cell fence at EOF: keep the original text as markdown so a later
+        // save cannot silently invent a closing fence the author never wrote.
+        markdown = ["```" + state.language, ...code];
+    }
+    flushMarkdown();
+
+    return { cells, eol };
+}
+
+export function serializeMarkdownNotebook(notebook: RawNotebook): string {
+    const blocks = notebook.cells.map((cell) => {
+        if (cell.kind === "code") {
+            const language = cell.language ?? "sparql";
+            const body = trimBlankEdges(cell.value.split("\n")).join("\n");
+            return body.length > 0
+                ? "```" + language + "\n" + body + "\n```"
+                : "```" + language + "\n```";
+        }
+        return trimBlankEdges(cell.value.split("\n")).join("\n");
+    });
+
+    const text = blocks.filter((block) => block.length > 0).join("\n\n");
+    const result = text.length > 0 ? text + "\n" : "";
+    return notebook.eol === "\r\n" ? result.replace(/\n/g, "\r\n") : result;
+}
+
+/** Drops leading/trailing lines that are empty or whitespace-only. */
+function trimBlankEdges(lines: string[]): string[] {
+    let start = 0;
+    let end = lines.length;
+    while (start < end && lines[start].trim().length === 0) start++;
+    while (end > start && lines[end - 1].trim().length === 0) end--;
+    return lines.slice(start, end);
+}

--- a/cimnotebook/vscode/src/notebook/outputs.test.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.test.ts
@@ -1,0 +1,183 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    askResultToMarkdown,
+    DISPLAY_ROW_CAP,
+    errorSummary,
+    MIME_MARKDOWN,
+    outputItemsFor,
+    selectResultsToMarkdown,
+    turtleToMarkdown,
+    updateResultToMarkdown,
+} from "./outputs";
+
+function selectJson(bindings: Record<string, unknown>[], vars = ["s"]): string {
+    return JSON.stringify({ head: { vars }, results: { bindings } });
+}
+
+describe("selectResultsToMarkdown", () => {
+    it("renders a header and one row per binding", () => {
+        const md = selectResultsToMarkdown(
+            selectJson(
+                [
+                    { s: { type: "uri", value: "http://x/a" } },
+                    { s: { type: "literal", value: "plain" } },
+                ],
+                ["s"],
+            ),
+        );
+        assert.ok(md.startsWith("| s |\n| --- |\n| http://x/a |\n| plain |"));
+    });
+
+    it("renders lang and typed literals in Turtle-ish form, bnodes with _:", () => {
+        const md = selectResultsToMarkdown(
+            selectJson(
+                [
+                    {
+                        a: { type: "literal", value: "hi", "xml:lang": "en" },
+                        b: {
+                            type: "literal",
+                            value: "4",
+                            datatype: "http://www.w3.org/2001/XMLSchema#int",
+                        },
+                        c: { type: "bnode", value: "b0" },
+                    },
+                ],
+                ["a", "b", "c"],
+            ),
+        );
+        assert.ok(md.includes('"hi"@en'));
+        assert.ok(md.includes('"4"^^<http://www.w3.org/2001/XMLSchema#int>'));
+        assert.ok(md.includes("_:b0"));
+    });
+
+    it("leaves unbound variables empty and escapes pipes/newlines", () => {
+        const md = selectResultsToMarkdown(
+            selectJson([{ a: { type: "literal", value: "x|y\nz" } }], ["a", "b"]),
+        );
+        assert.ok(md.includes("| x\\|y<br>z |  |"));
+    });
+
+    it("caps the table at DISPLAY_ROW_CAP rows with a note", () => {
+        const rows = Array.from({ length: DISPLAY_ROW_CAP + 5 }, (_, i) => ({
+            s: { type: "literal", value: `row${i}` },
+        }));
+        const md = selectResultsToMarkdown(selectJson(rows));
+        assert.ok(md.includes(`first ${DISPLAY_ROW_CAP} of ${DISPLAY_ROW_CAP + 5} fetched rows`));
+        assert.ok(!md.includes(`row${DISPLAY_ROW_CAP}`));
+    });
+
+    it("shows an empty-result message and the stats footer", () => {
+        const md = selectResultsToMarkdown(selectJson([]), {
+            durationMs: 12,
+            rowCount: 0,
+            truncated: false,
+            resolvedTarget: "http://h/ds/query",
+        });
+        assert.ok(md.startsWith("*No results.*"));
+        assert.ok(md.includes("0 results · 12 ms · http://h/ds/query"));
+    });
+
+    it("marks server-side truncation in the footer", () => {
+        const md = selectResultsToMarkdown(selectJson([{ s: { type: "literal", value: "x" } }]), {
+            durationMs: 3,
+            rowCount: 10000,
+            truncated: true,
+            resolvedTarget: null,
+        });
+        assert.ok(md.includes("10000+ results (server cap reached)"));
+    });
+});
+
+describe("askResultToMarkdown", () => {
+    it("renders true and false verdicts", () => {
+        assert.ok(askResultToMarkdown('{"head":{},"boolean":true}').includes("**true**"));
+        assert.ok(askResultToMarkdown('{"head":{},"boolean":false}').includes("**false**"));
+    });
+});
+
+describe("turtleToMarkdown", () => {
+    it("fences the turtle payload", () => {
+        assert.equal(turtleToMarkdown("<a> <b> <c> .\n"), "```turtle\n<a> <b> <c> .\n```");
+    });
+
+    it("shows a message for an empty graph", () => {
+        assert.ok(turtleToMarkdown("   \n").startsWith("*Empty graph.*"));
+    });
+});
+
+describe("updateResultToMarkdown", () => {
+    it("confirms the update with stats", () => {
+        const md = updateResultToMarkdown({ durationMs: 8, truncated: false });
+        assert.ok(md.startsWith("✅ **Update executed.**"));
+        assert.ok(md.includes("8 ms"));
+    });
+});
+
+describe("error rendering", () => {
+    it("summarizes with code and parse position", () => {
+        assert.equal(
+            errorSummary({ code: "PARSE_ERROR", message: "bad token", line: 3, column: 7 }),
+            "PARSE_ERROR: bad token (line 3, column 7)",
+        );
+        assert.equal(errorSummary({ code: "HTTP_ERROR", message: "boom" }), "HTTP_ERROR: boom");
+    });
+});
+
+describe("outputItemsFor", () => {
+    // The items of one cell output are alternatives — VS Code renders the richest MIME type by
+    // its display order, which ranks application/json ABOVE text/markdown. An application/json
+    // item therefore hides the formatted result, whatever order the items are given in.
+    it("never offers application/json, which would outrank the markdown rendering", () => {
+        const responses = [
+            { status: "SUCCESS", queryKind: "SELECT", resultsJson: selectJson([]) },
+            { status: "SUCCESS", queryKind: "ASK", resultsJson: '{"boolean":true}' },
+            { status: "SUCCESS", queryKind: "CONSTRUCT", turtle: "<a> <b> <c> ." },
+            { status: "SUCCESS", queryKind: "UPDATE" },
+        ] as const;
+
+        for (const response of responses) {
+            const items = outputItemsFor(response);
+            assert.equal(items[0].mime, MIME_MARKDOWN, `${response.queryKind}: markdown first`);
+            assert.ok(
+                !items.some((i) => i.mime === "application/json"),
+                `${response.queryKind} must not offer application/json`,
+            );
+        }
+    });
+
+    it("carries the raw SELECT results alongside the table", () => {
+        const resultsJson = selectJson([{ s: { type: "uri", value: "http://x" } }]);
+        const items = outputItemsFor({ status: "SUCCESS", queryKind: "SELECT", resultsJson });
+
+        assert.deepEqual(
+            items.map((i) => i.mime),
+            [MIME_MARKDOWN, "application/sparql-results+json", "text/plain"],
+        );
+        assert.ok(items[0].text.includes("| http://x |"));
+        assert.equal(items[1].text, resultsJson);
+    });
+
+    it("has no items for an unknown result kind", () => {
+        assert.deepEqual(outputItemsFor({ status: "SUCCESS" }), []);
+    });
+});

--- a/cimnotebook/vscode/src/notebook/outputs.test.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.test.ts
@@ -67,7 +67,7 @@ describe("selectResultsToMarkdown", () => {
             ),
         );
         assert.ok(md.includes('"hi"@en'));
-        assert.ok(md.includes('"4"^^<http://www.w3.org/2001/XMLSchema#int>'));
+        assert.ok(md.includes('"4"^^&lt;http://www.w3.org/2001/XMLSchema#int&gt;'));
         assert.ok(md.includes("_:b0"));
     });
 
@@ -76,6 +76,14 @@ describe("selectResultsToMarkdown", () => {
             selectJson([{ a: { type: "literal", value: "x|y\nz" } }], ["a", "b"]),
         );
         assert.ok(md.includes("| x\\|y<br>z |  |"));
+    });
+
+    it("escapes HTML in cell values so result data is never parsed as markup", () => {
+        const md = selectResultsToMarkdown(
+            selectJson([{ a: { type: "literal", value: "use <b> & stay a<b" } }], ["a"]),
+        );
+        assert.ok(md.includes("| use &lt;b&gt; &amp; stay a&lt;b |"));
+        assert.ok(!md.includes("<b>"));
     });
 
     it("caps the table at DISPLAY_ROW_CAP rows with a note", () => {

--- a/cimnotebook/vscode/src/notebook/outputs.test.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.test.ts
@@ -26,6 +26,7 @@ import {
     MIME_MARKDOWN,
     outputItemsFor,
     selectResultsToMarkdown,
+    shaclReportToMarkdown,
     turtleToMarkdown,
     updateResultToMarkdown,
 } from "./outputs";
@@ -125,6 +126,37 @@ describe("turtleToMarkdown", () => {
     });
 });
 
+describe("shaclReportToMarkdown", () => {
+    const report = "[] a sh:ValidationReport ; sh:conforms true .";
+
+    it("renders a conforming verdict with the fenced report", () => {
+        const md = shaclReportToMarkdown(
+            report,
+            { conforms: true, violations: 0, warnings: 0, infos: 0 },
+            { durationMs: 12, truncated: false, resolvedTarget: "./model.xml" },
+        );
+        assert.ok(md.startsWith("✅ **Conforms**"));
+        assert.ok(md.includes("```turtle\n" + report + "\n```"));
+        assert.ok(md.includes("12 ms"));
+    });
+
+    it("counts violations and mentions warnings/infos only when present", () => {
+        const md = shaclReportToMarkdown("report", {
+            conforms: false,
+            violations: 2,
+            warnings: 1,
+            infos: 0,
+        });
+        assert.ok(md.startsWith("❌ **Does not conform** — 2 violations, 1 warning."));
+        assert.ok(!md.includes("info"));
+    });
+
+    it("copes with a missing summary and an empty report", () => {
+        const md = shaclReportToMarkdown("", null);
+        assert.equal(md, "**Validation finished.**");
+    });
+});
+
 describe("updateResultToMarkdown", () => {
     it("confirms the update with stats", () => {
         const md = updateResultToMarkdown({ durationMs: 8, truncated: false });
@@ -153,6 +185,12 @@ describe("outputItemsFor", () => {
             { status: "SUCCESS", queryKind: "ASK", resultsJson: '{"boolean":true}' },
             { status: "SUCCESS", queryKind: "CONSTRUCT", turtle: "<a> <b> <c> ." },
             { status: "SUCCESS", queryKind: "UPDATE" },
+            {
+                status: "SUCCESS",
+                queryKind: "SHACL",
+                turtle: "",
+                shaclSummary: { conforms: true, violations: 0, warnings: 0, infos: 0 },
+            },
         ] as const;
 
         for (const response of responses) {

--- a/cimnotebook/vscode/src/notebook/outputs.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.ts
@@ -26,7 +26,7 @@
  * *Change Presentation*.
  */
 
-import { ExecError, ExecStats, ExecuteResponse } from "./endpoint";
+import { ExecError, ExecStats, ExecuteResponse, ShaclSummary } from "./endpoint";
 
 /** Rows shown in the markdown table; the raw output item carries the full result. */
 export const DISPLAY_ROW_CAP = 50;
@@ -80,6 +80,16 @@ export function outputItemsFor(response: ExecuteResponse): OutputItem[] {
         }
         case "UPDATE":
             return [{ mime: MIME_MARKDOWN, text: updateResultToMarkdown(stats) }];
+        case "SHACL": {
+            const turtle = response.turtle ?? "";
+            return [
+                {
+                    mime: MIME_MARKDOWN,
+                    text: shaclReportToMarkdown(turtle, response.shaclSummary, stats),
+                },
+                { mime: MIME_TEXT, text: turtle },
+            ];
+        }
         default:
             return [];
     }
@@ -139,6 +149,38 @@ export function turtleToMarkdown(turtle: string, stats?: ExecStats | null): stri
 /** Confirmation line for a successful UPDATE. */
 export function updateResultToMarkdown(stats?: ExecStats | null): string {
     return "✅ **Update executed.**" + statsFooter(stats);
+}
+
+/** Verdict banner plus the fenced validation report for a SHACL run. */
+export function shaclReportToMarkdown(
+    turtle: string,
+    summary: ShaclSummary | null | undefined,
+    stats?: ExecStats | null,
+): string {
+    const banner =
+        summary == null
+            ? "**Validation finished.**"
+            : summary.conforms
+              ? "✅ **Conforms** — no validation results."
+              : `❌ **Does not conform** — ${shaclCounts(summary)}.`;
+    const report = turtle.trimEnd();
+    const fenced = report.length > 0 ? "\n\n```turtle\n" + report + "\n```" : "";
+    return banner + fenced + statsFooter(stats);
+}
+
+function shaclCounts(summary: ShaclSummary): string {
+    const parts = [plural(summary.violations, "violation")];
+    if (summary.warnings > 0) {
+        parts.push(plural(summary.warnings, "warning"));
+    }
+    if (summary.infos > 0) {
+        parts.push(plural(summary.infos, "info"));
+    }
+    return parts.join(", ");
+}
+
+function plural(n: number, noun: string): string {
+    return `${n} ${noun}${n === 1 ? "" : "s"}`;
 }
 
 /** One-line summary for `NotebookCellOutputItem.error`, with parse position if known. */

--- a/cimnotebook/vscode/src/notebook/outputs.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.ts
@@ -1,0 +1,201 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Renders `cimvocabcheck.notebook.execute` responses as the items of one notebook cell
+ * output. Pure string module: the vscode `NotebookCellOutputItem` wrapping happens in the
+ * executor, so these builders stay unit-testable with plain `node --test`.
+ *
+ * The markdown item is the primary rendering (v1 ships no custom notebook renderer); the
+ * raw payload travels alongside under its own MIME type for other renderers and for
+ * *Change Presentation*.
+ */
+
+import { ExecError, ExecStats, ExecuteResponse } from "./endpoint";
+
+/** Rows shown in the markdown table; the raw output item carries the full result. */
+export const DISPLAY_ROW_CAP = 50;
+
+export const MIME_MARKDOWN = "text/markdown";
+export const MIME_SPARQL_JSON = "application/sparql-results+json";
+export const MIME_TEXT = "text/plain";
+
+/** One representation of a cell result — the executor turns these into output items. */
+export interface OutputItem {
+    mime: string;
+    text: string;
+}
+
+/**
+ * The items representing a successful result, primary rendering first.
+ *
+ * The items of one output are *alternatives*: VS Code renders exactly one of them, the
+ * richest MIME type by its display order. That order (`NOTEBOOK_DISPLAY_ORDER`) ranks
+ * **`application/json` above `text/markdown`**, so an `application/json` item silently
+ * wins over — and hides — the formatted table, whatever order the items are given in.
+ * Hence the raw results ship as `application/sparql-results+json` (which no built-in
+ * renderer claims) plus `text/plain` (which ranks *below* markdown, so it stays available
+ * under *Change Presentation* without taking over). Never add `application/json` here.
+ */
+export function outputItemsFor(response: ExecuteResponse): OutputItem[] {
+    const stats = response.stats;
+    switch (response.queryKind) {
+        case "SELECT": {
+            const resultsJson = response.resultsJson ?? "{}";
+            return [
+                { mime: MIME_MARKDOWN, text: selectResultsToMarkdown(resultsJson, stats) },
+                { mime: MIME_SPARQL_JSON, text: resultsJson },
+                { mime: MIME_TEXT, text: resultsJson },
+            ];
+        }
+        case "ASK": {
+            const resultsJson = response.resultsJson ?? "{}";
+            return [
+                { mime: MIME_MARKDOWN, text: askResultToMarkdown(resultsJson, stats) },
+                { mime: MIME_SPARQL_JSON, text: resultsJson },
+            ];
+        }
+        case "CONSTRUCT":
+        case "DESCRIBE": {
+            const turtle = response.turtle ?? "";
+            return [
+                { mime: MIME_MARKDOWN, text: turtleToMarkdown(turtle, stats) },
+                { mime: MIME_TEXT, text: turtle },
+            ];
+        }
+        case "UPDATE":
+            return [{ mime: MIME_MARKDOWN, text: updateResultToMarkdown(stats) }];
+        default:
+            return [];
+    }
+}
+
+interface SparqlResultsJson {
+    head: { vars?: string[] };
+    results?: { bindings: Record<string, SparqlTerm>[] };
+    boolean?: boolean;
+}
+
+interface SparqlTerm {
+    type: string;
+    value: string;
+    "xml:lang"?: string;
+    datatype?: string;
+}
+
+/** Markdown table for a SELECT result (SPARQL 1.1 Query Results JSON). */
+export function selectResultsToMarkdown(resultsJson: string, stats?: ExecStats | null): string {
+    const parsed = JSON.parse(resultsJson) as SparqlResultsJson;
+    const vars = parsed.head.vars ?? [];
+    const bindings = parsed.results?.bindings ?? [];
+
+    if (bindings.length === 0) {
+        return "*No results.*" + statsFooter(stats);
+    }
+
+    const header = `| ${vars.map(escapeCell).join(" | ")} |`;
+    const divider = `| ${vars.map(() => "---").join(" | ")} |`;
+    const rows = bindings
+        .slice(0, DISPLAY_ROW_CAP)
+        .map((b) => `| ${vars.map((v) => escapeCell(termToText(b[v]))).join(" | ")} |`);
+
+    const capNote =
+        bindings.length > DISPLAY_ROW_CAP
+            ? `\n\n*Table shows the first ${DISPLAY_ROW_CAP} of ${bindings.length} fetched rows.*`
+            : "";
+    return [header, divider, ...rows].join("\n") + capNote + statsFooter(stats);
+}
+
+/** Markdown verdict for an ASK result. */
+export function askResultToMarkdown(resultsJson: string, stats?: ExecStats | null): string {
+    const parsed = JSON.parse(resultsJson) as SparqlResultsJson;
+    return (parsed.boolean === true ? "✅ **true**" : "❌ **false**") + statsFooter(stats);
+}
+
+/** Fenced turtle block for a CONSTRUCT/DESCRIBE result. */
+export function turtleToMarkdown(turtle: string, stats?: ExecStats | null): string {
+    const body = turtle.trimEnd();
+    if (body.length === 0) {
+        return "*Empty graph.*" + statsFooter(stats);
+    }
+    return "```turtle\n" + body + "\n```" + statsFooter(stats);
+}
+
+/** Confirmation line for a successful UPDATE. */
+export function updateResultToMarkdown(stats?: ExecStats | null): string {
+    return "✅ **Update executed.**" + statsFooter(stats);
+}
+
+/** One-line summary for `NotebookCellOutputItem.error`, with parse position if known. */
+export function errorSummary(error: ExecError): string {
+    const position =
+        error.line != null
+            ? ` (line ${error.line}${error.column != null ? `, column ${error.column}` : ""})`
+            : "";
+    return `${error.code}: ${error.message}${position}`;
+}
+
+function statsFooter(stats?: ExecStats | null): string {
+    if (!stats) {
+        return "";
+    }
+    const parts: string[] = [];
+    if (stats.rowCount != null) {
+        parts.push(
+            stats.truncated
+                ? `${stats.rowCount}+ results (server cap reached)`
+                : `${stats.rowCount} results`,
+        );
+    }
+    parts.push(`${stats.durationMs} ms`);
+    if (stats.resolvedTarget) {
+        parts.push(stats.resolvedTarget);
+    }
+    return `\n\n<small>${parts.map(escapeHtml).join(" · ")}</small>`;
+}
+
+/** Escapes a value for use inside a markdown table cell. */
+function escapeCell(value: string): string {
+    return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>");
+}
+
+function escapeHtml(value: string | number): string {
+    return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Compact display text for one SPARQL JSON term. */
+function termToText(term: SparqlTerm | undefined): string {
+    if (term === undefined) {
+        return "";
+    }
+    switch (term.type) {
+        case "uri":
+            return term.value;
+        case "bnode":
+            return `_:${term.value}`;
+        default: {
+            if (term["xml:lang"]) {
+                return `"${term.value}"@${term["xml:lang"]}`;
+            }
+            if (term.datatype) {
+                return `"${term.value}"^^<${term.datatype}>`;
+            }
+            return term.value;
+        }
+    }
+}

--- a/cimnotebook/vscode/src/notebook/outputs.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.ts
@@ -211,9 +211,13 @@ function statsFooter(stats?: ExecStats | null): string {
     return `\n\n<small>${parts.map(escapeHtml).join(" · ")}</small>`;
 }
 
-/** Escapes a value for use inside a markdown table cell. */
+/**
+ * Escapes a value for use inside a markdown table cell. HTML must be escaped too — the renderer
+ * accepts inline HTML (this module emits `<br>`/`<small>` itself), so an unescaped `<` in a
+ * result value would be parsed as markup instead of shown.
+ */
 function escapeCell(value: string): string {
-    return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>");
+    return escapeHtml(value).replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>");
 }
 
 function escapeHtml(value: string | number): string {

--- a/cimnotebook/vscode/src/notebook/relativizePath.test.ts
+++ b/cimnotebook/vscode/src/notebook/relativizePath.test.ts
@@ -1,0 +1,60 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as path from "path";
+
+import { relativizePath } from "./relativizePath";
+
+describe("relativizePath", () => {
+    it("relativizes a descendant path with a ./ prefix", () => {
+        const from = path.join("/ws", "notebooks");
+        const to = path.join("/ws", "notebooks", "data", "model.xml");
+        assert.equal(relativizePath(from, to), "./data/model.xml");
+    });
+
+    it("keeps the ../ form for paths outside the base directory", () => {
+        const from = path.join("/ws", "notebooks");
+        const to = path.join("/ws", "data", "model.xml");
+        assert.equal(relativizePath(from, to), "../data/model.xml");
+    });
+
+    it("returns ./name for a direct sibling file", () => {
+        const from = path.join("/ws", "notebooks");
+        const to = path.join("/ws", "notebooks", "model.xml");
+        assert.equal(relativizePath(from, to), "./model.xml");
+    });
+
+    it("returns . for the base directory itself, not an empty string", () => {
+        const dir = path.join("/ws", "notebooks");
+        assert.equal(relativizePath(dir, dir), ".");
+    });
+
+    it("keeps a Windows cross-drive path absolute instead of prefixing ./", () => {
+        assert.equal(
+            relativizePath("C:\\ws\\notebooks", "D:\\data\\model.xml", path.win32),
+            "D:/data/model.xml",
+        );
+        // Same drive still relativizes normally.
+        assert.equal(
+            relativizePath("C:\\ws\\notebooks", "C:\\ws\\notebooks\\model.xml", path.win32),
+            "./model.xml",
+        );
+    });
+});

--- a/cimnotebook/vscode/src/notebook/relativizePath.ts
+++ b/cimnotebook/vscode/src/notebook/relativizePath.ts
@@ -1,0 +1,44 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Turns an absolute filesystem path into the relative, forward-slash, `./`-prefixed form
+ * used for `# [endpoint=...]` directives and `opencgmes.jsonc` path fields — both are
+ * resolved relative to a base directory (the notebook's folder or the config file's
+ * folder) and always use `/` even on Windows. Pure (only node's `path`), so it is used
+ * both by the vscode-facing file pickers and directly in node tests.
+ */
+
+import * as path from "path";
+
+/** The subset of node's `path` used here — injectable so tests can exercise win32 rules. */
+export type PathImpl = Pick<typeof path, "relative" | "isAbsolute" | "sep">;
+
+export function relativizePath(fromDir: string, toPath: string, impl: PathImpl = path): string {
+    const relative = impl.relative(fromDir, toPath);
+    if (impl.isAbsolute(relative)) {
+        // No relative form exists (Windows: base and target on different drives) —
+        // keep the absolute path rather than fabricating a broken "./C:/..." one.
+        return relative.split(impl.sep).join("/");
+    }
+    const slashed = relative.split(impl.sep).join("/");
+    if (slashed === "") {
+        return ".";
+    }
+    return slashed.startsWith(".") ? slashed : `./${slashed}`;
+}

--- a/cimnotebook/vscode/src/notebook/serializers.ts
+++ b/cimnotebook/vscode/src/notebook/serializers.ts
@@ -17,11 +17,12 @@
  */
 
 /**
- * VS Code adapters around the pure notebook format modules. The contributed
+ * VS Code adapters around the pure notebook format modules. The three contributed
  * notebook types (see package.json `contributes.notebooks`) share these serializers:
  *
  * - `cimnotebook`            — `*.cimnb.md`, opens as a notebook by default
  * - `cimnotebook-markdown`   — any `*.md`/`*.markdown` via "Open With…"
+ * - `cimnotebook-sparqlbook` — `*.sparqlbook` (Zazuko interop) via "Open With…"
  *
  * Outputs are always transient: notebook files on disk stay pure source.
  */
@@ -31,24 +32,47 @@ import { TextDecoder, TextEncoder } from "util";
 
 import { RawCell, RawNotebook } from "./cells";
 import { parseMarkdownNotebook, serializeMarkdownNotebook } from "./markdown";
+import { parseSparqlBook, serializeSparqlBook } from "./sparqlbook";
 
 export const NOTEBOOK_TYPE_DEFAULT = "cimnotebook";
 export const NOTEBOOK_TYPE_MARKDOWN = "cimnotebook-markdown";
+export const NOTEBOOK_TYPE_SPARQLBOOK = "cimnotebook-sparqlbook";
 
 /** All notebook types owned by this extension. */
-export const NOTEBOOK_TYPES = [NOTEBOOK_TYPE_DEFAULT, NOTEBOOK_TYPE_MARKDOWN] as const;
+export const NOTEBOOK_TYPES = [
+    NOTEBOOK_TYPE_DEFAULT,
+    NOTEBOOK_TYPE_MARKDOWN,
+    NOTEBOOK_TYPE_SPARQLBOOK,
+] as const;
 
 /** Notebook-level metadata key carrying the source file's line ending. */
 const METADATA_EOL = "cimnotebookEol";
 
 export function registerNotebookSerializers(context: vscode.ExtensionContext): void {
     const markdown = new FormatSerializer(parseMarkdownNotebook, serializeMarkdownNotebook);
+    const sparqlbook = new FormatSerializer(parseSparqlBook, serializeSparqlBook);
     const options: vscode.NotebookDocumentContentOptions = { transientOutputs: true };
 
     context.subscriptions.push(
         vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_DEFAULT, markdown, options),
         vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_MARKDOWN, markdown, options),
+        vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_SPARQLBOOK, sparqlbook, options),
     );
+}
+
+/** Snapshot of an open notebook document as raw cells, for the convert command. */
+export function notebookDocumentToRaw(notebook: vscode.NotebookDocument): RawNotebook {
+    return {
+        cells: notebook.getCells().map((cell) => {
+            const data = new vscode.NotebookCellData(
+                cell.kind,
+                cell.document.getText(),
+                cell.document.languageId,
+            );
+            return cellDataToRaw(data, cell.metadata as Record<string, unknown>);
+        }),
+        eol: readEol(notebook.metadata),
+    };
 }
 
 class FormatSerializer implements vscode.NotebookSerializer {

--- a/cimnotebook/vscode/src/notebook/serializers.ts
+++ b/cimnotebook/vscode/src/notebook/serializers.ts
@@ -1,0 +1,103 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * VS Code adapters around the pure notebook format modules. The contributed
+ * notebook types (see package.json `contributes.notebooks`) share these serializers:
+ *
+ * - `cimnotebook`            — `*.cimnb.md`, opens as a notebook by default
+ * - `cimnotebook-markdown`   — any `*.md`/`*.markdown` via "Open With…"
+ *
+ * Outputs are always transient: notebook files on disk stay pure source.
+ */
+
+import * as vscode from "vscode";
+import { TextDecoder, TextEncoder } from "util";
+
+import { RawCell, RawNotebook } from "./cells";
+import { parseMarkdownNotebook, serializeMarkdownNotebook } from "./markdown";
+
+export const NOTEBOOK_TYPE_DEFAULT = "cimnotebook";
+export const NOTEBOOK_TYPE_MARKDOWN = "cimnotebook-markdown";
+
+/** All notebook types owned by this extension. */
+export const NOTEBOOK_TYPES = [NOTEBOOK_TYPE_DEFAULT, NOTEBOOK_TYPE_MARKDOWN] as const;
+
+/** Notebook-level metadata key carrying the source file's line ending. */
+const METADATA_EOL = "cimnotebookEol";
+
+export function registerNotebookSerializers(context: vscode.ExtensionContext): void {
+    const markdown = new FormatSerializer(parseMarkdownNotebook, serializeMarkdownNotebook);
+    const options: vscode.NotebookDocumentContentOptions = { transientOutputs: true };
+
+    context.subscriptions.push(
+        vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_DEFAULT, markdown, options),
+        vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_MARKDOWN, markdown, options),
+    );
+}
+
+class FormatSerializer implements vscode.NotebookSerializer {
+    constructor(
+        private readonly parse: (text: string) => RawNotebook,
+        private readonly serialize: (notebook: RawNotebook) => string,
+    ) {}
+
+    deserializeNotebook(content: Uint8Array): vscode.NotebookData {
+        const raw = this.parse(new TextDecoder().decode(content));
+        const data = new vscode.NotebookData(raw.cells.map(rawToCellData));
+        data.metadata = { [METADATA_EOL]: raw.eol };
+        return data;
+    }
+
+    serializeNotebook(data: vscode.NotebookData): Uint8Array {
+        const raw: RawNotebook = {
+            cells: data.cells.map((cell) => cellDataToRaw(cell, cell.metadata)),
+            eol: readEol(data.metadata),
+        };
+        return new TextEncoder().encode(this.serialize(raw));
+    }
+}
+
+function rawToCellData(cell: RawCell): vscode.NotebookCellData {
+    const data = new vscode.NotebookCellData(
+        cell.kind === "markdown" ? vscode.NotebookCellKind.Markup : vscode.NotebookCellKind.Code,
+        cell.value,
+        cell.kind === "markdown" ? "markdown" : (cell.language ?? "sparql"),
+    );
+    if (cell.metadata !== undefined) {
+        data.metadata = cell.metadata;
+    }
+    return data;
+}
+
+function cellDataToRaw(
+    cell: vscode.NotebookCellData,
+    metadata: Record<string, unknown> | undefined,
+): RawCell {
+    const isMarkdown = cell.kind === vscode.NotebookCellKind.Markup;
+    return {
+        kind: isMarkdown ? "markdown" : "code",
+        ...(isMarkdown ? {} : { language: cell.languageId }),
+        value: cell.value,
+        ...(metadata !== undefined && Object.keys(metadata).length > 0 ? { metadata } : {}),
+    };
+}
+
+function readEol(metadata: { [key: string]: unknown } | undefined): RawNotebook["eol"] {
+    return metadata?.[METADATA_EOL] === "\r\n" ? "\r\n" : "\n";
+}

--- a/cimnotebook/vscode/src/notebook/sparqlbook.test.ts
+++ b/cimnotebook/vscode/src/notebook/sparqlbook.test.ts
@@ -1,0 +1,91 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseSparqlBook, serializeSparqlBook } from "./sparqlbook";
+
+describe("parseSparqlBook", () => {
+    it("maps kind ordinals to markdown/code cells", () => {
+        const text = JSON.stringify([
+            { kind: 1, language: "markdown", value: "# Title" },
+            { kind: 2, language: "sparql", value: "ASK {}" },
+        ]);
+        const { cells } = parseSparqlBook(text);
+        assert.deepEqual(cells, [
+            { kind: "markdown", value: "# Title", metadata: undefined },
+            { kind: "code", language: "sparql", value: "ASK {}", metadata: undefined },
+        ]);
+    });
+
+    it("passes per-cell metadata through (Zazuko external-file cells)", () => {
+        const text = JSON.stringify([
+            { kind: 2, language: "sparql", value: "SELECT 1", metadata: { file: "./q.sparql" } },
+        ]);
+        const { cells } = parseSparqlBook(text);
+        assert.deepEqual(cells[0].metadata, { file: "./q.sparql" });
+    });
+
+    it("accepts an empty file as an empty notebook", () => {
+        assert.deepEqual(parseSparqlBook("").cells, []);
+        assert.deepEqual(parseSparqlBook("[]").cells, []);
+    });
+
+    it("rejects non-array JSON with a clear message", () => {
+        assert.throws(() => parseSparqlBook("{}"), /expected a JSON array/);
+        assert.throws(() => parseSparqlBook("not json"), /JSON parse failed/);
+    });
+
+    it("defaults missing language on code cells to sparql", () => {
+        const { cells } = parseSparqlBook(JSON.stringify([{ kind: 2, value: "ASK {}" }]));
+        assert.equal(cells[0].language, "sparql");
+    });
+});
+
+describe("serializeSparqlBook", () => {
+    it("writes the Zazuko JSON layout, pretty-printed", () => {
+        const text = serializeSparqlBook({
+            eol: "\n",
+            cells: [
+                { kind: "markdown", value: "# Title" },
+                { kind: "code", language: "shacl", value: "ex:S a sh:NodeShape ." },
+            ],
+        });
+        const parsed = JSON.parse(text);
+        assert.deepEqual(parsed, [
+            { kind: 1, language: "markdown", value: "# Title" },
+            { kind: 2, language: "shacl", value: "ex:S a sh:NodeShape ." },
+        ]);
+        assert.ok(text.includes("\n  "), "must be pretty-printed for reviewable diffs");
+        assert.ok(text.endsWith("\n"));
+    });
+
+    it("round-trips cells and metadata", () => {
+        const original = JSON.stringify(
+            [
+                { kind: 1, language: "markdown", value: "intro" },
+                { kind: 2, language: "sparql", value: "SELECT 1", metadata: { file: "a.rq" } },
+            ],
+            null,
+            2,
+        );
+        const roundTripped = serializeSparqlBook(parseSparqlBook(original));
+        assert.deepEqual(JSON.parse(roundTripped), JSON.parse(original));
+    });
+});

--- a/cimnotebook/vscode/src/notebook/sparqlbook.ts
+++ b/cimnotebook/vscode/src/notebook/sparqlbook.ts
@@ -1,0 +1,81 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `.sparqlbook` interop format: the JSON layout used by the Zazuko "SPARQL Notebook"
+ * extension — a pretty-printed array of `{ kind, language, value, metadata }` where
+ * `kind` is the VS Code NotebookCellKind ordinal (1 = markup, 2 = code). Per-cell
+ * metadata is passed through untouched so foreign notebooks survive a round trip.
+ */
+
+import { RawCell, RawNotebook } from "./cells";
+
+/** NotebookCellKind ordinals used on disk (mirror vscode.NotebookCellKind). */
+const KIND_MARKUP = 1;
+const KIND_CODE = 2;
+
+interface SparqlBookCell {
+    kind: number;
+    language: string;
+    value: string;
+    metadata?: Record<string, unknown>;
+}
+
+export function parseSparqlBook(text: string): RawNotebook {
+    let raw: unknown;
+    try {
+        raw = JSON.parse(text.length > 0 ? text : "[]");
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Not a valid .sparqlbook file (JSON parse failed: ${msg})`, {
+            cause: err,
+        });
+    }
+    if (!Array.isArray(raw)) {
+        throw new Error("Not a valid .sparqlbook file (expected a JSON array of cells)");
+    }
+
+    const cells: RawCell[] = raw.map((entry, index) => {
+        if (typeof entry !== "object" || entry === null) {
+            throw new Error(`Not a valid .sparqlbook file (cell ${index} is not an object)`);
+        }
+        const cell = entry as Partial<SparqlBookCell>;
+        const value = typeof cell.value === "string" ? cell.value : "";
+        if (cell.kind === KIND_MARKUP) {
+            return { kind: "markdown", value, metadata: cell.metadata };
+        }
+        return {
+            kind: "code",
+            language: typeof cell.language === "string" ? cell.language : "sparql",
+            value,
+            metadata: cell.metadata,
+        };
+    });
+
+    return { cells, eol: "\n" };
+}
+
+export function serializeSparqlBook(notebook: RawNotebook): string {
+    const cells: SparqlBookCell[] = notebook.cells.map((cell) => ({
+        kind: cell.kind === "markdown" ? KIND_MARKUP : KIND_CODE,
+        language: cell.kind === "markdown" ? "markdown" : (cell.language ?? "sparql"),
+        value: cell.value,
+        ...(cell.metadata !== undefined ? { metadata: cell.metadata } : {}),
+    }));
+    return JSON.stringify(cells, null, 2) + "\n";
+}

--- a/cimnotebook/vscode/src/notebook/statusBar.ts
+++ b/cimnotebook/vscode/src/notebook/statusBar.ts
@@ -1,0 +1,68 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Per-cell status bar item showing where the cell will run — connection, URL, files, or
+ * a warning when nothing is configured. Clicking it opens the *Set Cell Endpoint*
+ * command for that cell.
+ */
+
+import * as vscode from "vscode";
+
+import { ConnectionStore } from "./connections";
+import { statusBarText } from "./endpoint";
+import { NOTEBOOK_TYPES } from "./serializers";
+import { SET_ENDPOINT_COMMAND } from "./endpointCommands";
+
+export function registerCellStatusBar(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+): void {
+    const changeEmitter = new vscode.EventEmitter<void>();
+    context.subscriptions.push(changeEmitter);
+    // Re-resolve labels when the config or a notebook default changes; cell edits
+    // already re-trigger the provider through VS Code itself.
+    context.subscriptions.push(store.onDidChange(() => changeEmitter.fire()));
+
+    const provider: vscode.NotebookCellStatusBarItemProvider = {
+        onDidChangeCellStatusBarItems: changeEmitter.event,
+        async provideCellStatusBarItems(cell) {
+            if (cell.kind !== vscode.NotebookCellKind.Code) {
+                return [];
+            }
+            const resolution = await store.resolveCell(cell);
+            const item = new vscode.NotebookCellStatusBarItem(
+                statusBarText(resolution),
+                vscode.NotebookCellStatusBarAlignment.Right,
+            );
+            item.tooltip = "Set the endpoint this cell runs against";
+            item.command = {
+                title: "Set Cell Endpoint",
+                command: SET_ENDPOINT_COMMAND,
+                arguments: [cell],
+            };
+            return [item];
+        },
+    };
+
+    for (const notebookType of NOTEBOOK_TYPES) {
+        context.subscriptions.push(
+            vscode.notebooks.registerNotebookCellStatusBarItemProvider(notebookType, provider),
+        );
+    }
+}

--- a/cimnotebook/vscode/src/sidebar/configEditor.ts
+++ b/cimnotebook/vscode/src/sidebar/configEditor.ts
@@ -48,7 +48,11 @@ export async function targetConfig(): Promise<ConfigTarget> {
     const folder = active
         ? vscode.workspace.getWorkspaceFolder(active)
         : vscode.workspace.workspaceFolders?.[0];
-    if (active && folder) {
+    if (active && active.scheme === "file") {
+        // Mirror the server's nearest-config discovery (ConfigLoader.discoverFile): walk from the
+        // document's directory all the way to the filesystem root, not just to the workspace
+        // folder — otherwise the sidebar would edit (or offer to create) a different file than
+        // the one validation and execution actually use.
         let dir = vscode.Uri.joinPath(active, "..");
         for (let i = 0; i < 64; i++) {
             for (const name of ["opencgmes.jsonc", "opencgmes.json"]) {
@@ -57,10 +61,11 @@ export async function targetConfig(): Promise<ConfigTarget> {
                     return { uri: candidate, exists: true };
                 }
             }
-            if (dir.path === folder.uri.path || dir.path === "/") {
+            const parent = vscode.Uri.joinPath(dir, "..");
+            if (parent.path === dir.path) {
                 break;
             }
-            dir = vscode.Uri.joinPath(dir, "..");
+            dir = parent;
         }
     }
     const root = folder ?? vscode.workspace.workspaceFolders?.[0];

--- a/cimnotebook/vscode/src/sidebar/configEditor.ts
+++ b/cimnotebook/vscode/src/sidebar/configEditor.ts
@@ -1,0 +1,174 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Owns the configuration tree views' one write mechanism: which `opencgmes.jsonc` file
+ * they edit, and how. `read()`/`update()` are the only way the tree views (or their
+ * commands) touch the file — always through {@link parseConfigModel}/
+ * {@link applyConfigModel}'s comment-preserving property-path edits, exactly like the
+ * former webview sidebar did, so hand-editing and the tree views coexist.
+ *
+ * The edited file is the *nearest* `opencgmes.{jsonc,json}` walking up from the active
+ * document (within its workspace folder), falling back to the first workspace folder's
+ * root — matching validation's own nearest-config discovery.
+ */
+
+import * as vscode from "vscode";
+
+import { applyConfigModel, ConfigModel, parseConfigModel } from "./configModel";
+
+export interface ConfigTarget {
+    uri: vscode.Uri;
+    exists: boolean;
+}
+
+export interface ConfigState extends ConfigTarget {
+    model: ConfigModel;
+}
+
+export async function targetConfig(): Promise<ConfigTarget> {
+    const active =
+        vscode.window.activeNotebookEditor?.notebook.uri ??
+        vscode.window.activeTextEditor?.document.uri;
+    const folder = active
+        ? vscode.workspace.getWorkspaceFolder(active)
+        : vscode.workspace.workspaceFolders?.[0];
+    if (active && folder) {
+        let dir = vscode.Uri.joinPath(active, "..");
+        for (let i = 0; i < 64; i++) {
+            for (const name of ["opencgmes.jsonc", "opencgmes.json"]) {
+                const candidate = vscode.Uri.joinPath(dir, name);
+                if (await exists(candidate)) {
+                    return { uri: candidate, exists: true };
+                }
+            }
+            if (dir.path === folder.uri.path || dir.path === "/") {
+                break;
+            }
+            dir = vscode.Uri.joinPath(dir, "..");
+        }
+    }
+    const root = folder ?? vscode.workspace.workspaceFolders?.[0];
+    if (root) {
+        const jsonc = vscode.Uri.joinPath(root.uri, "opencgmes.jsonc");
+        if (await exists(jsonc)) {
+            return { uri: jsonc, exists: true };
+        }
+        const json = vscode.Uri.joinPath(root.uri, "opencgmes.json");
+        if (await exists(json)) {
+            return { uri: json, exists: true };
+        }
+        return { uri: jsonc, exists: false };
+    }
+    return { uri: vscode.Uri.file("opencgmes.jsonc"), exists: false };
+}
+
+/** The current target config's location and parsed model. */
+export async function readConfig(): Promise<ConfigState> {
+    const target = await targetConfig();
+    const text = target.exists ? await readText(target.uri) : "";
+    return { ...target, model: parseConfigModel(text) };
+}
+
+/**
+ * Applies `mutate` to `target`'s model and writes the result back — a property-path
+ * edit, so comments and formatting elsewhere in the file are preserved. `target` is the
+ * {@link readConfig} result the calling wizard was built from: pinning the file here
+ * keeps a mid-wizard focus change from silently redirecting the write to a different
+ * config. The text itself is re-read (and existence re-checked) at write time, so
+ * concurrent hand-edits are never clobbered by a stale in-memory copy. Returns `false`
+ * (after showing an error message) if the write failed; the tree views treat that as
+ * "nothing changed" and skip the refresh.
+ *
+ * An existing config is edited through a {@link vscode.WorkspaceEdit} and then saved,
+ * not written straight to disk: when the file is open in an editor with unsaved changes,
+ * that buffer — not the file on disk — is its current content, and a raw `fs.writeFile`
+ * would both build on stale text and be silently reverted by the user's next save. The
+ * edit also lands on the editor's undo stack, so the change can be undone like any other.
+ */
+export async function updateConfig(
+    target: ConfigTarget,
+    mutate: (model: ConfigModel) => void,
+): Promise<boolean> {
+    try {
+        if (!(await exists(target.uri))) {
+            const model = parseConfigModel("");
+            mutate(model);
+            const created = applyConfigModel("", model);
+            await vscode.workspace.fs.writeFile(target.uri, Buffer.from(created, "utf8"));
+            return true;
+        }
+
+        const document = await vscode.workspace.openTextDocument(target.uri);
+        const text = document.getText();
+        const model = parseConfigModel(text);
+        mutate(model);
+        const newText = applyConfigModel(text, model);
+        if (newText === text) {
+            return true;
+        }
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(
+            target.uri,
+            new vscode.Range(document.positionAt(0), document.positionAt(text.length)),
+            newText,
+        );
+        if (!(await vscode.workspace.applyEdit(edit))) {
+            throw new Error("the workspace edit was rejected");
+        }
+        await document.save();
+        return true;
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`CIMNotebook: saving the config failed: ${msg}`);
+        return false;
+    }
+}
+
+/** Opens the target config, offering to create it first when it doesn't exist yet. */
+export async function openConfig(): Promise<void> {
+    const target = await targetConfig();
+    if (target.exists) {
+        await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(target.uri));
+    } else {
+        await vscode.commands.executeCommand("cimnotebook.createConfig");
+    }
+}
+
+async function exists(uri: vscode.Uri): Promise<boolean> {
+    try {
+        await vscode.workspace.fs.stat(uri);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * The config's current text: an already-open editor's buffer when there is one (it may hold
+ * unsaved edits, and those are what the tree views should reflect), else the file on disk. Only
+ * *already-open* documents are consulted — this runs on every tree refresh, and opening the
+ * document here just to read it would be wasteful.
+ */
+async function readText(uri: vscode.Uri): Promise<string> {
+    const open = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
+    if (open) {
+        return open.getText();
+    }
+    return Buffer.from(await vscode.workspace.fs.readFile(uri)).toString("utf8");
+}

--- a/cimnotebook/vscode/src/sidebar/configModel.test.ts
+++ b/cimnotebook/vscode/src/sidebar/configModel.test.ts
@@ -52,6 +52,7 @@ describe("parseConfigModel", () => {
                 shaclUrl: undefined,
                 authType: undefined,
                 default: true,
+                rawIndex: 0,
             },
         ]);
     });
@@ -116,8 +117,74 @@ describe("applyConfigModel", () => {
                 shaclUrl: undefined,
                 authType: "basic",
                 default: undefined,
+                rawIndex: 0,
             },
         ]);
+    });
+
+    // A config the sidebar's form model cannot fully represent: comments between and inside
+    // entries, a field the form does not know, and a work-in-progress entry without a url.
+    const HANDWRITTEN = `{
+  "cimnotebook": {
+    "connections": [
+      // production — ask ops for credentials
+      {
+        "name": "prod",
+        "url": "https://example.org/query",
+        "description": "the shared instance"
+      },
+      { "name": "wip" },
+      { "name": "local", "url": "http://localhost:3030/ds/query" }
+    ]
+  }
+}
+`;
+
+    it("edits one connection in place, keeping comments, unknown fields, and skipped entries", () => {
+        const model = parseConfigModel(HANDWRITTEN);
+        const local = model.connections?.find((c) => c.name === "local");
+        assert.ok(local);
+        local.default = true;
+
+        const result = applyConfigModel(HANDWRITTEN, model);
+
+        assert.ok(result.includes("production — ask ops for credentials"), "comment kept");
+        assert.ok(result.includes('"description": "the shared instance"'), "unknown field kept");
+        assert.ok(result.includes('{ "name": "wip" }'), "incomplete entry kept verbatim");
+        const parsedBack = parseConfigModel(result);
+        assert.equal(parsedBack.connections?.find((c) => c.name === "local")?.default, true);
+        assert.equal(parsedBack.connections?.find((c) => c.name === "prod")?.default, undefined);
+    });
+
+    it("removes exactly the targeted entry by its raw-array position", () => {
+        const model = parseConfigModel(HANDWRITTEN);
+        model.connections = model.connections?.filter((c) => c.name !== "prod");
+
+        const result = applyConfigModel(HANDWRITTEN, model);
+
+        assert.ok(!result.includes('"prod"'));
+        // The neighbor may get reformatted by the removal edit, but it must survive.
+        assert.ok(result.includes('"wip"'), "skipped entry survives the removal");
+        assert.ok(result.includes('"local"'));
+    });
+
+    it("appends a new connection without rewriting existing entries", () => {
+        const model = parseConfigModel(HANDWRITTEN);
+        model.connections = [
+            ...(model.connections ?? []),
+            { name: "new", url: "http://h/q", default: true },
+        ];
+
+        const result = applyConfigModel(HANDWRITTEN, model);
+
+        assert.ok(result.includes("production — ask ops for credentials"), "comment kept");
+        assert.ok(result.includes('{ "name": "wip" }'), "skipped entry kept");
+        const parsedBack = parseConfigModel(result);
+        assert.deepEqual(
+            parsedBack.connections?.map((c) => c.name),
+            ["prod", "local", "new"],
+        );
+        assert.equal(parsedBack.connections?.find((c) => c.name === "new")?.default, true);
     });
 
     it("builds a full config from empty text", () => {

--- a/cimnotebook/vscode/src/sidebar/configModel.test.ts
+++ b/cimnotebook/vscode/src/sidebar/configModel.test.ts
@@ -1,0 +1,138 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyConfigModel, ConfigModel, parseConfigModel } from "./configModel";
+
+const CONFIG = `{
+  // keep me: file header comment
+  "cimvocabcheck": {
+    // keep me: strictness comment
+    "strictness": "default",
+    "schemas": ["a.rdf", "b.rdf"]
+  },
+  "cimnotebook": {
+    "queryTimeoutSeconds": 30,
+    "connections": [
+      { "name": "local", "url": "http://localhost:3030/ds/query", "default": true }
+    ]
+  }
+}
+`;
+
+describe("parseConfigModel", () => {
+    it("reads both sections leniently", () => {
+        const model = parseConfigModel(CONFIG);
+        assert.equal(model.strictness, "default");
+        assert.deepEqual(model.schemas, ["a.rdf", "b.rdf"]);
+        assert.equal(model.queryTimeoutSeconds, 30);
+        assert.equal(model.maxRows, undefined);
+        assert.deepEqual(model.connections, [
+            {
+                name: "local",
+                url: "http://localhost:3030/ds/query",
+                updateUrl: undefined,
+                shaclUrl: undefined,
+                authType: undefined,
+                default: true,
+            },
+        ]);
+    });
+
+    it("tolerates comments, trailing commas, and garbage", () => {
+        assert.deepEqual(parseConfigModel('{ /* c */ "cimvocabcheck": { }, }').schemas, undefined);
+        assert.equal(parseConfigModel("not json").strictness, undefined);
+        assert.equal(parseConfigModel("").strictness, undefined);
+    });
+});
+
+describe("applyConfigModel", () => {
+    it("changes only the edited value and keeps comments elsewhere", () => {
+        const model = parseConfigModel(CONFIG);
+        model.strictness = "strict";
+
+        const result = applyConfigModel(CONFIG, model);
+
+        assert.ok(result.includes('"strictness": "strict"'));
+        assert.ok(result.includes("keep me: file header comment"));
+        assert.ok(result.includes("keep me: strictness comment"));
+        assert.ok(
+            result.includes('"schemas": ["a.rdf", "b.rdf"]'),
+            "untouched array kept verbatim",
+        );
+        assert.deepEqual(parseConfigModel(result).connections, model.connections);
+    });
+
+    it("is a no-op for an unchanged model", () => {
+        assert.equal(applyConfigModel(CONFIG, parseConfigModel(CONFIG)), CONFIG);
+    });
+
+    it("removes a property when the form clears it", () => {
+        const model = parseConfigModel(CONFIG);
+        model.strictness = "";
+
+        const result = applyConfigModel(CONFIG, model);
+
+        assert.ok(!result.includes('"strictness"'));
+        assert.ok(result.includes("keep me: file header comment"));
+    });
+
+    it("replaces the connections array and drops empty optional fields", () => {
+        const model = parseConfigModel(CONFIG);
+        model.connections = [
+            {
+                name: "prod",
+                url: "https://example.org/query",
+                updateUrl: "  ",
+                authType: "basic",
+                default: false,
+            },
+        ];
+
+        const parsedBack = parseConfigModel(applyConfigModel(CONFIG, model));
+
+        assert.deepEqual(parsedBack.connections, [
+            {
+                name: "prod",
+                url: "https://example.org/query",
+                updateUrl: undefined,
+                shaclUrl: undefined,
+                authType: "basic",
+                default: undefined,
+            },
+        ]);
+    });
+
+    it("builds a full config from empty text", () => {
+        const model: ConfigModel = {
+            strictness: "strict",
+            queryTimeoutSeconds: 10,
+            connections: [{ name: "local", url: "http://h/q", default: true }],
+        };
+
+        const result = applyConfigModel("", model);
+        const parsedBack = parseConfigModel(result);
+
+        assert.equal(parsedBack.strictness, "strict");
+        assert.equal(parsedBack.queryTimeoutSeconds, 10);
+        assert.equal(parsedBack.connections?.[0].name, "local");
+        assert.equal(parsedBack.connections?.[0].default, true);
+    });
+});

--- a/cimnotebook/vscode/src/sidebar/configModel.ts
+++ b/cimnotebook/vscode/src/sidebar/configModel.ts
@@ -23,9 +23,11 @@
  * Editing goes through jsonc-parser's `modify`/`applyEdits`, which patches individual
  * property paths: comments and formatting everywhere else in the file survive a save.
  * Only a value that actually changed is touched; a field cleared in the form removes
- * the property. The one caveat: rewriting an *array* value (schemas, connections)
- * replaces that array wholesale, so comments *inside* it are lost — the sidebar
- * documents this.
+ * the property. Connections are diffed entry-by-entry and field-by-field (keyed by
+ * {@link ConnectionModel.rawIndex}), so comments between entries, fields the form does
+ * not know, and entries the lenient parse skips all survive an edit. The remaining
+ * caveat: rewriting the *schemas* array replaces it wholesale, so comments inside that
+ * one array are lost.
  */
 
 import { applyEdits, modify, parse } from "jsonc-parser";
@@ -37,6 +39,13 @@ export interface ConnectionModel {
     shaclUrl?: string;
     authType?: "none" | "basic";
     default?: boolean;
+    /**
+     * The entry's index in the raw `connections` JSON array, assigned by {@link parseConfigModel}
+     * and used by {@link applyConfigModel} to edit that entry in place. Not necessarily the
+     * position in {@link ConfigModel.connections}: the raw array can hold entries the lenient
+     * parse skips (they stay in the file untouched). Absent on entries newly created by the UI.
+     */
+    rawIndex?: number;
 }
 
 export interface ConfigModel {
@@ -111,15 +120,85 @@ export function applyConfigModel(text: string, model: ConfigModel): string {
         model.queryTimeoutSeconds !== before.queryTimeoutSeconds,
     );
     set(["cimnotebook", "maxRows"], model.maxRows, model.maxRows !== before.maxRows);
-    set(
-        ["cimnotebook", "connections"],
-        undefinedIfEmpty(model.connections?.map(normalizeConnection)),
-        !sameJson(
-            undefinedIfEmpty(model.connections?.map(normalizeConnection)),
-            before.connections,
-        ),
-    );
+    result = applyConnections(result, model.connections ?? [], before.connections);
     return result;
+}
+
+/**
+ * Applies connection changes as the narrowest possible edits. Entries are paired with the file's
+ * raw array by {@link ConnectionModel.rawIndex} and diffed field-by-field, so everything the form
+ * did not change — comments between entries, fields it does not know, entries the lenient parse
+ * skipped — survives. Removals go highest-index-first (earlier indices stay valid), additions are
+ * appended. Only when the file has no connections array at all is one written as a whole.
+ */
+function applyConnections(
+    text: string,
+    after: ConnectionModel[],
+    beforeConnections: ConnectionModel[] | undefined,
+): string {
+    let result = text;
+    const edit = (path: (string | number)[], value: unknown): void => {
+        result = applyEdits(result, modify(result, path, value, FORMATTING));
+    };
+
+    if (beforeConnections === undefined) {
+        const created = after.map(normalizeConnection);
+        if (created.length > 0) {
+            edit(["cimnotebook", "connections"], created);
+        }
+        return result;
+    }
+
+    const beforeByRaw = new Map<number, ConnectionModel>();
+    for (const connection of beforeConnections) {
+        if (connection.rawIndex !== undefined) {
+            beforeByRaw.set(connection.rawIndex, connection);
+        }
+    }
+    const keptRaw = new Set<number>();
+
+    for (const connection of after) {
+        const beforeEntry =
+            connection.rawIndex !== undefined ? beforeByRaw.get(connection.rawIndex) : undefined;
+        if (connection.rawIndex === undefined || beforeEntry === undefined) {
+            continue; // an addition — appended below, after removals
+        }
+        keptRaw.add(connection.rawIndex);
+        const beforeFields = editableFields(beforeEntry);
+        const afterFields = editableFields(connection);
+        for (const key of Object.keys(afterFields) as (keyof EditableFields)[]) {
+            if (afterFields[key] !== beforeFields[key]) {
+                edit(["cimnotebook", "connections", connection.rawIndex, key], afterFields[key]);
+            }
+        }
+    }
+
+    const removed = [...beforeByRaw.keys()].filter((i) => !keptRaw.has(i)).sort((a, b) => b - a);
+    for (const rawIndex of removed) {
+        edit(["cimnotebook", "connections", rawIndex], undefined);
+    }
+
+    for (const connection of after) {
+        if (connection.rawIndex === undefined) {
+            edit(["cimnotebook", "connections", -1], normalizeConnection(connection));
+        }
+    }
+    return result;
+}
+
+type EditableFields = ReturnType<typeof editableFields>;
+
+/** A connection's form-editable fields in their normalized written form, for field diffing. */
+function editableFields(connection: ConnectionModel) {
+    const normalized = normalizeConnection(connection);
+    return {
+        name: normalized.name,
+        url: normalized.url,
+        updateUrl: normalized.updateUrl,
+        shaclUrl: normalized.shaclUrl,
+        authType: normalized.authType,
+        default: normalized.default,
+    };
 }
 
 /** Drops empty/false optional fields so the written JSON stays minimal. */
@@ -172,12 +251,12 @@ function asConnections(value: unknown): ConnectionModel[] | undefined {
         return undefined;
     }
     const connections: ConnectionModel[] = [];
-    for (const entry of value) {
+    value.forEach((entry, rawIndex) => {
         const obj = asObject(entry);
         const name = asString(obj["name"]);
         const url = asString(obj["url"]);
         if (name === undefined || url === undefined) {
-            continue;
+            return;
         }
         connections.push({
             name,
@@ -186,9 +265,10 @@ function asConnections(value: unknown): ConnectionModel[] | undefined {
             shaclUrl: asString(obj["shaclUrl"]),
             authType: obj["authType"] === "basic" ? "basic" : undefined,
             default: obj["default"] === true ? true : undefined,
+            rawIndex,
         });
-    }
-    return connections.length > 0 ? connections : undefined;
+    });
+    return connections;
 }
 
 function emptyToUndefined(value: string | undefined): string | undefined {

--- a/cimnotebook/vscode/src/sidebar/configModel.ts
+++ b/cimnotebook/vscode/src/sidebar/configModel.ts
@@ -1,0 +1,204 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The form model behind the configuration sidebar, and its mapping to/from
+ * `opencgmes.jsonc` text. Pure module (no `vscode` import).
+ *
+ * Editing goes through jsonc-parser's `modify`/`applyEdits`, which patches individual
+ * property paths: comments and formatting everywhere else in the file survive a save.
+ * Only a value that actually changed is touched; a field cleared in the form removes
+ * the property. The one caveat: rewriting an *array* value (schemas, connections)
+ * replaces that array wholesale, so comments *inside* it are lost — the sidebar
+ * documents this.
+ */
+
+import { applyEdits, modify, parse } from "jsonc-parser";
+
+export interface ConnectionModel {
+    name: string;
+    url: string;
+    updateUrl?: string;
+    shaclUrl?: string;
+    authType?: "none" | "basic";
+    default?: boolean;
+}
+
+export interface ConfigModel {
+    // "cimvocabcheck" section
+    strictness?: string;
+    standardVocabulary?: string;
+    schemasDirectory?: string;
+    schemas?: string[];
+    // "cimnotebook" section
+    queryTimeoutSeconds?: number;
+    maxRows?: number;
+    connections?: ConnectionModel[];
+}
+
+const FORMATTING = { formattingOptions: { insertSpaces: true, tabSize: 2 } };
+
+/** Reads the sidebar-editable fields from config text (error-tolerant JSONC parse). */
+export function parseConfigModel(text: string): ConfigModel {
+    const root = (parse(text, [], { allowTrailingComma: true }) ?? {}) as Record<string, unknown>;
+    const vocab = asObject(root["cimvocabcheck"]);
+    const notebook = asObject(root["cimnotebook"]);
+    return {
+        strictness: asString(vocab["strictness"]),
+        standardVocabulary: asString(vocab["standardVocabulary"]),
+        schemasDirectory: asString(vocab["schemasDirectory"]),
+        schemas: asStringArray(vocab["schemas"]),
+        queryTimeoutSeconds: asNumber(notebook["queryTimeoutSeconds"]),
+        maxRows: asNumber(notebook["maxRows"]),
+        connections: asConnections(notebook["connections"]),
+    };
+}
+
+/**
+ * Returns the config text with the model applied — property-path edits only, so
+ * comments and formatting outside the changed values are preserved. Unchanged fields
+ * produce no edit at all.
+ */
+export function applyConfigModel(text: string, model: ConfigModel): string {
+    const before = parseConfigModel(text);
+    let result = text.trim().length === 0 ? "{}\n" : text;
+
+    const set = (path: (string | number)[], value: unknown, changed: boolean): void => {
+        if (!changed) {
+            return;
+        }
+        result = applyEdits(result, modify(result, path, value, FORMATTING));
+    };
+
+    set(
+        ["cimvocabcheck", "strictness"],
+        emptyToUndefined(model.strictness),
+        emptyToUndefined(model.strictness) !== before.strictness,
+    );
+    set(
+        ["cimvocabcheck", "standardVocabulary"],
+        emptyToUndefined(model.standardVocabulary),
+        emptyToUndefined(model.standardVocabulary) !== before.standardVocabulary,
+    );
+    set(
+        ["cimvocabcheck", "schemasDirectory"],
+        emptyToUndefined(model.schemasDirectory),
+        emptyToUndefined(model.schemasDirectory) !== before.schemasDirectory,
+    );
+    set(
+        ["cimvocabcheck", "schemas"],
+        undefinedIfEmpty(model.schemas),
+        !sameJson(undefinedIfEmpty(model.schemas), before.schemas),
+    );
+    set(
+        ["cimnotebook", "queryTimeoutSeconds"],
+        model.queryTimeoutSeconds,
+        model.queryTimeoutSeconds !== before.queryTimeoutSeconds,
+    );
+    set(["cimnotebook", "maxRows"], model.maxRows, model.maxRows !== before.maxRows);
+    set(
+        ["cimnotebook", "connections"],
+        undefinedIfEmpty(model.connections?.map(normalizeConnection)),
+        !sameJson(
+            undefinedIfEmpty(model.connections?.map(normalizeConnection)),
+            before.connections,
+        ),
+    );
+    return result;
+}
+
+/** Drops empty/false optional fields so the written JSON stays minimal. */
+function normalizeConnection(connection: ConnectionModel): ConnectionModel {
+    const normalized: ConnectionModel = {
+        name: connection.name.trim(),
+        url: connection.url.trim(),
+    };
+    if (connection.updateUrl?.trim()) {
+        normalized.updateUrl = connection.updateUrl.trim();
+    }
+    if (connection.shaclUrl?.trim()) {
+        normalized.shaclUrl = connection.shaclUrl.trim();
+    }
+    if (connection.authType === "basic") {
+        normalized.authType = "basic";
+    }
+    if (connection.default === true) {
+        normalized.default = true;
+    }
+    return normalized;
+}
+
+// ---- lenient readers ---------------------------------------------------------------------
+
+function asObject(value: unknown): Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+    const strings = value.filter((v): v is string => typeof v === "string");
+    return strings.length > 0 ? strings : undefined;
+}
+
+function asConnections(value: unknown): ConnectionModel[] | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+    const connections: ConnectionModel[] = [];
+    for (const entry of value) {
+        const obj = asObject(entry);
+        const name = asString(obj["name"]);
+        const url = asString(obj["url"]);
+        if (name === undefined || url === undefined) {
+            continue;
+        }
+        connections.push({
+            name,
+            url,
+            updateUrl: asString(obj["updateUrl"]),
+            shaclUrl: asString(obj["shaclUrl"]),
+            authType: obj["authType"] === "basic" ? "basic" : undefined,
+            default: obj["default"] === true ? true : undefined,
+        });
+    }
+    return connections.length > 0 ? connections : undefined;
+}
+
+function emptyToUndefined(value: string | undefined): string | undefined {
+    return value === undefined || value.trim() === "" ? undefined : value.trim();
+}
+
+function undefinedIfEmpty<T>(value: T[] | undefined): T[] | undefined {
+    return value !== undefined && value.length > 0 ? value : undefined;
+}
+
+function sameJson(a: unknown, b: unknown): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/cimnotebook/vscode/src/sidebar/treeItems.test.ts
+++ b/cimnotebook/vscode/src/sidebar/treeItems.test.ts
@@ -1,0 +1,155 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    connectionContextValue,
+    connectionDescription,
+    connectionIcon,
+    connectionLabel,
+    effectiveStandardVocabulary,
+    numberSettingDescription,
+    schemasDirectoryDescription,
+    standardVocabularyDescription,
+    standardVocabularyValueToWrite,
+    strictnessDescription,
+    strictnessValueToWrite,
+    validateConnectionName,
+    validateOptionalUrl,
+    validatePositiveIntegerOrEmpty,
+    validateRequiredUrl,
+} from "./treeItems";
+
+describe("connection label/description/icon/contextValue", () => {
+    it("plain connection", () => {
+        const c = { name: "local", url: "http://localhost:3030/ds/query" };
+        assert.equal(connectionLabel(c), "local");
+        assert.equal(connectionDescription(c), "http://localhost:3030/ds/query");
+        assert.equal(connectionIcon(c), "plug");
+        assert.equal(connectionContextValue(c), "connection");
+    });
+
+    it("default connection with basic auth", () => {
+        const c = {
+            name: "prod",
+            url: "https://h/query",
+            authType: "basic" as const,
+            default: true,
+        };
+        // Plain words, no $(...) codicons: TreeItem.description renders literal text.
+        assert.equal(connectionDescription(c), "https://h/query · basic auth · default");
+        assert.equal(connectionIcon(c), "star-full");
+        assert.equal(connectionContextValue(c), "connection basic default");
+    });
+});
+
+describe("validateConnectionName", () => {
+    it("rejects empty names", () => {
+        assert.match(validateConnectionName("  ", []) ?? "", /Enter a connection name/);
+    });
+
+    it("rejects names that look like file paths or URLs", () => {
+        assert.match(validateConnectionName("a.b", []) ?? "", /can't contain/);
+        assert.match(validateConnectionName("a/b", []) ?? "", /can't contain/);
+        assert.match(validateConnectionName("a\\b", []) ?? "", /can't contain/);
+        assert.match(validateConnectionName("http://h/query", []) ?? "", /can't contain/);
+    });
+
+    it("rejects names with whitespace (directives end at the first space)", () => {
+        assert.match(validateConnectionName("my conn", []) ?? "", /whitespace/);
+    });
+
+    it("rejects duplicates but allows keeping the current name while editing", () => {
+        assert.match(validateConnectionName("prod", ["prod", "dev"]) ?? "", /already used/);
+        assert.equal(validateConnectionName("prod", ["prod", "dev"], "prod"), undefined);
+    });
+
+    it("accepts a fresh, valid name", () => {
+        assert.equal(validateConnectionName("local-fuseki", ["prod"]), undefined);
+    });
+});
+
+describe("validateRequiredUrl / validateOptionalUrl", () => {
+    it("required: rejects empty and non-http(s) values", () => {
+        assert.ok(validateRequiredUrl(""));
+        assert.ok(validateRequiredUrl("ftp://h/x"));
+        assert.equal(validateRequiredUrl("http://h/query"), undefined);
+        assert.equal(validateRequiredUrl("https://h/query"), undefined);
+    });
+
+    it("optional: accepts empty, still validates non-empty values", () => {
+        assert.equal(validateOptionalUrl(""), undefined);
+        assert.equal(validateOptionalUrl("   "), undefined);
+        assert.equal(validateOptionalUrl("https://h/update"), undefined);
+        assert.ok(validateOptionalUrl("not-a-url"));
+    });
+});
+
+describe("strictness / standardVocabulary description and write-value mapping", () => {
+    it("strictness shows the effective value, unset reads as its own 'default' level", () => {
+        assert.equal(strictnessDescription(undefined), "default");
+        assert.equal(strictnessDescription(""), "default");
+        assert.equal(strictnessDescription("strict"), "strict");
+    });
+
+    it("standardVocabulary annotates the implicit default", () => {
+        assert.equal(standardVocabularyDescription(undefined), "check (default)");
+        assert.equal(standardVocabularyDescription("ignore"), "ignore");
+        assert.equal(effectiveStandardVocabulary(undefined), "check");
+        assert.equal(effectiveStandardVocabulary("ignore"), "ignore");
+    });
+
+    it("schemasDirectory unset means the listed schema files alone, or syntax-only with none", () => {
+        assert.equal(
+            schemasDirectoryDescription(undefined, 0),
+            "not set (validation is syntax-only)",
+        );
+        assert.equal(schemasDirectoryDescription("", 0), "not set (validation is syntax-only)");
+        assert.equal(
+            schemasDirectoryDescription(undefined, 2),
+            "not set (schema files below are used)",
+        );
+        assert.equal(schemasDirectoryDescription("profiles", 0), "profiles");
+    });
+
+    it("picking the schema-default value clears the field; anything else is written", () => {
+        assert.equal(strictnessValueToWrite("default"), undefined);
+        assert.equal(strictnessValueToWrite("strict"), "strict");
+        assert.equal(standardVocabularyValueToWrite("check"), undefined);
+        assert.equal(standardVocabularyValueToWrite("ignore"), "ignore");
+    });
+});
+
+describe("numberSettingDescription / validatePositiveIntegerOrEmpty", () => {
+    it("shows the value, or the default annotated when unset", () => {
+        assert.equal(numberSettingDescription(45, 30), "45");
+        assert.equal(numberSettingDescription(undefined, 30), "30 (default)");
+    });
+
+    it("accepts empty (clears) and positive integers; rejects everything else", () => {
+        assert.equal(validatePositiveIntegerOrEmpty(""), undefined);
+        assert.equal(validatePositiveIntegerOrEmpty("  "), undefined);
+        assert.equal(validatePositiveIntegerOrEmpty("42"), undefined);
+        assert.ok(validatePositiveIntegerOrEmpty("0"));
+        assert.ok(validatePositiveIntegerOrEmpty("-1"));
+        assert.ok(validatePositiveIntegerOrEmpty("abc"));
+        assert.ok(validatePositiveIntegerOrEmpty("4.5"));
+    });
+});

--- a/cimnotebook/vscode/src/sidebar/treeItems.ts
+++ b/cimnotebook/vscode/src/sidebar/treeItems.ts
@@ -1,0 +1,194 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure label/description builders and field validators for the three configuration tree
+ * views (`treeViews.ts`). Kept dependency-free of `vscode` — unlike the tree providers
+ * themselves, which build `vscode.TreeItem`s and register commands — so this is the part
+ * that gets node tests, mirroring `endpoint.ts` next to `endpointCommands.ts`.
+ */
+
+import { classifyDirective } from "../notebook/endpoint";
+import { ConnectionModel } from "./configModel";
+
+// ---- connections --------------------------------------------------------------------------
+
+export function connectionLabel(connection: ConnectionModel): string {
+    return connection.name;
+}
+
+/**
+ * URL plus "· basic auth" / "· default" markers. Plain words, not `$(...)` codicons —
+ * `TreeItem.description` is rendered as literal text, unlike QuickPick labels.
+ */
+export function connectionDescription(connection: ConnectionModel): string {
+    const parts = [connection.url];
+    if (connection.authType === "basic") {
+        parts.push("· basic auth");
+    }
+    if (connection.default) {
+        parts.push("· default");
+    }
+    return parts.join(" ");
+}
+
+export function connectionIcon(connection: ConnectionModel): string {
+    return connection.default ? "star-full" : "plug";
+}
+
+/**
+ * Space-separated facets for the item's `contextValue`, matched by `viewItem =~ /.../ `
+ * `when` clauses in `package.json` (e.g. gating the credentials action to basic auth).
+ */
+export function connectionContextValue(connection: ConnectionModel): string {
+    const parts = ["connection"];
+    if (connection.authType === "basic") {
+        parts.push("basic");
+    }
+    if (connection.default) {
+        parts.push("default");
+    }
+    return parts.join(" ");
+}
+
+/**
+ * A connection name must be non-empty, contain no whitespace (names are written into
+ * `# [endpoint=...]` directives, whose value ends at the first whitespace), classify as
+ * a *name* under `classifyDirective` in `endpoint.ts` (no `.`/`/`/`\`, not a URL — the
+ * single source of truth for how a directive is read), and be unique among the other
+ * connections. `currentName` excludes the connection being edited from the uniqueness
+ * check.
+ */
+export function validateConnectionName(
+    name: string,
+    existingNames: string[],
+    currentName?: string,
+): string | undefined {
+    const trimmed = name.trim();
+    if (trimmed === "") {
+        return "Enter a connection name.";
+    }
+    if (/\s/.test(trimmed)) {
+        return "Connection names can't contain whitespace (they're used in # [endpoint=…] directives).";
+    }
+    if (classifyDirective(trimmed) !== "name") {
+        return "Connection names can't contain '.', '/', or '\\' (that would look like a file path).";
+    }
+    if (existingNames.some((existing) => existing !== currentName && existing === trimmed)) {
+        return `"${trimmed}" is already used by another connection.`;
+    }
+    return undefined;
+}
+
+const HTTP_URL = /^https?:\/\/\S+$/i;
+
+export function validateRequiredUrl(url: string): string | undefined {
+    return HTTP_URL.test(url.trim()) ? undefined : "Enter an http(s):// URL.";
+}
+
+/** Empty is allowed (the field is optional and gets derived); anything else must be a URL. */
+export function validateOptionalUrl(url: string): string | undefined {
+    const trimmed = url.trim();
+    if (trimmed === "") {
+        return undefined;
+    }
+    return HTTP_URL.test(trimmed) ? undefined : "Enter an http(s):// URL, or leave empty.";
+}
+
+// ---- validation section --------------------------------------------------------------------
+
+export interface LevelOption {
+    value: string;
+    detail: string;
+}
+
+/** The `cimvocabcheck.strictness` levels, in the schema's declared order. */
+export const STRICTNESS_LEVELS: LevelOption[] = [
+    {
+        value: "permissive",
+        detail: "Only unknown-term and syntax errors; semantic checks and hints are suppressed.",
+    },
+    { value: "default", detail: "All checks, original severities. Only errors fail validation." },
+    { value: "strict", detail: "All checks; warnings are promoted to errors." },
+    { value: "pedantic", detail: "All checks; warnings and hints are promoted to errors." },
+];
+
+/** The `cimvocabcheck.standardVocabulary` modes. */
+export const STANDARD_VOCABULARY_OPTIONS: LevelOption[] = [
+    { value: "check", detail: "Typos in rdf/rdfs/owl/sh terms are reported as errors." },
+    { value: "ignore", detail: "Terms in these namespaces are accepted without inspection." },
+];
+
+/** Effective strictness: the config's own default value doubles as the "unset" display. */
+export function strictnessDescription(value: string | undefined): string {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : "default";
+}
+
+/** The effective mode ("check" when unset), without the "(default)" annotation. */
+export function effectiveStandardVocabulary(value: string | undefined): string {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : "check";
+}
+
+export function standardVocabularyDescription(value: string | undefined): string {
+    const effective = effectiveStandardVocabulary(value);
+    return value?.trim() ? effective : `${effective} (default)`;
+}
+
+/**
+ * There is no bundled default schema and no implicit directory: with the directory unset,
+ * validation runs on the listed schema files alone — or syntax-only when there are none.
+ */
+export function schemasDirectoryDescription(
+    value: string | undefined,
+    schemaFileCount: number,
+): string {
+    const trimmed = value?.trim();
+    if (trimmed) {
+        return trimmed;
+    }
+    return schemaFileCount > 0
+        ? "not set (schema files below are used)"
+        : "not set (validation is syntax-only)";
+}
+
+/** Selecting the schema's own default value clears the field, keeping the file minimal. */
+export function strictnessValueToWrite(picked: string): string | undefined {
+    return picked === "default" ? undefined : picked;
+}
+
+export function standardVocabularyValueToWrite(picked: string): string | undefined {
+    return picked === "check" ? undefined : picked;
+}
+
+// ---- execution section ---------------------------------------------------------------------
+
+export function numberSettingDescription(value: number | undefined, defaultValue: number): string {
+    return value !== undefined ? String(value) : `${defaultValue} (default)`;
+}
+
+/** `showInputBox` validator for the integer notebook settings (empty clears the field). */
+export function validatePositiveIntegerOrEmpty(input: string): string | undefined {
+    if (input.trim() === "") {
+        return undefined;
+    }
+    return /^\d+$/.test(input.trim()) && Number(input.trim()) > 0
+        ? undefined
+        : "Enter a positive whole number, or leave empty to reset to the default.";
+}

--- a/cimnotebook/vscode/src/sidebar/treeViews.ts
+++ b/cimnotebook/vscode/src/sidebar/treeViews.ts
@@ -38,7 +38,7 @@
 import * as vscode from "vscode";
 
 import { ConnectionStore } from "../notebook/connections";
-import { clearCredentials, setCredentials } from "../notebook/credentials";
+import { runCredentialsAction } from "../notebook/credentials";
 import { pickWorkspaceFiles, pickWorkspaceFolder } from "../notebook/filePicker";
 import { ConnectionModel } from "./configModel";
 import { openConfig, readConfig, targetConfig, updateConfig } from "./configEditor";
@@ -475,7 +475,9 @@ async function editConnection(node?: ConnectionNode): Promise<void> {
         if (index === -1) {
             return;
         }
-        list[index] = updated;
+        // Keep the raw-array position so applyConfigModel edits the entry in place instead of
+        // treating the wizard result as a new connection.
+        list[index] = { ...updated, rawIndex: list[index].rawIndex };
         if (updated.default) {
             makeSingleDefault(list, index);
         }
@@ -538,15 +540,12 @@ async function manageConnectionCredentials(
     const action = await vscode.window.showQuickPick(["Set credentials", "Clear credentials"], {
         title: `Credentials for "${name}"`,
     });
-    if (action === "Set credentials") {
-        if (await setCredentials(context.secrets, name)) {
-            vscode.window.showInformationMessage(
-                `CIMNotebook: credentials for "${name}" stored in VS Code secret storage.`,
-            );
-        }
-    } else if (action === "Clear credentials") {
-        await clearCredentials(context.secrets, name);
-        vscode.window.showInformationMessage(`CIMNotebook: credentials for "${name}" cleared.`);
+    if (action !== undefined) {
+        await runCredentialsAction(
+            context.secrets,
+            name,
+            action === "Set credentials" ? "set" : "clear",
+        );
     }
 }
 

--- a/cimnotebook/vscode/src/sidebar/treeViews.ts
+++ b/cimnotebook/vscode/src/sidebar/treeViews.ts
@@ -1,0 +1,710 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The three native configuration tree views (replacing the M6 webview form): one
+ * collapsible section each for connections, validation settings, and notebook execution
+ * settings, all editing the workspace's `opencgmes.jsonc` through {@link updateConfig}.
+ *
+ * Each provider reads the config once per refresh in `getChildren` and embeds everything
+ * an item needs into its node, so `getTreeItem` is synchronous — no per-item re-reads.
+ * Every mutating command resolves the config once up front (`readConfig`) and threads
+ * that target into `updateConfig`, so a focus change during a wizard can't redirect the
+ * write; the file text itself is still re-read at write time, so concurrent hand-edits
+ * are never clobbered by a stale in-memory copy. Connection and schema-file nodes carry
+ * their list *index*, so rows with duplicate names/paths affect exactly the clicked
+ * entry.
+ *
+ * Item labels/descriptions and field validation are pure helpers in `treeItems.ts`; this
+ * file is the thin `vscode.TreeDataProvider` wiring plus the command handlers (wizards,
+ * QuickPicks) that drive them.
+ */
+
+import * as vscode from "vscode";
+
+import { ConnectionStore } from "../notebook/connections";
+import { clearCredentials, setCredentials } from "../notebook/credentials";
+import { pickWorkspaceFiles, pickWorkspaceFolder } from "../notebook/filePicker";
+import { ConnectionModel } from "./configModel";
+import { openConfig, readConfig, targetConfig, updateConfig } from "./configEditor";
+import {
+    connectionContextValue,
+    connectionDescription,
+    connectionIcon,
+    connectionLabel,
+    effectiveStandardVocabulary,
+    numberSettingDescription,
+    schemasDirectoryDescription,
+    standardVocabularyDescription,
+    standardVocabularyValueToWrite,
+    STANDARD_VOCABULARY_OPTIONS,
+    strictnessDescription,
+    strictnessValueToWrite,
+    STRICTNESS_LEVELS,
+    validateConnectionName,
+    validateOptionalUrl,
+    validatePositiveIntegerOrEmpty,
+    validateRequiredUrl,
+} from "./treeItems";
+
+export const CONNECTIONS_VIEW_ID = "cimnotebook.connectionsView";
+export const VALIDATION_VIEW_ID = "cimnotebook.validationView";
+export const EXECUTION_VIEW_ID = "cimnotebook.executionView";
+
+const HAS_CONFIG_CONTEXT = "cimnotebook.hasConfig";
+
+const DEFAULT_QUERY_TIMEOUT_SECONDS = 30;
+const DEFAULT_MAX_ROWS = 10_000;
+
+const ADD_CONNECTION_COMMAND = "cimnotebook.connections.add";
+const EDIT_CONNECTION_COMMAND = "cimnotebook.connections.edit";
+const REMOVE_CONNECTION_COMMAND = "cimnotebook.connections.remove";
+const TOGGLE_DEFAULT_CONNECTION_COMMAND = "cimnotebook.connections.toggleDefault";
+const CONNECTION_CREDENTIALS_COMMAND = "cimnotebook.connections.credentials";
+const OPEN_CONFIG_COMMAND = "cimnotebook.config.openFile";
+const EDIT_STRICTNESS_COMMAND = "cimnotebook.config.editStrictness";
+const EDIT_STANDARD_VOCABULARY_COMMAND = "cimnotebook.config.editStandardVocabulary";
+const EDIT_SCHEMAS_DIRECTORY_COMMAND = "cimnotebook.config.editSchemasDirectory";
+const ADD_SCHEMA_FILE_COMMAND = "cimnotebook.config.addSchemaFile";
+const REMOVE_SCHEMA_FILE_COMMAND = "cimnotebook.config.removeSchemaFile";
+const EDIT_QUERY_TIMEOUT_COMMAND = "cimnotebook.config.editQueryTimeout";
+const EDIT_MAX_ROWS_COMMAND = "cimnotebook.config.editMaxRows";
+
+export function registerConfigTreeViews(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+): void {
+    const refreshEmitter = new vscode.EventEmitter<void>();
+    context.subscriptions.push(refreshEmitter);
+
+    // createTreeView (not registerTreeDataProvider) for the top section so the resolved
+    // config file can be surfaced as the view description — the sections follow the
+    // active document's nearest config, and the user should see which file they edit.
+    const connectionsView = vscode.window.createTreeView(CONNECTIONS_VIEW_ID, {
+        treeDataProvider: new ConnectionsProvider(refreshEmitter.event),
+    });
+    context.subscriptions.push(
+        connectionsView,
+        vscode.window.registerTreeDataProvider(
+            VALIDATION_VIEW_ID,
+            new ValidationProvider(refreshEmitter.event),
+        ),
+        vscode.window.registerTreeDataProvider(
+            EXECUTION_VIEW_ID,
+            new ExecutionProvider(refreshEmitter.event),
+        ),
+    );
+
+    const refresh = async (): Promise<void> => {
+        refreshEmitter.fire();
+        const target = await targetConfig();
+        connectionsView.description = target.exists
+            ? vscode.workspace.asRelativePath(target.uri)
+            : undefined;
+        await vscode.commands.executeCommand("setContext", HAS_CONFIG_CONTEXT, target.exists);
+    };
+    context.subscriptions.push(
+        store.onDidChange(() => void refresh()),
+        vscode.window.onDidChangeActiveTextEditor(() => void refresh()),
+        vscode.window.onDidChangeActiveNotebookEditor(() => void refresh()),
+    );
+    void refresh();
+
+    registerCommands(context, refresh);
+}
+
+// ---- tree data providers --------------------------------------------------------------------
+
+/** A connection row: the rendered entry plus its position in `connections` at render time. */
+interface ConnectionNode {
+    connection: ConnectionModel;
+    index: number;
+}
+
+class ConnectionsProvider implements vscode.TreeDataProvider<ConnectionNode> {
+    constructor(readonly onDidChangeTreeData: vscode.Event<void>) {}
+
+    async getChildren(node?: ConnectionNode): Promise<ConnectionNode[]> {
+        if (node) {
+            return [];
+        }
+        const { model } = await readConfig();
+        return (model.connections ?? []).map((connection, index) => ({ connection, index }));
+    }
+
+    getTreeItem(node: ConnectionNode): vscode.TreeItem {
+        const item = new vscode.TreeItem(
+            connectionLabel(node.connection),
+            vscode.TreeItemCollapsibleState.None,
+        );
+        item.description = connectionDescription(node.connection);
+        item.iconPath = new vscode.ThemeIcon(connectionIcon(node.connection));
+        item.contextValue = connectionContextValue(node.connection);
+        item.command = {
+            title: "Edit Connection",
+            command: EDIT_CONNECTION_COMMAND,
+            arguments: [node],
+        };
+        return item;
+    }
+}
+
+interface SchemaFileNode {
+    kind: "schemaFile";
+    file: string;
+    /** Position in `schemas` at render time — removal targets exactly this occurrence. */
+    index: number;
+    openUri: vscode.Uri;
+}
+
+type ValidationNode =
+    | { kind: "strictness"; description: string }
+    | { kind: "standardVocabulary"; description: string }
+    | { kind: "schemasDirectory"; description: string }
+    | { kind: "schemasParent"; files: SchemaFileNode[] }
+    | SchemaFileNode;
+
+class ValidationProvider implements vscode.TreeDataProvider<ValidationNode> {
+    constructor(readonly onDidChangeTreeData: vscode.Event<void>) {}
+
+    async getChildren(node?: ValidationNode): Promise<ValidationNode[]> {
+        if (node) {
+            return node.kind === "schemasParent" ? node.files : [];
+        }
+        const { model, uri, exists } = await readConfig();
+        if (!exists) {
+            // Empty tree → the view's viewsWelcome "Create Config File" prompt shows
+            // instead of rows whose first edit would silently create a bare config.
+            return [];
+        }
+        const files = (model.schemas ?? []).map((file, index): SchemaFileNode => ({
+            kind: "schemaFile",
+            file,
+            index,
+            openUri: vscode.Uri.joinPath(uri, "..", file),
+        }));
+        return [
+            { kind: "strictness", description: strictnessDescription(model.strictness) },
+            {
+                kind: "standardVocabulary",
+                description: standardVocabularyDescription(model.standardVocabulary),
+            },
+            {
+                kind: "schemasDirectory",
+                description: schemasDirectoryDescription(model.schemasDirectory, files.length),
+            },
+            { kind: "schemasParent", files },
+        ];
+    }
+
+    getTreeItem(node: ValidationNode): vscode.TreeItem {
+        switch (node.kind) {
+            case "strictness":
+                return leaf("Strictness", node.description, {
+                    command: EDIT_STRICTNESS_COMMAND,
+                    contextValue: "strictness",
+                    icon: "settings-gear",
+                });
+            case "standardVocabulary":
+                return leaf("Standard vocabulary check", node.description, {
+                    command: EDIT_STANDARD_VOCABULARY_COMMAND,
+                    contextValue: "standardVocabulary",
+                    icon: "settings-gear",
+                });
+            case "schemasDirectory":
+                return leaf("Schemas directory", node.description, {
+                    command: EDIT_SCHEMAS_DIRECTORY_COMMAND,
+                    contextValue: "schemasDirectory",
+                    icon: "folder",
+                });
+            case "schemasParent": {
+                const item = new vscode.TreeItem(
+                    "Schema files",
+                    vscode.TreeItemCollapsibleState.Expanded,
+                );
+                item.contextValue = "schemasParent";
+                return item;
+            }
+            case "schemaFile": {
+                const item = new vscode.TreeItem(node.file, vscode.TreeItemCollapsibleState.None);
+                item.iconPath = new vscode.ThemeIcon("file");
+                item.contextValue = "schemaFile";
+                item.command = {
+                    title: "Open Schema File",
+                    command: "vscode.open",
+                    arguments: [node.openUri],
+                };
+                return item;
+            }
+        }
+    }
+}
+
+type ExecutionNode = { kind: "queryTimeoutSeconds" | "maxRows"; description: string };
+
+class ExecutionProvider implements vscode.TreeDataProvider<ExecutionNode> {
+    constructor(readonly onDidChangeTreeData: vscode.Event<void>) {}
+
+    async getChildren(node?: ExecutionNode): Promise<ExecutionNode[]> {
+        if (node) {
+            return [];
+        }
+        const { model, exists } = await readConfig();
+        if (!exists) {
+            return [];
+        }
+        return [
+            {
+                kind: "queryTimeoutSeconds",
+                description: numberSettingDescription(
+                    model.queryTimeoutSeconds,
+                    DEFAULT_QUERY_TIMEOUT_SECONDS,
+                ),
+            },
+            {
+                kind: "maxRows",
+                description: numberSettingDescription(model.maxRows, DEFAULT_MAX_ROWS),
+            },
+        ];
+    }
+
+    getTreeItem(node: ExecutionNode): vscode.TreeItem {
+        if (node.kind === "queryTimeoutSeconds") {
+            return leaf("Query timeout (seconds)", node.description, {
+                command: EDIT_QUERY_TIMEOUT_COMMAND,
+                contextValue: "queryTimeoutSeconds",
+            });
+        }
+        return leaf("Max rows / triples", node.description, {
+            command: EDIT_MAX_ROWS_COMMAND,
+            contextValue: "maxRows",
+        });
+    }
+}
+
+function leaf(
+    label: string,
+    description: string,
+    options: { command: string; contextValue: string; icon?: string },
+): vscode.TreeItem {
+    const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
+    item.description = description;
+    item.contextValue = options.contextValue;
+    if (options.icon) {
+        item.iconPath = new vscode.ThemeIcon(options.icon);
+    }
+    item.command = { title: "Edit", command: options.command };
+    return item;
+}
+
+// ---- commands --------------------------------------------------------------------------------
+
+function registerCommands(context: vscode.ExtensionContext, refresh: () => Promise<void>): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(ADD_CONNECTION_COMMAND, () =>
+            addConnection().then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_CONNECTION_COMMAND, (n?: ConnectionNode) =>
+            editConnection(n).then(refresh),
+        ),
+        vscode.commands.registerCommand(REMOVE_CONNECTION_COMMAND, (n?: ConnectionNode) =>
+            removeConnection(n).then(refresh),
+        ),
+        vscode.commands.registerCommand(TOGGLE_DEFAULT_CONNECTION_COMMAND, (n?: ConnectionNode) =>
+            toggleDefaultConnection(n).then(refresh),
+        ),
+        vscode.commands.registerCommand(CONNECTION_CREDENTIALS_COMMAND, (n?: ConnectionNode) =>
+            manageConnectionCredentials(context, n),
+        ),
+        vscode.commands.registerCommand(OPEN_CONFIG_COMMAND, () => openConfig()),
+        vscode.commands.registerCommand(EDIT_STRICTNESS_COMMAND, () =>
+            editStrictness().then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_STANDARD_VOCABULARY_COMMAND, () =>
+            editStandardVocabulary().then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_SCHEMAS_DIRECTORY_COMMAND, () =>
+            editSchemasDirectory().then(refresh),
+        ),
+        vscode.commands.registerCommand(ADD_SCHEMA_FILE_COMMAND, () =>
+            addSchemaFile().then(refresh),
+        ),
+        vscode.commands.registerCommand(REMOVE_SCHEMA_FILE_COMMAND, (n?: SchemaFileNode) =>
+            removeSchemaFile(n).then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_QUERY_TIMEOUT_COMMAND, () =>
+            editQueryTimeout().then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_MAX_ROWS_COMMAND, () => editMaxRows().then(refresh)),
+    );
+}
+
+// ---- connections ---------------------------------------------------------------------------
+
+async function runConnectionWizard(
+    existingNames: string[],
+    prefill?: ConnectionModel,
+): Promise<ConnectionModel | undefined> {
+    const name = await vscode.window.showInputBox({
+        title: prefill ? `Edit connection "${prefill.name}" — name` : "New connection — name",
+        value: prefill?.name ?? "",
+        placeHolder: "local-fuseki",
+        validateInput: (v) => validateConnectionName(v, existingNames, prefill?.name),
+    });
+    if (name === undefined) {
+        return undefined;
+    }
+
+    const url = await vscode.window.showInputBox({
+        title: "Query URL",
+        value: prefill?.url ?? "",
+        placeHolder: "http://localhost:3030/ds/query",
+        validateInput: validateRequiredUrl,
+    });
+    if (url === undefined) {
+        return undefined;
+    }
+
+    const updateUrl = await vscode.window.showInputBox({
+        title: "Update URL (optional — derived from the query URL when empty)",
+        value: prefill?.updateUrl ?? "",
+        validateInput: validateOptionalUrl,
+    });
+    if (updateUrl === undefined) {
+        return undefined;
+    }
+
+    const shaclUrl = await vscode.window.showInputBox({
+        title: "SHACL URL (optional — derived from the query URL when empty)",
+        value: prefill?.shaclUrl ?? "",
+        validateInput: validateOptionalUrl,
+    });
+    if (shaclUrl === undefined) {
+        return undefined;
+    }
+
+    const authOptions =
+        prefill?.authType === "basic" ? ["Basic auth", "None"] : ["None", "Basic auth"];
+    const authPick = await vscode.window.showQuickPick(authOptions, { title: "Authentication" });
+    if (authPick === undefined) {
+        return undefined;
+    }
+
+    const defaultOptions = prefill?.default ? ["Yes", "No"] : ["No", "Yes"];
+    const defaultPick = await vscode.window.showQuickPick(defaultOptions, {
+        title: "Set as the workspace default connection?",
+    });
+    if (defaultPick === undefined) {
+        return undefined;
+    }
+
+    return {
+        name: name.trim(),
+        url: url.trim(),
+        updateUrl: updateUrl.trim() || undefined,
+        shaclUrl: shaclUrl.trim() || undefined,
+        authType: authPick === "Basic auth" ? "basic" : undefined,
+        default: defaultPick === "Yes" ? true : undefined,
+    };
+}
+
+/**
+ * The clicked row's position in the (possibly changed) list: its render-time index when
+ * the entry there still matches, else the first name match. Duplicate names — legal in a
+ * hand-edited file — thus affect exactly the clicked entry, not every namesake.
+ */
+function connectionIndex(list: ConnectionModel[], node: ConnectionNode): number {
+    if (list[node.index]?.name === node.connection.name) {
+        return node.index;
+    }
+    return list.findIndex((c) => c.name === node.connection.name);
+}
+
+/** Makes `index` the single default connection; every other entry loses the flag. */
+function makeSingleDefault(list: ConnectionModel[], index: number): void {
+    list.forEach((c, i) => {
+        c.default = i === index ? true : undefined;
+    });
+}
+
+async function addConnection(): Promise<void> {
+    const state = await readConfig();
+    const existingNames = (state.model.connections ?? []).map((c) => c.name);
+    const connection = await runConnectionWizard(existingNames);
+    if (!connection) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        const list = [...(m.connections ?? [])];
+        list.push(connection);
+        if (connection.default) {
+            makeSingleDefault(list, list.length - 1);
+        }
+        m.connections = list;
+    });
+}
+
+async function editConnection(node?: ConnectionNode): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const state = await readConfig();
+    const existingNames = (state.model.connections ?? []).map((c) => c.name);
+    const updated = await runConnectionWizard(existingNames, node.connection);
+    if (!updated) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        const list = [...(m.connections ?? [])];
+        const index = connectionIndex(list, node);
+        if (index === -1) {
+            return;
+        }
+        list[index] = updated;
+        if (updated.default) {
+            makeSingleDefault(list, index);
+        }
+        m.connections = list;
+    });
+}
+
+async function removeConnection(node?: ConnectionNode): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const confirm = await vscode.window.showWarningMessage(
+        `Remove connection "${node.connection.name}"?`,
+        { modal: true },
+        "Remove",
+    );
+    if (confirm !== "Remove") {
+        return;
+    }
+    const state = await readConfig();
+    await updateConfig(state, (m) => {
+        const list = [...(m.connections ?? [])];
+        const index = connectionIndex(list, node);
+        if (index !== -1) {
+            list.splice(index, 1);
+        }
+        m.connections = list;
+    });
+}
+
+async function toggleDefaultConnection(node?: ConnectionNode): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const makeDefault = !node.connection.default;
+    const state = await readConfig();
+    await updateConfig(state, (m) => {
+        const list = [...(m.connections ?? [])];
+        const index = connectionIndex(list, node);
+        if (index === -1) {
+            return;
+        }
+        if (makeDefault) {
+            makeSingleDefault(list, index);
+        } else {
+            list[index].default = undefined;
+        }
+        m.connections = list;
+    });
+}
+
+async function manageConnectionCredentials(
+    context: vscode.ExtensionContext,
+    node?: ConnectionNode,
+): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const name = node.connection.name;
+    const action = await vscode.window.showQuickPick(["Set credentials", "Clear credentials"], {
+        title: `Credentials for "${name}"`,
+    });
+    if (action === "Set credentials") {
+        if (await setCredentials(context.secrets, name)) {
+            vscode.window.showInformationMessage(
+                `CIMNotebook: credentials for "${name}" stored in VS Code secret storage.`,
+            );
+        }
+    } else if (action === "Clear credentials") {
+        await clearCredentials(context.secrets, name);
+        vscode.window.showInformationMessage(`CIMNotebook: credentials for "${name}" cleared.`);
+    }
+}
+
+// ---- validation section ----------------------------------------------------------------------
+
+async function editStrictness(): Promise<void> {
+    const state = await readConfig();
+    const current = strictnessDescription(state.model.strictness);
+    const items = STRICTNESS_LEVELS.map((level) => ({
+        label: level.value,
+        description: level.value === current ? "Current" : undefined,
+        detail: level.detail,
+    }));
+    const pick = await vscode.window.showQuickPick(items, { title: "Strictness" });
+    if (!pick) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        m.strictness = strictnessValueToWrite(pick.label);
+    });
+}
+
+async function editStandardVocabulary(): Promise<void> {
+    const state = await readConfig();
+    const current = effectiveStandardVocabulary(state.model.standardVocabulary);
+    const items = STANDARD_VOCABULARY_OPTIONS.map((option) => ({
+        label: option.value,
+        description: option.value === current ? "Current" : undefined,
+        detail: option.detail,
+    }));
+    const pick = await vscode.window.showQuickPick(items, { title: "Standard vocabulary check" });
+    if (!pick) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        m.standardVocabulary = standardVocabularyValueToWrite(pick.label);
+    });
+}
+
+async function editSchemasDirectory(): Promise<void> {
+    const state = await readConfig();
+    const configDir = vscode.Uri.joinPath(state.uri, "..");
+    const choice = await vscode.window.showQuickPick(
+        [
+            { label: "$(folder-opened) Browse for a folder…", action: "browse" as const },
+            {
+                label: "$(discard) Clear (no schemas directory)",
+                action: "clear" as const,
+            },
+            { label: "$(edit) Type a path…", action: "type" as const },
+        ],
+        { title: "Schemas directory" },
+    );
+    if (!choice) {
+        return;
+    }
+    let value: string | undefined;
+    if (choice.action === "browse") {
+        value = await pickWorkspaceFolder({ baseUri: configDir, title: "Schemas directory" });
+        if (value === undefined) {
+            return;
+        }
+    } else if (choice.action === "type") {
+        const typed = await vscode.window.showInputBox({
+            title: "Schemas directory (relative to the config file)",
+            value: state.model.schemasDirectory ?? "",
+            placeHolder: "./schemas",
+        });
+        if (typed === undefined) {
+            return;
+        }
+        value = typed;
+    } else {
+        value = "";
+    }
+    await updateConfig(state, (m) => {
+        m.schemasDirectory = value?.trim() ? value.trim() : undefined;
+    });
+}
+
+/** `./schemas/x.rdf` and `schemas/x.rdf` resolve to the same file — compare without `./`. */
+function canonicalPath(p: string): string {
+    return p.startsWith("./") ? p.slice(2) : p;
+}
+
+async function addSchemaFile(): Promise<void> {
+    const state = await readConfig();
+    const configDir = vscode.Uri.joinPath(state.uri, "..");
+    const picked = await pickWorkspaceFiles({
+        pattern: "**/*.{rdf,ttl,owl}",
+        baseUri: configDir,
+        title: "Add schema file(s)",
+        canPickMany: true,
+    });
+    if (!picked || picked.length === 0) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        const merged = [...(m.schemas ?? [])];
+        const seen = new Set(merged.map(canonicalPath));
+        for (const file of picked) {
+            if (!seen.has(canonicalPath(file))) {
+                merged.push(file);
+                seen.add(canonicalPath(file));
+            }
+        }
+        m.schemas = merged;
+    });
+}
+
+async function removeSchemaFile(node?: SchemaFileNode): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const state = await readConfig();
+    await updateConfig(state, (m) => {
+        const list = [...(m.schemas ?? [])];
+        // The render-time index when that entry is unchanged, else the first value match —
+        // duplicates are removed one occurrence at a time.
+        const index = list[node.index] === node.file ? node.index : list.indexOf(node.file);
+        if (index !== -1) {
+            list.splice(index, 1);
+        }
+        m.schemas = list;
+    });
+}
+
+// ---- execution section ------------------------------------------------------------------------
+
+async function editQueryTimeout(): Promise<void> {
+    const state = await readConfig();
+    const input = await vscode.window.showInputBox({
+        title: `Query timeout, in seconds (empty resets to the default: ${DEFAULT_QUERY_TIMEOUT_SECONDS})`,
+        value:
+            state.model.queryTimeoutSeconds !== undefined
+                ? String(state.model.queryTimeoutSeconds)
+                : "",
+        validateInput: validatePositiveIntegerOrEmpty,
+    });
+    if (input === undefined) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        m.queryTimeoutSeconds = input.trim() ? Number(input.trim()) : undefined;
+    });
+}
+
+async function editMaxRows(): Promise<void> {
+    const state = await readConfig();
+    const input = await vscode.window.showInputBox({
+        title: `Max rows / triples (empty resets to the default: ${DEFAULT_MAX_ROWS})`,
+        value: state.model.maxRows !== undefined ? String(state.model.maxRows) : "",
+        validateInput: validatePositiveIntegerOrEmpty,
+    });
+    if (input === undefined) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        m.maxRows = input.trim() ? Number(input.trim()) : undefined;
+    });
+}

--- a/cimnotebook/vscode/tsconfig.json
+++ b/cimnotebook/vscode/tsconfig.json
@@ -4,7 +4,7 @@
         "moduleResolution": "Node16",
         "target": "ES2021",
         "outDir": "out",
-        "lib": ["ES2021"],
+        "lib": ["ES2021", "ES2022.Error"],
         "sourceMap": true,
         "rootDir": "src",
         "strict": true,

--- a/cimnotebook/vscode/tsconfig.test.json
+++ b/cimnotebook/vscode/tsconfig.test.json
@@ -14,6 +14,10 @@
         "src/notebook/sparqlbook.ts",
         "src/notebook/endpoint.ts",
         "src/notebook/outputs.ts",
-        "src/notebook/*.test.ts"
+        "src/notebook/relativizePath.ts",
+        "src/notebook/*.test.ts",
+        "src/sidebar/configModel.ts",
+        "src/sidebar/treeItems.ts",
+        "src/sidebar/*.test.ts"
     ]
 }

--- a/cimnotebook/vscode/tsconfig.test.json
+++ b/cimnotebook/vscode/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "out-test",
+        "noEmit": false,
+        "sourceMap": false,
+        // Only "node": the format modules under test must stay importable without a
+        // running VS Code host — an accidental `import "vscode"` fails this build.
+        "types": ["node"]
+    },
+    "include": [
+        "src/notebook/cells.ts",
+        "src/notebook/markdown.ts",
+        "src/notebook/sparqlbook.ts",
+        "src/notebook/*.test.ts"
+    ]
+}

--- a/cimnotebook/vscode/tsconfig.test.json
+++ b/cimnotebook/vscode/tsconfig.test.json
@@ -12,6 +12,8 @@
         "src/notebook/cells.ts",
         "src/notebook/markdown.ts",
         "src/notebook/sparqlbook.ts",
+        "src/notebook/endpoint.ts",
+        "src/notebook/outputs.ts",
         "src/notebook/*.test.ts"
     ]
 }

--- a/cimvocabcheck/core/src/main/java/de/soptim/opencgmes/cimvocabcheck/core/ConfigTemplate.java
+++ b/cimvocabcheck/core/src/main/java/de/soptim/opencgmes/cimvocabcheck/core/ConfigTemplate.java
@@ -71,6 +71,19 @@ public final class ConfigTemplate {
           // their ontology conventions: "cim16" (CGMES 2.4.15), "cim17"/"cim18" (CGMES 3.0+).
           // "cimNamespaces": { "http://example.org/CIM-Custom#": "cim17" }
         }
+
+        // CIM Notebooks (VS Code) read the "cimnotebook" section: named connections that
+        // cells reference with "# [endpoint=<name>]", plus execution defaults. Passwords
+        // NEVER belong in this file — declare "authType": "basic" and CIMNotebook keeps
+        // the credentials in VS Code secret storage.
+        // "cimnotebook": {
+        //   "connections": [
+        //     { "name": "local-fuseki", "url": "http://localhost:3030/cgmes/query", "default": true },
+        //     { "name": "prod", "url": "https://sparql.example.org/query", "authType": "basic" }
+        //   ],
+        //   "queryTimeoutSeconds": 30,
+        //   "maxRows": 10000
+        // }
       }
       """;
 

--- a/cimvocabcheck/lsp/pom.xml
+++ b/cimvocabcheck/lsp/pom.xml
@@ -54,6 +54,10 @@
         <ver.slf4j>2.0.18</ver.slf4j>
         <ver.log4j2>2.26.1</ver.log4j2>
         <ver.junit4>4.13.2</ver.junit4>
+        <!-- Test-only: in-process Fuseki server for notebook execution tests. Jena itself is
+             already on the classpath transitively via cimvocabcheck-core (${ver.jena} there);
+             kept in sync manually since this module has no direct compile-scope Jena dependency. -->
+        <ver.jena>6.1.0</ver.jena>
 
         <ver.plugin.compiler>3.15.0</ver.plugin.compiler>
         <ver.plugin.surefire>3.5.6</ver.plugin.surefire>
@@ -125,6 +129,14 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${ver.junit4}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- In-process HTTP endpoint for notebook execution tests -->
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-fuseki-main</artifactId>
+            <version>${ver.jena}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cimvocabcheck/lsp/pom.xml
+++ b/cimvocabcheck/lsp/pom.xml
@@ -54,9 +54,10 @@
         <ver.slf4j>2.0.18</ver.slf4j>
         <ver.log4j2>2.26.1</ver.log4j2>
         <ver.junit4>4.13.2</ver.junit4>
-        <!-- Test-only: in-process Fuseki server for notebook execution tests. Jena itself is
-             already on the classpath transitively via cimvocabcheck-core (${ver.jena} there);
-             kept in sync manually since this module has no direct compile-scope Jena dependency. -->
+        <!-- Jena bits this module needs directly: jena-shacl (compile, notebook SHACL cells) and
+             jena-fuseki-main (test, in-process endpoint for notebook execution tests). The Jena
+             core stack itself comes transitively via cimvocabcheck-core (${ver.jena} there);
+             kept in sync manually. -->
         <ver.jena>6.1.0</ver.jena>
 
         <ver.plugin.compiler>3.15.0</ver.plugin.compiler>
@@ -122,6 +123,13 @@
             <artifactId>log4j-core</artifactId>
             <version>${ver.log4j2}</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <!-- SHACL validation engine for notebook SHACL cells -->
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-shacl</artifactId>
+            <version>${ver.jena}</version>
         </dependency>
 
         <!-- Test -->

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/DocumentUris.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/DocumentUris.java
@@ -1,0 +1,77 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Reduces a document URI to the file it denotes.
+ *
+ * <p>Ordinary documents arrive as {@code file:} URIs, notebook cells as {@code
+ * vscode-notebook-cell:/path/to/notebook.cimnb.md#<cell-id>} — the notebook's path plus a cell-id
+ * fragment. Both forms are mapped to the same plain filesystem path, which is what config
+ * discovery, relative {@code # [endpoint=...]} resolution, and {@link NotebookDefaults} key on.
+ */
+final class DocumentUris {
+
+  private static final String CELL_SCHEME = "vscode-notebook-cell:";
+
+  private DocumentUris() {}
+
+  /** Whether {@code uri} is a notebook cell rather than a document on disk. */
+  static boolean isNotebookCell(String uri) {
+    return uri != null && uri.toLowerCase(Locale.ROOT).startsWith(CELL_SCHEME);
+  }
+
+  /**
+   * The file a document URI denotes — for a cell, the notebook file itself — or {@code null} when
+   * the URI names no file (an unsaved {@code untitled:} document, an unparseable URI).
+   */
+  static Path path(String uri) {
+    if (uri == null) {
+      return null;
+    }
+    try {
+      int hash = uri.indexOf('#');
+      URI parsed = URI.create(hash >= 0 ? uri.substring(0, hash) : uri);
+      if ("file".equalsIgnoreCase(parsed.getScheme())) {
+        return Path.of(parsed);
+      }
+      String p = parsed.getPath();
+      if (p == null || p.isBlank()) {
+        return null;
+      }
+      // On Windows the cell URI path is "/C:/Users/…"; Path.of rejects the leading slash.
+      if (p.length() >= 3 && p.charAt(0) == '/' && p.charAt(2) == ':') {
+        p = p.substring(1);
+      }
+      return Path.of(p);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /** The directory containing a document URI's file, or {@code null} when it has none. */
+  static Path dir(String uri) {
+    Path path = path(uri);
+    return path == null ? null : path.getParent();
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/EndpointDirective.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/EndpointDirective.java
@@ -18,6 +18,8 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -30,11 +32,13 @@ import java.util.regex.Pattern;
  * <pre>{@code
  * # [endpoint=https://lindas.admin.ch/query]
  * # [endpoint=./relative/path/file.ttl]
+ * # [endpoint=./rdf/{a,b}.ttl]
  * }</pre>
  *
- * <p>Because the directive is a {@code #} comment it is ignored by the SPARQL parser; CIMVocabCheck
- * reads it only to decide <em>which</em> schema to validate the query against (the schema is
- * assumed to be loaded into the endpoint, not the live instance data).
+ * <p>Several directives (or a glob pattern) declare a union of local files. Because the directive
+ * is a {@code #} comment it is ignored by the SPARQL parser; CIMVocabCheck reads it only to decide
+ * <em>which</em> schema to validate the query against (the schema is assumed to be loaded into the
+ * endpoint, not the live instance data).
  */
 final class EndpointDirective {
 
@@ -46,10 +50,20 @@ final class EndpointDirective {
 
   /** Returns the first endpoint declared in {@code text}, or empty if none is present. */
   static Optional<String> parse(String text) {
+    List<String> all = parseAll(text);
+    return all.isEmpty() ? Optional.empty() : Optional.of(all.get(0));
+  }
+
+  /** Returns every endpoint declared in {@code text}, in order; empty when none is present. */
+  static List<String> parseAll(String text) {
     if (text == null) {
-      return Optional.empty();
+      return List.of();
     }
+    List<String> values = new ArrayList<>();
     Matcher m = PATTERN.matcher(text);
-    return m.find() ? Optional.of(m.group(1).trim()) : Optional.empty();
+    while (m.find()) {
+      values.add(m.group(1).trim());
+    }
+    return List.copyOf(values);
   }
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaults.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaults.java
@@ -18,9 +18,9 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.CommandArguments;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 final class NotebookDefaults {
 
   private static final Logger LOG = LoggerFactory.getLogger(NotebookDefaults.class);
-  private static final Gson GSON = new Gson();
 
   private final Map<String, String> endpoints = new ConcurrentHashMap<>();
   private final List<Runnable> onChangeCallbacks = new CopyOnWriteArrayList<>();
@@ -64,16 +63,10 @@ final class NotebookDefaults {
    * in {@code NotebookCommandHandler}.
    */
   void apply(List<Object> arguments) {
-    if (arguments == null || arguments.isEmpty() || arguments.get(0) == null) {
-      LOG.warn("Ignoring setDefaultEndpoint without an argument");
-      return;
-    }
     try {
-      Object first = arguments.get(0);
-      JsonElement el =
-          first instanceof JsonElement je ? je : GSON.fromJson(first.toString(), JsonElement.class);
+      JsonElement el = CommandArguments.firstAsJson(arguments);
       if (el == null || !el.isJsonObject()) {
-        LOG.warn("Ignoring malformed setDefaultEndpoint argument: {}", first);
+        LOG.warn("Ignoring missing or malformed setDefaultEndpoint argument");
         return;
       }
       JsonObject obj = el.getAsJsonObject();

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaults.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaults.java
@@ -1,0 +1,145 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The per-notebook default endpoint: the {@code # [endpoint=...]} value a notebook's directive-less
+ * cells run — and validate — against.
+ *
+ * <p>The default is a client-side choice (VS Code's <em>Set Cell Endpoint → Notebook default</em>,
+ * remembered in workspace state rather than written into the notebook file), so the server can only
+ * learn about it by being told: the client pushes every change, and re-pushes on startup, through
+ * the {@value SparqlWorkspaceService#CMD_SET_DEFAULT_ENDPOINT} command. Without that, a cell with
+ * no directive of its own has no schema source and falls back to syntax-only validation.
+ *
+ * <p>Entries are keyed by the notebook's own path, which a cell URI carries too — see {@link
+ * DocumentUris} — so a cell can look up the notebook it belongs to.
+ */
+final class NotebookDefaults {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookDefaults.class);
+  private static final Gson GSON = new Gson();
+
+  private final Map<String, String> endpoints = new ConcurrentHashMap<>();
+  private final List<Runnable> onChangeCallbacks = new CopyOnWriteArrayList<>();
+
+  /** Registers a callback invoked after each change (typically: revalidate open documents). */
+  void addOnChangeCallback(Runnable callback) {
+    onChangeCallbacks.add(callback);
+  }
+
+  /**
+   * Applies one {@value SparqlWorkspaceService#CMD_SET_DEFAULT_ENDPOINT} invocation. Its single
+   * argument is {@code {"notebookUri": "...", "endpoint": "..."}}; a {@code null}/absent endpoint
+   * clears the notebook's default. Over JSON-RPC lsp4j delivers arguments as Gson {@link
+   * JsonElement}s, while an in-process call may pass a JSON {@link String} — both are accepted, as
+   * in {@code NotebookCommandHandler}.
+   */
+  void apply(List<Object> arguments) {
+    if (arguments == null || arguments.isEmpty() || arguments.get(0) == null) {
+      LOG.warn("Ignoring setDefaultEndpoint without an argument");
+      return;
+    }
+    try {
+      Object first = arguments.get(0);
+      JsonElement el =
+          first instanceof JsonElement je ? je : GSON.fromJson(first.toString(), JsonElement.class);
+      if (el == null || !el.isJsonObject()) {
+        LOG.warn("Ignoring malformed setDefaultEndpoint argument: {}", first);
+        return;
+      }
+      JsonObject obj = el.getAsJsonObject();
+      set(stringField(obj, "notebookUri"), stringField(obj, "endpoint"));
+    } catch (RuntimeException e) {
+      LOG.warn("Ignoring malformed setDefaultEndpoint argument: {}", e.getMessage());
+    }
+  }
+
+  /** Sets a notebook's default endpoint, or clears it when {@code endpoint} is null/blank. */
+  void set(String notebookUri, String endpoint) {
+    String key = key(notebookUri);
+    if (key == null) {
+      LOG.debug("Ignoring notebook default for unusable URI {}", notebookUri);
+      return;
+    }
+    if (endpoint == null || endpoint.isBlank()) {
+      endpoints.remove(key);
+    } else {
+      endpoints.put(key, endpoint.trim());
+    }
+    LOG.debug("Notebook default for {} is now {}", key, endpoints.get(key));
+    fireOnChange();
+  }
+
+  /**
+   * The default endpoint of the notebook owning {@code cellUri}, or {@code null} if none is set.
+   */
+  String forCell(String cellUri) {
+    String key = key(cellUri);
+    return key == null ? null : endpoints.get(key);
+  }
+
+  /**
+   * The map key a notebook URI and its cell URIs agree on: the notebook's path. Unsaved notebooks
+   * have none, so their opaque URI body ({@code untitled:Untitled-1} and {@code
+   * vscode-notebook-cell:Untitled-1#…} alike) is used instead.
+   */
+  private static String key(String uri) {
+    Path path = DocumentUris.path(uri);
+    if (path != null) {
+      return path.normalize().toString();
+    }
+    if (uri == null || uri.isBlank()) {
+      return null;
+    }
+    try {
+      String body = URI.create(uri.split("#", 2)[0]).getSchemeSpecificPart();
+      return body == null || body.isBlank() ? null : body;
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  private static String stringField(JsonObject obj, String name) {
+    JsonElement value = obj.get(name);
+    return value == null || value.isJsonNull() ? null : value.getAsString();
+  }
+
+  private void fireOnChange() {
+    for (Runnable callback : onChangeCallbacks) {
+      try {
+        callback.run();
+      } catch (Exception e) {
+        LOG.error("Notebook-default change callback failed: {}", e.getMessage(), e);
+      }
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
@@ -28,6 +28,7 @@ import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.EndpointSchema;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.EndpointSchemaLoader;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.RdfsSchemaIndex;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.FileGlobs;
 import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConfigLoader;
 import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConnection;
 import de.soptim.opencgmes.cimvocabcheck.lsp.schema.SchemaLoader;
@@ -35,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -49,6 +51,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 import org.apache.jena.graph.Node;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
@@ -210,46 +214,95 @@ final class SchemaManager {
    * @param docDir the document's own directory, used for config discovery and relative endpoints
    */
   Optional<ResolvedSchema> resolveSchema(String endpoint, Path docDir) {
-    return resolveFrom(schemaSourceOf(endpoint, docDir), docDir);
+    return resolveSchema(endpoint == null ? List.of() : List.of(endpoint), docDir);
+  }
+
+  /** {@link #resolveSchema(String, Path)} over all of a document's directives. */
+  Optional<ResolvedSchema> resolveSchema(List<String> endpoints, Path docDir) {
+    return resolveFrom(schemaSourceOf(endpoints, docDir), docDir);
+  }
+
+  /** Single-directive form of {@link #schemaSourceOf(List, Path)}. */
+  SchemaSource schemaSourceOf(String endpoint, Path docDir) {
+    return schemaSourceOf(endpoint == null ? List.of() : List.of(endpoint), docDir);
   }
 
   /**
-   * The source an endpoint directive loads its schema from — a remote SPARQL endpoint URL or a
-   * local {@code .ttl}/{@code .rdf}/{@code .owl} file — or {@code null} when the directive names no
-   * schema at all and the document's workspace schema applies instead. That is the case for a blank
-   * directive, and for two notebook-specific ones:
+   * The source a document's endpoint directives load their schema from — a remote SPARQL endpoint
+   * URL or a union of local {@code .ttl}/{@code .rdf}/{@code .owl} files (several directives and
+   * glob patterns like {@code ./rdf/*.ttl} name multiple files) — or {@code null} when the
+   * directives name no schema at all and the document's workspace schema applies instead. That is
+   * the case for a blank directive, and for these notebook-specific ones:
    *
    * <ul>
    *   <li><b>Instance data.</b> The same directive is also the cell's execution target, which may
    *       be a CIMXML model or an {@code .nt}/{@code .nq}/{@code .trig} dump. Loading data as a
-   *       schema would turn every term in the cell into a false diagnostic.
+   *       schema would turn every term in the cell into a false diagnostic. In a multi-file union,
+   *       instance-data files are skipped and only the schema files load.
    *   <li><b>An unresolvable connection name.</b> Names with no matching {@code "cimnotebook"}
    *       connection, or whose connection declares no remote URL, have no schema to offer.
+   *   <li><b>Conflicting directives.</b> Several directives are meaningful only as a union of
+   *       files; two URLs, two connection names, or a mix of kinds carry no single schema (the
+   *       client refuses to execute such cells for the same reason).
    * </ul>
    */
-  String schemaSourceOf(String endpoint, Path docDir) {
-    if (endpoint == null || endpoint.isBlank()) {
+  SchemaSource schemaSourceOf(List<String> endpoints, Path docDir) {
+    List<String> directives =
+        endpoints == null
+            ? List.of()
+            : endpoints.stream().filter(e -> e != null && !e.isBlank()).toList();
+    if (directives.isEmpty()) {
       return null;
     }
-    if (isRemote(endpoint)) {
-      return endpoint;
+    if (directives.size() == 1) {
+      String endpoint = directives.get(0);
+      if (isRemote(endpoint)) {
+        return SchemaSource.remote(endpoint);
+      }
+      if (looksLikeConnectionName(endpoint)) {
+        // Notebook cells may name a connection from the "cimnotebook" config section instead of a
+        // URL or file. Resolving it here keeps validation and execution agreeing on what the
+        // directive means: the schema loads from the connection's endpoint.
+        NotebookConnection connection =
+            NotebookConfigLoader.forDirectory(docDir).config().byName(endpoint);
+        return connection != null && connection.url() != null && isRemote(connection.url())
+            ? SchemaSource.remote(connection.url())
+            : null;
+      }
+    } else if (!directives.stream().allMatch(SchemaManager::looksLikeFile)) {
+      return null; // conflicting directives — see the javadoc
     }
-    if (looksLikeConnectionName(endpoint)) {
-      // Notebook cells may name a connection from the "cimnotebook" config section instead of a
-      // URL or file. Resolving it here keeps validation and execution agreeing on what the
-      // directive means: the schema loads from the connection's endpoint.
-      NotebookConnection connection =
-          NotebookConfigLoader.forDirectory(docDir).config().byName(endpoint);
-      return connection != null && connection.url() != null && isRemote(connection.url())
-          ? connection.url()
-          : null;
+    List<Path> schemaFiles = resolveSchemaFiles(directives, docDir);
+    return schemaFiles.isEmpty() ? null : SchemaSource.localFiles(schemaFiles);
+  }
+
+  /**
+   * Resolves file directives to the schema files they name: glob patterns expand to their matches,
+   * plain paths resolve as-is (existence is checked at load time so a missing file still warns),
+   * and non-schema files — instance data — are skipped.
+   */
+  private List<Path> resolveSchemaFiles(List<String> directives, Path docDir) {
+    var files = new LinkedHashSet<Path>();
+    for (String directive : directives) {
+      if (FileGlobs.isPattern(directive)) {
+        Path base = docDir != null ? docDir : workspaceRoot;
+        try {
+          FileGlobs.expand(directive, base).stream()
+              .filter(SchemaManager::isSchemaFile)
+              .forEach(files::add);
+        } catch (PatternSyntaxException e) {
+          LOG.debug("Ignoring invalid endpoint pattern {}: {}", directive, e.getMessage());
+        }
+        continue;
+      }
+      Path file = resolveLocalEndpoint(directive, docDir);
+      if (isSchemaFile(file)) {
+        files.add(file);
+      } else {
+        LOG.debug("Endpoint directive {} is not a schema file; using the workspace schema", file);
+      }
     }
-    Path file = resolveLocalEndpoint(endpoint, docDir);
-    if (!isSchemaFile(file)) {
-      LOG.debug("Endpoint directive {} is not a schema file; using the workspace schema", file);
-      return null;
-    }
-    return file.toString();
+    return List.copyOf(files);
   }
 
   /**
@@ -258,21 +311,29 @@ final class SchemaManager {
    * opencgmes.jsonc} above it). Empty when nothing applies: no config, a config without schemas, or
    * an endpoint that is still loading or failed — the caller then validates syntax-only.
    */
-  Optional<ResolvedSchema> resolveFrom(String source, Path docDir) {
+  Optional<ResolvedSchema> resolveFrom(SchemaSource source, Path docDir) {
     if (source == null) {
       return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
     }
-    return isRemote(source) ? resolveRemote(source) : resolveLocal(Path.of(source));
+    return source.isRemote() ? resolveRemote(source.remoteUrl()) : resolveLocal(source.files());
   }
 
   /**
-   * Whether a directive could be a named connection: no path separators, no extension dot. Only
-   * such directives pay for a config lookup; files virtually always have an extension, so
-   * "model.xml" never does, while "local-fuseki" does. (A connection whose name contains a dot or
-   * slash is not resolvable from a directive — documented limitation.)
+   * Whether a directive could be a named connection: no path separators, no extension dot, no glob
+   * metacharacters. Only such directives pay for a config lookup; files virtually always have an
+   * extension, so "model.xml" never does, while "local-fuseki" does. (A connection whose name
+   * contains a dot or slash is not resolvable from a directive — documented limitation.)
    */
   private static boolean looksLikeConnectionName(String endpoint) {
-    return !endpoint.contains("/") && !endpoint.contains("\\") && !endpoint.contains(".");
+    return !endpoint.contains("/")
+        && !endpoint.contains("\\")
+        && !endpoint.contains(".")
+        && !FileGlobs.isPattern(endpoint);
+  }
+
+  /** Whether a directive is file-ish: not a remote URL and not a plausible connection name. */
+  private static boolean looksLikeFile(String endpoint) {
+    return !isRemote(endpoint) && !looksLikeConnectionName(endpoint);
   }
 
   /** Whether a local endpoint directive names a schema file (vs instance data — see above). */
@@ -389,9 +450,9 @@ final class SchemaManager {
     return base != null ? base.resolve(endpoint).normalize() : p.normalize();
   }
 
-  /** Loads a schema from a local file synchronously (fast); caches success and failure. */
-  private Optional<ResolvedSchema> resolveLocal(Path file) {
-    String key = file.toString();
+  /** Loads a schema from local files synchronously (fast); caches success and failure. */
+  private Optional<ResolvedSchema> resolveLocal(List<Path> files) {
+    String key = files.stream().map(Path::toString).collect(Collectors.joining("\n"));
     ResolvedSchema cached = endpointCache.get(key);
     if (cached != null) {
       return Optional.of(cached);
@@ -400,26 +461,37 @@ final class SchemaManager {
       return Optional.empty();
     }
     try {
-      if (!Files.isRegularFile(file)) {
-        fail(key, MessageType.Warning, "CIMVocabCheck: endpoint schema file not found: " + file);
+      List<Path> missing = files.stream().filter(f -> !Files.isRegularFile(f)).toList();
+      if (!missing.isEmpty()) {
+        fail(
+            key,
+            MessageType.Warning,
+            "CIMVocabCheck: endpoint schema file not found: " + describeFiles(missing));
         return Optional.empty();
       }
       // loadIndexWithSources (rather than loadIndex) keeps the VersionIri → Path mapping so a
       // DefinitionIndex can be built below — go-to-definition on a local-file endpoint must jump
       // into that real file, not fall back to the remote-only EndpointDefinitionPeek.
-      var loaded = CgmesSchemaLoader.fromFiles(List.of(file)).loadIndexWithSources();
+      var loaded = CgmesSchemaLoader.fromFiles(files).loadIndexWithSources();
       var defIndex = DefinitionIndex.build(loaded.index(), loaded.sourcePaths());
       ResolvedSchema schema = buildSchema(loaded.index(), Map.of(), defIndex);
       endpointCache.put(key, schema);
-      LOG.info("Loaded endpoint schema from file {}", file);
+      LOG.info("Loaded endpoint schema from {}", describeFiles(files));
       return Optional.of(schema);
     } catch (Exception e) {
       fail(
           key,
           MessageType.Error,
-          "CIMVocabCheck: failed to load schema from " + file + " — " + e.getMessage());
+          "CIMVocabCheck: failed to load schema from "
+              + describeFiles(files)
+              + " — "
+              + e.getMessage());
       return Optional.empty();
     }
+  }
+
+  private static String describeFiles(List<Path> files) {
+    return files.stream().map(Path::toString).collect(Collectors.joining(", "));
   }
 
   /**

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -126,6 +127,13 @@ final class SchemaManager {
   /** How long a failed endpoint load is negatively cached before a retry is allowed. */
   private static final Duration FAILURE_TTL = Duration.ofSeconds(30);
 
+  /**
+   * Extensions a local {@code # [endpoint=...]} directive must have to be loaded as a schema.
+   * Anything else (a CIMXML {@code .xml} model, {@code .nt}/{@code .nq}/{@code .trig} data) is
+   * instance data for notebook execution, not a schema — see {@link #resolveSchema}.
+   */
+  private static final Set<String> SCHEMA_FILE_EXTENSIONS = Set.of("ttl", "rdf", "owl");
+
   /** Schemas loaded from a {@code # [endpoint=...]} directive, keyed by resolved source. */
   private final Map<String, ResolvedSchema> endpointCache = new ConcurrentHashMap<>();
 
@@ -206,9 +214,27 @@ final class SchemaManager {
     if (endpoint == null || endpoint.isBlank()) {
       return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
     }
-    return isRemote(endpoint)
-        ? resolveRemote(endpoint)
-        : resolveLocal(resolveLocalEndpoint(endpoint, docDir));
+    if (isRemote(endpoint)) {
+      return resolveRemote(endpoint);
+    }
+    Path file = resolveLocalEndpoint(endpoint, docDir);
+    if (!isSchemaFile(file)) {
+      // The same # [endpoint=...] directive is also the notebook execution target, which may be
+      // instance data (a CIMXML model, an .nt/.nq/.trig dump). Loading that as a schema would
+      // produce misleading diagnostics, so validation quietly keeps the workspace schema instead.
+      LOG.debug("Endpoint directive {} is not a schema file; using the workspace schema", file);
+      return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
+    }
+    return resolveLocal(file);
+  }
+
+  /** Whether a local endpoint directive names a schema file (vs instance data — see above). */
+  private static boolean isSchemaFile(Path file) {
+    Path fileName = file.getFileName();
+    String name = fileName != null ? fileName.toString() : "";
+    int dot = name.lastIndexOf('.');
+    String extension = dot >= 0 ? name.substring(dot + 1).toLowerCase(Locale.ROOT) : "";
+    return SCHEMA_FILE_EXTENSIONS.contains(extension);
   }
 
   /**

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
@@ -28,6 +28,8 @@ import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.EndpointSchema;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.EndpointSchemaLoader;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.RdfsSchemaIndex;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConfigLoader;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConnection;
 import de.soptim.opencgmes.cimvocabcheck.lsp.schema.SchemaLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -199,33 +201,78 @@ final class SchemaManager {
   }
 
   /**
-   * Resolves the schema a document should be validated against.
-   *
-   * <p>When {@code endpoint} is {@code null}/blank, the document's workspace schema is used: the
-   * nearest {@code opencgmes.jsonc} above the document. When none is found (or it declares no
-   * schemas) the result is empty and the caller validates syntax-only. Otherwise the schema is
-   * loaded from the endpoint — a local {@code .ttl}/{@code .rdf}/{@code .owl} file or a remote
-   * SPARQL endpoint — and cached by resolved source.
+   * Resolves the schema a document should be validated against — {@link #schemaSourceOf} followed
+   * by {@link #resolveFrom}. Callers that also need to know <em>whether</em> the endpoint is a
+   * schema source (to tell a failed endpoint apart from one that never was one) should call the two
+   * separately.
    *
    * @param endpoint the {@code # [endpoint=...]} value, or {@code null} for the workspace schema
    * @param docDir the document's own directory, used for config discovery and relative endpoints
    */
   Optional<ResolvedSchema> resolveSchema(String endpoint, Path docDir) {
+    return resolveFrom(schemaSourceOf(endpoint, docDir), docDir);
+  }
+
+  /**
+   * The source an endpoint directive loads its schema from — a remote SPARQL endpoint URL or a
+   * local {@code .ttl}/{@code .rdf}/{@code .owl} file — or {@code null} when the directive names no
+   * schema at all and the document's workspace schema applies instead. That is the case for a blank
+   * directive, and for two notebook-specific ones:
+   *
+   * <ul>
+   *   <li><b>Instance data.</b> The same directive is also the cell's execution target, which may
+   *       be a CIMXML model or an {@code .nt}/{@code .nq}/{@code .trig} dump. Loading data as a
+   *       schema would turn every term in the cell into a false diagnostic.
+   *   <li><b>An unresolvable connection name.</b> Names with no matching {@code "cimnotebook"}
+   *       connection, or whose connection declares no remote URL, have no schema to offer.
+   * </ul>
+   */
+  String schemaSourceOf(String endpoint, Path docDir) {
     if (endpoint == null || endpoint.isBlank()) {
-      return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
+      return null;
     }
     if (isRemote(endpoint)) {
-      return resolveRemote(endpoint);
+      return endpoint;
+    }
+    if (looksLikeConnectionName(endpoint)) {
+      // Notebook cells may name a connection from the "cimnotebook" config section instead of a
+      // URL or file. Resolving it here keeps validation and execution agreeing on what the
+      // directive means: the schema loads from the connection's endpoint.
+      NotebookConnection connection =
+          NotebookConfigLoader.forDirectory(docDir).config().byName(endpoint);
+      return connection != null && connection.url() != null && isRemote(connection.url())
+          ? connection.url()
+          : null;
     }
     Path file = resolveLocalEndpoint(endpoint, docDir);
     if (!isSchemaFile(file)) {
-      // The same # [endpoint=...] directive is also the notebook execution target, which may be
-      // instance data (a CIMXML model, an .nt/.nq/.trig dump). Loading that as a schema would
-      // produce misleading diagnostics, so validation quietly keeps the workspace schema instead.
       LOG.debug("Endpoint directive {} is not a schema file; using the workspace schema", file);
+      return null;
+    }
+    return file.toString();
+  }
+
+  /**
+   * Loads the schema from a {@link #schemaSourceOf} result, caching it by source; {@code null} —
+   * i.e. no schema source — falls back to the document's workspace schema (the nearest {@code
+   * opencgmes.jsonc} above it). Empty when nothing applies: no config, a config without schemas, or
+   * an endpoint that is still loading or failed — the caller then validates syntax-only.
+   */
+  Optional<ResolvedSchema> resolveFrom(String source, Path docDir) {
+    if (source == null) {
       return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
     }
-    return resolveLocal(file);
+    return isRemote(source) ? resolveRemote(source) : resolveLocal(Path.of(source));
+  }
+
+  /**
+   * Whether a directive could be a named connection: no path separators, no extension dot. Only
+   * such directives pay for a config lookup; files virtually always have an extension, so
+   * "model.xml" never does, while "local-fuseki" does. (A connection whose name contains a dot or
+   * slash is not resolvable from a directive — documented limitation.)
+   */
+  private static boolean looksLikeConnectionName(String endpoint) {
+    return !endpoint.contains("/") && !endpoint.contains("\\") && !endpoint.contains(".");
   }
 
   /** Whether a local endpoint directive names a schema file (vs instance data — see above). */

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaSource.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaSource.java
@@ -1,0 +1,42 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Where a document's {@code # [endpoint=...]} schema comes from: a remote SPARQL endpoint URL, or
+ * one or more local schema files — several directives and glob patterns form a union of files.
+ * Exactly one of the two components is set.
+ */
+record SchemaSource(String remoteUrl, List<Path> files) {
+
+  static SchemaSource remote(String url) {
+    return new SchemaSource(url, null);
+  }
+
+  static SchemaSource localFiles(List<Path> files) {
+    return new SchemaSource(null, List.copyOf(files));
+  }
+
+  boolean isRemote() {
+    return remoteUrl != null;
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlLanguageServer.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlLanguageServer.java
@@ -74,11 +74,16 @@ public final class SparqlLanguageServer implements LanguageServer, LanguageClien
   /** Creates the server and wires up its document, workspace, and schema services. */
   public SparqlLanguageServer() {
     schemaManager = new SchemaManager();
-    textDocumentService = new SparqlTextDocumentService(schemaManager);
+    NotebookDefaults notebookDefaults = new NotebookDefaults();
+    textDocumentService = new SparqlTextDocumentService(schemaManager, notebookDefaults);
     notebookCommandHandler = new NotebookCommandHandler();
-    workspaceService = new SparqlWorkspaceService(schemaManager, notebookCommandHandler);
+    workspaceService =
+        new SparqlWorkspaceService(schemaManager, notebookCommandHandler, notebookDefaults);
     // After each successful schema load, revalidate all open documents.
     schemaManager.addOnLoadedCallback(textDocumentService::revalidateAll);
+    // Likewise when a notebook's default endpoint changes: its directive-less cells now validate
+    // against a different schema.
+    notebookDefaults.addOnChangeCallback(textDocumentService::revalidateAll);
   }
 
   // ---- LanguageClientAware ---------------------------------------------------------------

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlLanguageServer.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlLanguageServer.java
@@ -19,6 +19,7 @@
 package de.soptim.opencgmes.cimvocabcheck.lsp;
 
 import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookCommandHandler;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
@@ -66,6 +67,7 @@ public final class SparqlLanguageServer implements LanguageServer, LanguageClien
   private final SchemaManager schemaManager;
   private final SparqlTextDocumentService textDocumentService;
   private final SparqlWorkspaceService workspaceService;
+  private final NotebookCommandHandler notebookCommandHandler;
 
   private LanguageClient client;
 
@@ -73,7 +75,8 @@ public final class SparqlLanguageServer implements LanguageServer, LanguageClien
   public SparqlLanguageServer() {
     schemaManager = new SchemaManager();
     textDocumentService = new SparqlTextDocumentService(schemaManager);
-    workspaceService = new SparqlWorkspaceService(schemaManager);
+    notebookCommandHandler = new NotebookCommandHandler();
+    workspaceService = new SparqlWorkspaceService(schemaManager, notebookCommandHandler);
     // After each successful schema load, revalidate all open documents.
     schemaManager.addOnLoadedCallback(textDocumentService::revalidateAll);
   }
@@ -143,6 +146,7 @@ public final class SparqlLanguageServer implements LanguageServer, LanguageClien
   public CompletableFuture<Object> shutdown() {
     schemaManager.shutdown();
     textDocumentService.shutdown();
+    notebookCommandHandler.shutdown();
     return CompletableFuture.completedFuture(null);
   }
 

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlTextDocumentService.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlTextDocumentService.java
@@ -31,7 +31,8 @@ import de.soptim.opencgmes.cimvocabcheck.core.schema.SchemaIndex;
 import de.soptim.opencgmes.cimvocabcheck.core.shacl.EmbeddedSourceMapper;
 import de.soptim.opencgmes.cimvocabcheck.core.shacl.EmbeddedSparql;
 import de.soptim.opencgmes.cimvocabcheck.core.shacl.ShaclValidationResult;
-import java.net.URI;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConfigLoader;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConnection;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -96,6 +97,7 @@ final class SparqlTextDocumentService implements TextDocumentService {
   private static final long DEBOUNCE_MS = 300;
 
   private final SchemaManager schemaManager;
+  private final NotebookDefaults notebookDefaults;
   private final AtomicReference<LanguageClient> client = new AtomicReference<>();
 
   /** Whether a document is validated as SPARQL or as SHACL/Turtle. */
@@ -128,8 +130,9 @@ final class SparqlTextDocumentService implements TextDocumentService {
   private final EndpointDefinitionPeek endpointPeek =
       new EndpointDefinitionPeek(Duration.ofSeconds(15));
 
-  SparqlTextDocumentService(SchemaManager schemaManager) {
+  SparqlTextDocumentService(SchemaManager schemaManager, NotebookDefaults notebookDefaults) {
     this.schemaManager = schemaManager;
+    this.notebookDefaults = notebookDefaults;
   }
 
   void setClient(LanguageClient client) {
@@ -218,9 +221,10 @@ final class SparqlTextDocumentService implements TextDocumentService {
       // files. A local-file endpoint has a real source file to jump to, via the same
       // DefinitionIndex mechanism as a workspace schema; a remote SPARQL endpoint has none, so
       // the term's triples are fetched and opened as a generated read-only Turtle "peek" instead.
-      String endpoint = EndpointDirective.parse(text).orElse(null);
-      if (endpoint != null) {
-        var rsOpt = schemaManager.resolveSchema(endpoint, documentDir(uri));
+      Path docDir = documentDir(uri);
+      String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+      if (source != null) {
+        var rsOpt = schemaManager.resolveFrom(source, docDir);
         if (rsOpt.isEmpty() || !termKnown(rsOpt.get().api().schemaIndex(), term)) {
           return noDefinition();
         }
@@ -232,13 +236,13 @@ final class SparqlTextDocumentService implements TextDocumentService {
               .orElseGet(SparqlTextDocumentService::noDefinition);
         }
         return endpointPeek
-            .locationFor(endpoint, term.getURI())
+            .locationFor(source, term.getURI())
             .map(SparqlTextDocumentService::definitionAt)
             .orElseGet(SparqlTextDocumentService::noDefinition);
       }
 
       // Workspace document: jump into the local RDFS source file.
-      var wsOpt = schemaManager.workspaceSchemaFor(documentDir(uri));
+      var wsOpt = schemaManager.workspaceSchemaFor(docDir);
       if (wsOpt.isEmpty() || wsOpt.get().definitionIndex() == null) {
         return noDefinition();
       }
@@ -333,17 +337,46 @@ final class SparqlTextDocumentService implements TextDocumentService {
 
   /**
    * The schema index a document's IDE features (hover, completion, definition) should consult: the
-   * {@code # [endpoint=...]} schema when the document declares one and it has resolved, otherwise
-   * the document's workspace schema (nearest {@code opencgmes.jsonc}). Returns empty when no schema
-   * applies — no config / config without schemas, or an endpoint not yet available (still loading,
-   * or the load failed) — so the editor never shows information from the wrong (workspace) schema
-   * for an endpoint document.
+   * {@link #effectiveEndpoint} schema when one applies and has resolved, otherwise the document's
+   * workspace schema (nearest {@code opencgmes.jsonc}). Returns empty when no schema applies — no
+   * config / config without schemas, or an endpoint not yet available (still loading, or the load
+   * failed) — so the editor never shows information from the wrong (workspace) schema for an
+   * endpoint document.
    */
   private Optional<SchemaIndex> documentSchemaIndex(String uri, String text) {
-    String endpoint = EndpointDirective.parse(text).orElse(null);
     return schemaManager
-        .resolveSchema(endpoint, documentDir(uri))
+        .resolveSchema(effectiveEndpoint(uri, text), documentDir(uri))
         .map(rs -> rs.api().schemaIndex());
+  }
+
+  /**
+   * The endpoint a document's schema comes from.
+   *
+   * <p>The precedence mirrors the one the VS Code client uses to pick a cell's <em>execution</em>
+   * target, so a cell validates against what it runs against:
+   *
+   * <ol>
+   *   <li>the document's own {@code # [endpoint=...]} directive;
+   *   <li>for notebook cells, the {@link NotebookDefaults notebook default} the client set;
+   *   <li>for notebook cells, the {@code "cimnotebook"} connection marked {@code "default": true}.
+   * </ol>
+   *
+   * <p>Returns {@code null} when none applies — the document then uses its workspace schema. Only
+   * cells consult the notebook fallbacks: a stand-alone {@code .rq}/{@code .ttl} file is not part
+   * of a notebook and keeps its workspace schema.
+   */
+  private String effectiveEndpoint(String uri, String text) {
+    String directive = EndpointDirective.parse(text).orElse(null);
+    if (directive != null || !DocumentUris.isNotebookCell(uri)) {
+      return directive;
+    }
+    String notebookDefault = notebookDefaults.forCell(uri);
+    if (notebookDefault != null) {
+      return notebookDefault;
+    }
+    NotebookConnection defaultConnection =
+        NotebookConfigLoader.forDirectory(documentDir(uri)).config().defaultConnection();
+    return defaultConnection != null ? defaultConnection.url() : null;
   }
 
   // ---- Internal API ----------------------------------------------------------------------
@@ -383,16 +416,18 @@ final class SparqlTextDocumentService implements TextDocumentService {
       return;
     }
 
-    // A SPARQL Notebook cell may declare its schema source via "# [endpoint=...]"; otherwise the
-    // document's workspace schema (nearest opencgmes.jsonc) is used. With neither, validation is
-    // syntax-only — there is no bundled default schema.
-    String endpoint = EndpointDirective.parse(text).orElse(null);
-    var schemaOpt = schemaManager.resolveSchema(endpoint, documentDir(uri));
+    // A notebook cell may declare its schema source via "# [endpoint=...]" (or inherit one from the
+    // notebook default / the default connection); otherwise the document's workspace schema
+    // (nearest opencgmes.jsonc) is used. With neither, validation is syntax-only — there is no
+    // bundled default schema.
+    Path docDir = documentDir(uri);
+    String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+    var schemaOpt = schemaManager.resolveFrom(source, docDir);
     if (schemaOpt.isEmpty()) {
       // No schema resolved: an endpoint that failed / is still loading, or no config + no
       // endpoint. Fall back to a schema-independent syntax check so broken SPARQL still gets
       // squiggles; flag the endpoint case as an error (the others are the normal no-config state).
-      publishSyntaxOnly(uri, text, endpoint != null);
+      publishSyntaxOnly(uri, text, source != null);
       return;
     }
 
@@ -598,13 +633,14 @@ final class SparqlTextDocumentService implements TextDocumentService {
       return;
     }
 
-    String endpoint = EndpointDirective.parse(text).orElse(null);
-    var schemaOpt = schemaManager.resolveSchema(endpoint, documentDir(uri));
+    Path docDir = documentDir(uri);
+    String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+    var schemaOpt = schemaManager.resolveFrom(source, docDir);
     if (schemaOpt.isEmpty()) {
       // No schema resolved: an endpoint that failed / is still loading, or no config + no
       // endpoint. Fall back to a schema-independent check (Turtle parse, embedded-SPARQL
       // syntax, vocabulary typos); flag the endpoint case as an error.
-      publishShaclSyntaxOnly(uri, text, endpoint != null);
+      publishShaclSyntaxOnly(uri, text, source != null);
       return;
     }
     ResolvedSchema schema = schemaOpt.get();
@@ -970,31 +1006,12 @@ final class SparqlTextDocumentService implements TextDocumentService {
   }
 
   /**
-   * Best-effort parent directory of a document URI, used to resolve relative endpoint paths.
-   *
-   * <p>Handles both {@code file://} URIs and notebook cell URIs such as {@code
-   * vscode-notebook-cell:/path/to/notebook.sparqlbook#<cell-id>} — the fragment (cell id) is
-   * stripped so the notebook file's directory is returned.
+   * Best-effort parent directory of a document URI, used for config discovery and to resolve
+   * relative endpoint paths. Notebook cells resolve against the notebook file's directory — see
+   * {@link DocumentUris}.
    */
   static Path documentDir(String uri) {
-    try {
-      int hash = uri.indexOf('#');
-      String noFragment = hash >= 0 ? uri.substring(0, hash) : uri;
-      URI parsed = URI.create(noFragment);
-      if ("file".equalsIgnoreCase(parsed.getScheme())) {
-        return Path.of(parsed).getParent();
-      }
-      String p = parsed.getPath();
-      if (p == null || p.isBlank()) {
-        return null;
-      }
-      if (p.length() >= 3 && p.charAt(0) == '/' && p.charAt(2) == ':') {
-        p = p.substring(1);
-      }
-      return Path.of(p).getParent();
-    } catch (Exception e) {
-      return null;
-    }
+    return DocumentUris.dir(uri);
   }
 
   private static boolean isSparqlFile(String uri) {

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlTextDocumentService.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlTextDocumentService.java
@@ -222,7 +222,7 @@ final class SparqlTextDocumentService implements TextDocumentService {
       // DefinitionIndex mechanism as a workspace schema; a remote SPARQL endpoint has none, so
       // the term's triples are fetched and opened as a generated read-only Turtle "peek" instead.
       Path docDir = documentDir(uri);
-      String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+      SchemaSource source = schemaManager.schemaSourceOf(effectiveEndpoints(uri, text), docDir);
       if (source != null) {
         var rsOpt = schemaManager.resolveFrom(source, docDir);
         if (rsOpt.isEmpty() || !termKnown(rsOpt.get().api().schemaIndex(), term)) {
@@ -235,8 +235,9 @@ final class SparqlTextDocumentService implements TextDocumentService {
               .map(SparqlTextDocumentService::definitionAt)
               .orElseGet(SparqlTextDocumentService::noDefinition);
         }
+        // No DefinitionIndex means the schema came from a remote SPARQL endpoint.
         return endpointPeek
-            .locationFor(source, term.getURI())
+            .locationFor(source.remoteUrl(), term.getURI())
             .map(SparqlTextDocumentService::definitionAt)
             .orElseGet(SparqlTextDocumentService::noDefinition);
       }
@@ -345,38 +346,41 @@ final class SparqlTextDocumentService implements TextDocumentService {
    */
   private Optional<SchemaIndex> documentSchemaIndex(String uri, String text) {
     return schemaManager
-        .resolveSchema(effectiveEndpoint(uri, text), documentDir(uri))
+        .resolveSchema(effectiveEndpoints(uri, text), documentDir(uri))
         .map(rs -> rs.api().schemaIndex());
   }
 
   /**
-   * The endpoint a document's schema comes from.
+   * The endpoint(s) a document's schema comes from — several file directives (or a glob pattern)
+   * form a union of local files.
    *
    * <p>The precedence mirrors the one the VS Code client uses to pick a cell's <em>execution</em>
    * target, so a cell validates against what it runs against:
    *
    * <ol>
-   *   <li>the document's own {@code # [endpoint=...]} directive;
+   *   <li>the document's own {@code # [endpoint=...]} directives;
    *   <li>for notebook cells, the {@link NotebookDefaults notebook default} the client set;
    *   <li>for notebook cells, the {@code "cimnotebook"} connection marked {@code "default": true}.
    * </ol>
    *
-   * <p>Returns {@code null} when none applies — the document then uses its workspace schema. Only
+   * <p>Returns an empty list when none applies — the document then uses its workspace schema. Only
    * cells consult the notebook fallbacks: a stand-alone {@code .rq}/{@code .ttl} file is not part
    * of a notebook and keeps its workspace schema.
    */
-  private String effectiveEndpoint(String uri, String text) {
-    String directive = EndpointDirective.parse(text).orElse(null);
-    if (directive != null || !DocumentUris.isNotebookCell(uri)) {
-      return directive;
+  private List<String> effectiveEndpoints(String uri, String text) {
+    List<String> directives = EndpointDirective.parseAll(text);
+    if (!directives.isEmpty() || !DocumentUris.isNotebookCell(uri)) {
+      return directives;
     }
     String notebookDefault = notebookDefaults.forCell(uri);
     if (notebookDefault != null) {
-      return notebookDefault;
+      return List.of(notebookDefault);
     }
     NotebookConnection defaultConnection =
         NotebookConfigLoader.forDirectory(documentDir(uri)).config().defaultConnection();
-    return defaultConnection != null ? defaultConnection.url() : null;
+    return defaultConnection != null && defaultConnection.url() != null
+        ? List.of(defaultConnection.url())
+        : List.of();
   }
 
   // ---- Internal API ----------------------------------------------------------------------
@@ -421,7 +425,7 @@ final class SparqlTextDocumentService implements TextDocumentService {
     // (nearest opencgmes.jsonc) is used. With neither, validation is syntax-only — there is no
     // bundled default schema.
     Path docDir = documentDir(uri);
-    String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+    SchemaSource source = schemaManager.schemaSourceOf(effectiveEndpoints(uri, text), docDir);
     var schemaOpt = schemaManager.resolveFrom(source, docDir);
     if (schemaOpt.isEmpty()) {
       // No schema resolved: an endpoint that failed / is still loading, or no config + no
@@ -634,7 +638,7 @@ final class SparqlTextDocumentService implements TextDocumentService {
     }
 
     Path docDir = documentDir(uri);
-    String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+    SchemaSource source = schemaManager.schemaSourceOf(effectiveEndpoints(uri, text), docDir);
     var schemaOpt = schemaManager.resolveFrom(source, docDir);
     if (schemaOpt.isEmpty()) {
       // No schema resolved: an endpoint that failed / is still loading, or no config + no

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlWorkspaceService.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlWorkspaceService.java
@@ -58,13 +58,24 @@ final class SparqlWorkspaceService implements WorkspaceService {
    */
   static final String CMD_CREATE_CONFIG = "cimvocabcheck.createConfig";
 
+  /**
+   * Command id for the per-notebook default endpoint (see {@link NotebookDefaults}). The client
+   * sends {@code {"notebookUri": "...", "endpoint": "..."}} whenever the user picks a notebook
+   * default, and re-sends the notebook defaults it remembers when the server starts.
+   */
+  static final String CMD_SET_DEFAULT_ENDPOINT = "cimvocabcheck.notebook.setDefaultEndpoint";
+
   private final SchemaManager schemaManager;
   private final NotebookCommandHandler notebookCommandHandler;
+  private final NotebookDefaults notebookDefaults;
 
   SparqlWorkspaceService(
-      SchemaManager schemaManager, NotebookCommandHandler notebookCommandHandler) {
+      SchemaManager schemaManager,
+      NotebookCommandHandler notebookCommandHandler,
+      NotebookDefaults notebookDefaults) {
     this.schemaManager = schemaManager;
     this.notebookCommandHandler = notebookCommandHandler;
+    this.notebookDefaults = notebookDefaults;
   }
 
   @Override
@@ -98,6 +109,13 @@ final class SparqlWorkspaceService implements WorkspaceService {
     }
     if (NotebookCommandHandler.CMD_EXECUTE.equals(params.getCommand())) {
       return notebookCommandHandler.executeCommand(params.getArguments());
+    }
+    if (NotebookCommandHandler.CMD_LIST_CONNECTIONS.equals(params.getCommand())) {
+      return notebookCommandHandler.listConnections(params.getArguments());
+    }
+    if (CMD_SET_DEFAULT_ENDPOINT.equals(params.getCommand())) {
+      notebookDefaults.apply(params.getArguments());
+      return CompletableFuture.completedFuture(null);
     }
     if (!CMD_EXPLAIN_QUERY.equals(params.getCommand())) {
       LOG.warn("Unknown command: {}", params.getCommand());

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlWorkspaceService.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlWorkspaceService.java
@@ -24,6 +24,7 @@ import de.soptim.opencgmes.cimvocabcheck.core.ConfigTemplate;
 import de.soptim.opencgmes.cimvocabcheck.core.SparqlValidationApi;
 import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
 import de.soptim.opencgmes.cimvocabcheck.core.explain.QueryExplanation;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookCommandHandler;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
@@ -58,9 +59,12 @@ final class SparqlWorkspaceService implements WorkspaceService {
   static final String CMD_CREATE_CONFIG = "cimvocabcheck.createConfig";
 
   private final SchemaManager schemaManager;
+  private final NotebookCommandHandler notebookCommandHandler;
 
-  SparqlWorkspaceService(SchemaManager schemaManager) {
+  SparqlWorkspaceService(
+      SchemaManager schemaManager, NotebookCommandHandler notebookCommandHandler) {
     this.schemaManager = schemaManager;
+    this.notebookCommandHandler = notebookCommandHandler;
   }
 
   @Override
@@ -91,6 +95,9 @@ final class SparqlWorkspaceService implements WorkspaceService {
   public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
     if (CMD_CREATE_CONFIG.equals(params.getCommand())) {
       return CompletableFuture.completedFuture(ConfigTemplate.defaultJson());
+    }
+    if (NotebookCommandHandler.CMD_EXECUTE.equals(params.getCommand())) {
+      return notebookCommandHandler.executeCommand(params.getArguments());
     }
     if (!CMD_EXPLAIN_QUERY.equals(params.getCommand())) {
       LOG.warn("Unknown command: {}", params.getCommand());

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CancellationWatchdog.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CancellationWatchdog.java
@@ -1,0 +1,73 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Polls a {@link CancelChecker} on a background scheduler and runs a callback the first time it
+ * reports cancellation.
+ *
+ * <p>Used by {@link HttpQueryExecutor} to react to a client-sent {@code $/cancelRequest}, since
+ * Jena's blocking HTTP execution calls have no cancellation hook of their own — polling {@link
+ * CancelChecker#isCanceled()} (a non-throwing check) is simpler here than reacting to {@link
+ * CancelChecker#checkCanceled()}'s thrown exception on every poll.
+ */
+final class CancellationWatchdog {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CancellationWatchdog.class);
+  private static final long POLL_INTERVAL_MS = 250;
+
+  private CancellationWatchdog() {}
+
+  /**
+   * Starts polling {@code cancelChecker} every {@value #POLL_INTERVAL_MS}ms on {@code scheduler}.
+   * The first poll that observes cancellation runs {@code onCancel} exactly once. The caller must
+   * cancel the returned task (typically in a {@code finally} block) once the guarded operation
+   * finishes, whether normally or exceptionally.
+   */
+  static ScheduledFuture<?> watch(
+      ScheduledExecutorService scheduler, CancelChecker cancelChecker, Runnable onCancel) {
+    AtomicBoolean triggered = new AtomicBoolean(false);
+    return scheduler.scheduleWithFixedDelay(
+        () -> {
+          if (cancelChecker.isCanceled() && triggered.compareAndSet(false, true)) {
+            try {
+              onCancel.run();
+            } catch (RuntimeException e) {
+              // The guarded operation may already have finished on its own (e.g. the abort()
+              // callback racing a just-completed execution) — this is a best-effort signal, not
+              // a hard requirement, so a failure here is logged and swallowed rather than
+              // propagated to the scheduler (which would otherwise silently stop future polls).
+              LOG.debug(
+                  "Cancellation callback failed (likely already finished): {}", e.getMessage());
+            }
+          }
+        },
+        POLL_INTERVAL_MS,
+        POLL_INTERVAL_MS,
+        TimeUnit.MILLISECONDS);
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CommandArguments.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CommandArguments.java
@@ -1,0 +1,51 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import java.util.List;
+
+/**
+ * Decoding of {@code workspace/executeCommand} arguments shared by the notebook commands.
+ *
+ * <p>Over JSON-RPC, lsp4j delivers arguments as Gson {@link JsonElement}s; a direct in-process call
+ * may pass a JSON {@link String} instead. Every notebook command takes a single JSON-object
+ * argument, so the dual-case coercion lives here rather than in each handler.
+ */
+public final class CommandArguments {
+
+  private static final Gson GSON = new Gson();
+
+  private CommandArguments() {}
+
+  /**
+   * The command's first argument as JSON, or {@code null} when there is none (or it is JSON {@code
+   * null}). Throws Gson's {@code JsonSyntaxException} when a String argument is not JSON.
+   */
+  public static JsonElement firstAsJson(List<Object> arguments) {
+    if (arguments == null || arguments.isEmpty() || arguments.get(0) == null) {
+      return null;
+    }
+    Object first = arguments.get(0);
+    JsonElement el =
+        first instanceof JsonElement je ? je : GSON.fromJson(first.toString(), JsonElement.class);
+    return el == null || el.isJsonNull() ? null : el;
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
@@ -18,12 +18,7 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
-/**
- * Machine-readable failure reason reported in {@link ExecError#code()}.
- *
- * <p>Local-file targets (and their file-specific failure modes) are added once local-file execution
- * is implemented; every code needed for HTTP-endpoint execution is declared here.
- */
+/** Machine-readable failure reason reported in {@link ExecError#code()}. */
 enum ErrorCode {
   /** The command argument could not be parsed as an {@link ExecuteRequest} at all. */
   INVALID_REQUEST,
@@ -35,10 +30,17 @@ enum ErrorCode {
   PARSE_ERROR,
 
   /**
-   * The cell parsed as a SPARQL Update, but its target has no update endpoint configured (see
-   * {@link ExecuteTarget#updateUrl()}).
+   * The cell parsed as a SPARQL Update, but its target cannot execute updates: an HTTP target
+   * without an update endpoint (see {@link ExecuteTarget#updateUrl()}), or a read-only local-file
+   * target.
    */
   UPDATE_NOT_ALLOWED,
+
+  /** A file named in {@link ExecuteTarget#files()} does not exist (or is not a regular file). */
+  FILE_NOT_FOUND,
+
+  /** A file named in {@link ExecuteTarget#files()} could not be parsed as RDF/CIMXML. */
+  FILE_PARSE_ERROR,
 
   /** The endpoint answered with an HTTP error, or the connection otherwise failed. */
   HTTP_ERROR,

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
@@ -1,0 +1,57 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Machine-readable failure reason reported in {@link ExecError#code()}.
+ *
+ * <p>Local-file targets (and their file-specific failure modes) are added once local-file execution
+ * is implemented; every code needed for HTTP-endpoint execution is declared here.
+ */
+enum ErrorCode {
+  /** The command argument could not be parsed as an {@link ExecuteRequest} at all. */
+  INVALID_REQUEST,
+
+  /** No endpoint is configured for the cell (missing/blank {@code target}). */
+  NO_TARGET,
+
+  /** The cell's text is neither a valid SPARQL query nor a valid SPARQL Update request. */
+  PARSE_ERROR,
+
+  /**
+   * The cell parsed as a SPARQL Update, but its target has no update endpoint configured (see
+   * {@link ExecuteTarget#updateUrl()}).
+   */
+  UPDATE_NOT_ALLOWED,
+
+  /** The endpoint answered with an HTTP error, or the connection otherwise failed. */
+  HTTP_ERROR,
+
+  /** The endpoint rejected the request as unauthorized/forbidden (HTTP 401/403). */
+  AUTH_FAILED,
+
+  /** The request did not complete within the configured timeout. */
+  TIMEOUT,
+
+  /** The client cancelled the execution before it completed. */
+  CANCELLED,
+
+  /** An unexpected internal error occurred while handling the request. */
+  INTERNAL
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
@@ -18,11 +18,13 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
-/** Machine-readable failure reason reported in {@link ExecError#code()}. */
+/**
+ * Machine-readable failure reason reported in {@link ExecError#code()}.
+ *
+ * <p>A malformed command argument never reaches these codes — it is rejected at the JSON-RPC level
+ * as an {@code InvalidParams} response error (see {@code NotebookCommandHandler}).
+ */
 enum ErrorCode {
-  /** The command argument could not be parsed as an {@link ExecuteRequest} at all. */
-  INVALID_REQUEST,
-
   /** No endpoint is configured for the cell (missing/blank {@code target}). */
   NO_TARGET,
 

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecAuth.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecAuth.java
@@ -1,0 +1,41 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Credentials for an HTTP target, attached by the client per execute request. This is the
+ * <b>only</b> place credentials ever travel: the client keeps them in VS Code SecretStorage (never
+ * in {@code opencgmes.jsonc}), and the server uses them solely to build the request's {@code
+ * Authorization} header — they are never logged, cached, or echoed back in responses.
+ *
+ * @param type the scheme; only {@code "basic"} is understood.
+ * @param username the user name.
+ * @param password the password; may be empty.
+ */
+record ExecAuth(String type, String username, String password) {
+
+  /** The only {@link #type()} understood. */
+  static final String TYPE_BASIC = "basic";
+
+  /** Redacts credentials wherever a record accidentally ends up in a log or error message. */
+  @Override
+  public String toString() {
+    return "ExecAuth[type=" + type + ", username=***, password=***]";
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecContext.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecContext.java
@@ -18,12 +18,16 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
 /**
- * Per-execution overrides for the server-side defaults (see {@link ExecSupport#DEFAULT_TIMEOUT_MS}
- * / {@link ExecSupport#DEFAULT_MAX_ROWS}).
- *
- * @param timeoutMs request timeout in milliseconds, or {@code null} to use the default.
- * @param maxRows maximum number of solutions/triples to include in the result before truncating, or
- *     {@code null} to use the default.
+ * Resources a single cell execution needs for cancellation wiring, bundled to keep the executor
+ * call sites short. Shared by {@link HttpQueryExecutor} and {@link LocalQueryExecutor} via {@link
+ * ExecSupport#runCancellable}.
  */
-record ExecuteOptions(Integer timeoutMs, Integer maxRows) {}
+record ExecContext(
+    ExecutorService executionPool,
+    ScheduledExecutorService watchdogScheduler,
+    CancelChecker cancelChecker) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecError.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecError.java
@@ -1,0 +1,37 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Failure details reported when {@link ExecuteResponse#status()} is not {@code SUCCESS}.
+ *
+ * @param code machine-readable failure reason: the {@link ErrorCode} name. Carried as a string
+ *     because lsp4j's message Gson serializes enum fields as ordinals, which no client should have
+ *     to decode (pinned by {@code NotebookCommandHandlerTest}).
+ * @param message human-readable message, suitable for display in the cell's error output.
+ * @param detail additional detail (e.g. a parser error's underlying cause); {@code null} if none.
+ * @param line 1-based source line of a parse error; {@code null} if not applicable/unknown.
+ * @param column 1-based source column of a parse error; {@code null} if not applicable/unknown.
+ */
+record ExecError(String code, String message, String detail, Integer line, Integer column) {
+
+  ExecError(ErrorCode code, String message, String detail, Integer line, Integer column) {
+    this(code.name(), message, detail, line, column);
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecStats.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecStats.java
@@ -1,0 +1,30 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Execution metadata reported alongside a successful {@link ExecuteResponse}.
+ *
+ * @param durationMs wall-clock execution time in milliseconds.
+ * @param rowCount number of result rows (SELECT) or triples (CONSTRUCT/DESCRIBE) returned; {@code
+ *     null} for ASK and UPDATE.
+ * @param truncated whether the result was cut off at the {@code maxRows} limit.
+ * @param resolvedTarget the endpoint URL actually queried/updated.
+ */
+record ExecStats(long durationMs, Integer rowCount, boolean truncated, String resolvedTarget) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
@@ -20,6 +20,7 @@ package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.jena.query.QueryExecution;
@@ -57,6 +58,18 @@ final class ExecSupport {
    */
   static ExecuteResponse runCancellable(
       ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work) {
+    return runCancellable(ctx, bestEffortAbort, work, 0);
+  }
+
+  /**
+   * Like {@link #runCancellable(ExecContext, Runnable, Supplier)}, but additionally resolves to a
+   * {@link ErrorCode#TIMEOUT} response after {@code timeoutMs} (when positive). For Jena query
+   * executions the engine's own {@code timeout(...)} is the better mechanism — this variant exists
+   * for blocking work without native timeout support, such as in-process SHACL validation; like a
+   * cancelled UPDATE, timed-out work keeps running in the background until it finishes on its own.
+   */
+  static ExecuteResponse runCancellable(
+      ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work, long timeoutMs) {
     CompletableFuture<ExecuteResponse> workFuture =
         CompletableFuture.supplyAsync(work, ctx.executionPool());
     CompletableFuture<ExecuteResponse> cancelFuture = new CompletableFuture<>();
@@ -73,10 +86,25 @@ final class ExecSupport {
               cancelFuture.complete(ExecuteResponse.cancelled());
               bestEffortAbort.run();
             });
+    ScheduledFuture<?> timeoutTask =
+        timeoutMs > 0
+            ? ctx.watchdogScheduler()
+                .schedule(
+                    () ->
+                        cancelFuture.complete(
+                            ExecuteResponse.failed(
+                                new ExecError(
+                                    ErrorCode.TIMEOUT, "Request timed out.", null, null, null))),
+                    timeoutMs,
+                    TimeUnit.MILLISECONDS)
+            : null;
     try {
       return workFuture.applyToEither(cancelFuture, Function.identity()).join();
     } finally {
       watchdogTask.cancel(true);
+      if (timeoutTask != null) {
+        timeoutTask.cancel(true);
+      }
     }
   }
 
@@ -113,6 +141,7 @@ final class ExecSupport {
       }
       case UPDATE ->
           throw new IllegalStateException("UPDATE must be routed through executeUpdate(...)");
+      case SHACL -> throw new IllegalStateException("SHACL must be routed through ShaclExecutor");
     };
   }
 

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
@@ -18,6 +18,8 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -161,5 +163,21 @@ final class ExecSupport {
 
   static boolean isBlank(String s) {
     return s == null || s.isBlank();
+  }
+
+  /**
+   * The value for a preemptive {@code Authorization} header, or {@code null} when the target has no
+   * usable basic-auth credentials. Sent preemptively (rather than via a 401 challenge dance) so it
+   * also works with services that answer 400/404 instead of challenging.
+   */
+  static String basicAuthHeader(ExecAuth auth) {
+    if (auth == null
+        || !ExecAuth.TYPE_BASIC.equalsIgnoreCase(auth.type())
+        || auth.username() == null) {
+      return null;
+    }
+    String credentials = auth.username() + ":" + (auth.password() != null ? auth.password() : "");
+    return "Basic "
+        + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
@@ -1,0 +1,136 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.jena.query.QueryExecution;
+
+/**
+ * Execution plumbing shared by {@link HttpQueryExecutor} and {@link LocalQueryExecutor}:
+ * cancellation racing, the query-kind result dispatch, and option defaulting. The executors keep
+ * only what genuinely differs between them — how the {@link QueryExecution} is built and how its
+ * failures are classified.
+ *
+ * <p><b>Cancellation.</b> Jena's {@code abort()} support varies by execution type ({@code
+ * QueryExecution.abort()} interrupts an in-flight HTTP query, {@code UpdateExecution.abort()} does
+ * not — see {@link HttpQueryExecutor}), so the blocking Jena call always runs on a background task
+ * ({@link #runCancellable}) raced against a {@link CancellationWatchdog}-driven signal: whichever
+ * finishes first — the real result, or the cancellation signal — determines the response. {@code
+ * abort()} is still called as a best-effort courtesy to unblock the background task sooner, but the
+ * client-visible CANCELLED outcome never depends on it.
+ */
+final class ExecSupport {
+
+  /** Default request timeout, matching {@code SchemaManager}'s remote-fetch timeout. */
+  static final int DEFAULT_TIMEOUT_MS = 30_000;
+
+  /** Default cap on returned rows/triples before the result is marked truncated. */
+  static final int DEFAULT_MAX_ROWS = 10_000;
+
+  private ExecSupport() {}
+
+  /**
+   * Runs {@code work} on {@code ctx.executionPool()} and races it against cancellation of {@code
+   * ctx.cancelChecker()}, returning whichever resolves first. {@code bestEffortAbort} is invoked
+   * (on the watchdog thread) the moment cancellation is observed, as a courtesy to unblock {@code
+   * work} sooner where the underlying Jena execution supports it — see the class-level note on why
+   * this is not relied upon for correctness.
+   */
+  static ExecuteResponse runCancellable(
+      ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work) {
+    CompletableFuture<ExecuteResponse> workFuture =
+        CompletableFuture.supplyAsync(work, ctx.executionPool());
+    CompletableFuture<ExecuteResponse> cancelFuture = new CompletableFuture<>();
+
+    ScheduledFuture<?> watchdogTask =
+        CancellationWatchdog.watch(
+            ctx.watchdogScheduler(),
+            ctx.cancelChecker(),
+            () -> {
+              // Complete cancelFuture before aborting: aborting can itself unblock the blocked
+              // Jena call on ctx.executionPool(), which would otherwise race workFuture's own
+              // completion against cancelFuture below. Signalling cancellation first guarantees
+              // workFuture cannot win that race as a side effect of the abort it triggers.
+              cancelFuture.complete(ExecuteResponse.cancelled());
+              bestEffortAbort.run();
+            });
+    try {
+      return workFuture.applyToEither(cancelFuture, Function.identity()).join();
+    } finally {
+      watchdogTask.cancel(true);
+    }
+  }
+
+  /**
+   * Executes a SELECT/ASK/CONSTRUCT/DESCRIBE on an already-built {@link QueryExecution} and
+   * serializes the result into a success response. Exceptions propagate — each executor classifies
+   * its own failure modes ({@link HttpQueryExecutor}: HTTP status codes; {@link
+   * LocalQueryExecutor}: timeouts of the in-process engine).
+   */
+  static ExecuteResponse successFor(
+      QueryExecution qe, QueryKind kind, String resolvedTarget, int maxRows) {
+    long start = System.currentTimeMillis();
+    return switch (kind) {
+      case SELECT -> {
+        ResultSerializer.Serialized s = ResultSerializer.selectToJson(qe.execSelect(), maxRows);
+        yield ExecuteResponse.successJson(
+            kind, s.payload(), stats(start, s.count(), s.truncated(), resolvedTarget));
+      }
+      case ASK -> {
+        String json = ResultSerializer.askToJson(qe.execAsk());
+        yield ExecuteResponse.successJson(kind, json, stats(start, null, false, resolvedTarget));
+      }
+      case CONSTRUCT -> {
+        ResultSerializer.Serialized s =
+            ResultSerializer.constructToTurtle(qe.execConstructTriples(), maxRows);
+        yield ExecuteResponse.successTurtle(
+            kind, s.payload(), stats(start, s.count(), s.truncated(), resolvedTarget));
+      }
+      case DESCRIBE -> {
+        ResultSerializer.Serialized s =
+            ResultSerializer.constructToTurtle(qe.execDescribeTriples(), maxRows);
+        yield ExecuteResponse.successTurtle(
+            kind, s.payload(), stats(start, s.count(), s.truncated(), resolvedTarget));
+      }
+      case UPDATE ->
+          throw new IllegalStateException("UPDATE must be routed through executeUpdate(...)");
+    };
+  }
+
+  static ExecStats stats(long startMs, Integer rowCount, boolean truncated, String resolvedTarget) {
+    return new ExecStats(System.currentTimeMillis() - startMs, rowCount, truncated, resolvedTarget);
+  }
+
+  static long timeoutMs(ExecuteOptions options) {
+    return options != null && options.timeoutMs() != null
+        ? options.timeoutMs()
+        : DEFAULT_TIMEOUT_MS;
+  }
+
+  static int maxRows(ExecuteOptions options) {
+    return options != null && options.maxRows() != null ? options.maxRows() : DEFAULT_MAX_ROWS;
+  }
+
+  static boolean isBlank(String s) {
+    return s == null || s.isBlank();
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteOptions.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteOptions.java
@@ -1,0 +1,29 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Per-execution overrides for the server-side defaults (see {@link
+ * HttpQueryExecutor#DEFAULT_TIMEOUT_MS} / {@link HttpQueryExecutor#DEFAULT_MAX_ROWS}).
+ *
+ * @param timeoutMs request timeout in milliseconds, or {@code null} to use the default.
+ * @param maxRows maximum number of solutions/triples to include in the result before truncating, or
+ *     {@code null} to use the default.
+ */
+record ExecuteOptions(Integer timeoutMs, Integer maxRows) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteRequest.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteRequest.java
@@ -23,11 +23,20 @@ package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
  * notebook controller for each cell execution.
  *
  * @param cellUri URI of the executing cell; used only for logging/diagnostics.
+ * @param notebookUri URI of the notebook document the cell belongs to; relative paths in {@link
+ *     ExecuteTarget#files()} are resolved against its directory, matching how validation resolves
+ *     relative {@code # [endpoint=...]} directives. May be {@code null} (e.g. an untitled
+ *     notebook), in which case only absolute file paths can be executed.
  * @param languageId the cell's language id (e.g. {@code sparql}).
  * @param text the cell's source text.
- * @param target the endpoint to execute against, resolved client-side; {@code null} when the cell
- *     (and its notebook) has no {@code # [endpoint=...]} directive.
+ * @param target the endpoint or files to execute against, resolved client-side; {@code null} when
+ *     the cell (and its notebook) has no {@code # [endpoint=...]} directive.
  * @param options per-execution overrides; {@code null} to use all defaults.
  */
 record ExecuteRequest(
-    String cellUri, String languageId, String text, ExecuteTarget target, ExecuteOptions options) {}
+    String cellUri,
+    String notebookUri,
+    String languageId,
+    String text,
+    ExecuteTarget target,
+    ExecuteOptions options) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteRequest.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteRequest.java
@@ -1,0 +1,33 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Argument of the {@code cimvocabcheck.notebook.execute} workspace command, sent by the VS Code
+ * notebook controller for each cell execution.
+ *
+ * @param cellUri URI of the executing cell; used only for logging/diagnostics.
+ * @param languageId the cell's language id (e.g. {@code sparql}).
+ * @param text the cell's source text.
+ * @param target the endpoint to execute against, resolved client-side; {@code null} when the cell
+ *     (and its notebook) has no {@code # [endpoint=...]} directive.
+ * @param options per-execution overrides; {@code null} to use all defaults.
+ */
+record ExecuteRequest(
+    String cellUri, String languageId, String text, ExecuteTarget target, ExecuteOptions options) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteResponse.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteResponse.java
@@ -1,0 +1,81 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Result of the {@code cimvocabcheck.notebook.execute} workspace command.
+ *
+ * <p>{@code resultsJson} (SELECT/ASK) and {@code turtle} (CONSTRUCT/DESCRIBE) are opaque,
+ * pre-serialized payload strings — the client renders them without re-interpreting their structure
+ * beyond the {@code queryKind} tag. At most one of the two is set; both are {@code null} for a
+ * successful UPDATE and for any non-{@code SUCCESS} status.
+ *
+ * @param status the outcome of the execution: an {@link ExecutionStatus} name. Status and kind are
+ *     carried as strings because lsp4j's message Gson serializes enum fields as ordinals, which no
+ *     client should have to decode (pinned by {@code NotebookCommandHandlerTest}).
+ * @param queryKind the detected kind of the cell's text: a {@link QueryKind} name; {@code null}
+ *     unless {@code status} is {@code SUCCESS}.
+ * @param resultsJson SPARQL 1.1 Query Results JSON for a SELECT or ASK, {@code null} otherwise.
+ * @param turtle Turtle serialization of the result graph for a CONSTRUCT or DESCRIBE, {@code null}
+ *     otherwise.
+ * @param stats execution metadata; {@code null} unless {@code status} is {@code SUCCESS}.
+ * @param error failure details; {@code null} unless {@code status} is not {@code SUCCESS}.
+ */
+record ExecuteResponse(
+    String status,
+    String queryKind,
+    String resultsJson,
+    String turtle,
+    ExecStats stats,
+    ExecError error) {
+
+  /** A successful SELECT or ASK execution. */
+  static ExecuteResponse successJson(QueryKind kind, String resultsJson, ExecStats stats) {
+    return new ExecuteResponse(
+        ExecutionStatus.SUCCESS.name(), kind.name(), resultsJson, null, stats, null);
+  }
+
+  /** A successful CONSTRUCT or DESCRIBE execution. */
+  static ExecuteResponse successTurtle(QueryKind kind, String turtle, ExecStats stats) {
+    return new ExecuteResponse(
+        ExecutionStatus.SUCCESS.name(), kind.name(), null, turtle, stats, null);
+  }
+
+  /** A successful UPDATE execution (no result payload). */
+  static ExecuteResponse successUpdate(ExecStats stats) {
+    return new ExecuteResponse(
+        ExecutionStatus.SUCCESS.name(), QueryKind.UPDATE.name(), null, null, stats, null);
+  }
+
+  /** A failed execution. */
+  static ExecuteResponse failed(ExecError error) {
+    return new ExecuteResponse(ExecutionStatus.ERROR.name(), null, null, null, null, error);
+  }
+
+  /** An execution that was cancelled before it produced a result. */
+  static ExecuteResponse cancelled() {
+    return new ExecuteResponse(
+        ExecutionStatus.CANCELLED.name(),
+        null,
+        null,
+        null,
+        null,
+        new ExecError(ErrorCode.CANCELLED, "Execution was cancelled.", null, null, null));
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteResponse.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteResponse.java
@@ -32,8 +32,10 @@ package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
  * @param queryKind the detected kind of the cell's text: a {@link QueryKind} name; {@code null}
  *     unless {@code status} is {@code SUCCESS}.
  * @param resultsJson SPARQL 1.1 Query Results JSON for a SELECT or ASK, {@code null} otherwise.
- * @param turtle Turtle serialization of the result graph for a CONSTRUCT or DESCRIBE, {@code null}
- *     otherwise.
+ * @param turtle Turtle serialization of the result graph for a CONSTRUCT or DESCRIBE, or of the
+ *     validation report for a SHACL run; {@code null} otherwise.
+ * @param shaclSummary aggregated verdict of a SHACL run; {@code null} unless {@code queryKind} is
+ *     {@code SHACL}.
  * @param stats execution metadata; {@code null} unless {@code status} is {@code SUCCESS}.
  * @param error failure details; {@code null} unless {@code status} is not {@code SUCCESS}.
  */
@@ -42,36 +44,50 @@ record ExecuteResponse(
     String queryKind,
     String resultsJson,
     String turtle,
+    ShaclSummary shaclSummary,
     ExecStats stats,
     ExecError error) {
 
   /** A successful SELECT or ASK execution. */
   static ExecuteResponse successJson(QueryKind kind, String resultsJson, ExecStats stats) {
     return new ExecuteResponse(
-        ExecutionStatus.SUCCESS.name(), kind.name(), resultsJson, null, stats, null);
+        ExecutionStatus.SUCCESS.name(), kind.name(), resultsJson, null, null, stats, null);
   }
 
   /** A successful CONSTRUCT or DESCRIBE execution. */
   static ExecuteResponse successTurtle(QueryKind kind, String turtle, ExecStats stats) {
     return new ExecuteResponse(
-        ExecutionStatus.SUCCESS.name(), kind.name(), null, turtle, stats, null);
+        ExecutionStatus.SUCCESS.name(), kind.name(), null, turtle, null, stats, null);
   }
 
   /** A successful UPDATE execution (no result payload). */
   static ExecuteResponse successUpdate(ExecStats stats) {
     return new ExecuteResponse(
-        ExecutionStatus.SUCCESS.name(), QueryKind.UPDATE.name(), null, null, stats, null);
+        ExecutionStatus.SUCCESS.name(), QueryKind.UPDATE.name(), null, null, null, stats, null);
+  }
+
+  /** A completed SHACL validation run (successful even when the data does not conform). */
+  static ExecuteResponse successShacl(String reportTurtle, ShaclSummary summary, ExecStats stats) {
+    return new ExecuteResponse(
+        ExecutionStatus.SUCCESS.name(),
+        QueryKind.SHACL.name(),
+        null,
+        reportTurtle,
+        summary,
+        stats,
+        null);
   }
 
   /** A failed execution. */
   static ExecuteResponse failed(ExecError error) {
-    return new ExecuteResponse(ExecutionStatus.ERROR.name(), null, null, null, null, error);
+    return new ExecuteResponse(ExecutionStatus.ERROR.name(), null, null, null, null, null, error);
   }
 
   /** An execution that was cancelled before it produced a result. */
   static ExecuteResponse cancelled() {
     return new ExecuteResponse(
         ExecutionStatus.CANCELLED.name(),
+        null,
         null,
         null,
         null,

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
@@ -38,9 +38,11 @@ import java.util.List;
  *     targets only). Relative paths are resolved server-side against the directory of {@link
  *     ExecuteRequest#notebookUri()}; multiple files are queried as one union store. Local files are
  *     read-only — updates are rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED}.
+ * @param auth optional credentials for {@code "http"} targets — see {@link ExecAuth} for the
+ *     handling guarantees; {@code null} for anonymous access.
  */
 record ExecuteTarget(
-    String type, String url, String updateUrl, String shaclUrl, List<String> files) {
+    String type, String url, String updateUrl, String shaclUrl, List<String> files, ExecAuth auth) {
 
   /** Target {@link #type()}: a remote SPARQL endpoint. */
   static final String TYPE_HTTP = "http";

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
@@ -1,0 +1,36 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * The endpoint a cell is executed against, resolved client-side from the cell's {@code #
+ * [endpoint=...]} directive (see {@code EndpointDirective} in the parent package).
+ *
+ * @param type {@code "http"} for a remote SPARQL endpoint; other target types (local file, SHACL)
+ *     are added in later milestones.
+ * @param url the SPARQL query endpoint URL.
+ * @param updateUrl the SPARQL Update endpoint URL. {@code null}/blank means this target has no
+ *     configured update endpoint, so a cell that parses as a SPARQL Update is rejected with {@link
+ *     ErrorCode#UPDATE_NOT_ALLOWED} rather than silently reusing {@link #url()}.
+ */
+record ExecuteTarget(String type, String url, String updateUrl) {
+
+  /** The only target {@link #type()} understood in this milestone. */
+  static final String TYPE_HTTP = "http";
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
@@ -31,12 +31,16 @@ import java.util.List;
  *     means this target has no configured update endpoint, so a cell that parses as a SPARQL Update
  *     is rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED} rather than silently reusing {@link
  *     #url()}.
+ * @param shaclUrl the SHACL validation service URL ({@code "http"} targets only), e.g. Fuseki's
+ *     {@code …/shacl} operation. {@code null}/blank means SHACL cells cannot run against this
+ *     target; like {@link #updateUrl()}, the server never derives it — the client does.
  * @param files the local files to query, exactly as written in the directives ({@code "files"}
  *     targets only). Relative paths are resolved server-side against the directory of {@link
  *     ExecuteRequest#notebookUri()}; multiple files are queried as one union store. Local files are
  *     read-only — updates are rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED}.
  */
-record ExecuteTarget(String type, String url, String updateUrl, List<String> files) {
+record ExecuteTarget(
+    String type, String url, String updateUrl, String shaclUrl, List<String> files) {
 
   /** Target {@link #type()}: a remote SPARQL endpoint. */
   static final String TYPE_HTTP = "http";

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
@@ -18,19 +18,29 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
-/**
- * The endpoint a cell is executed against, resolved client-side from the cell's {@code #
- * [endpoint=...]} directive (see {@code EndpointDirective} in the parent package).
- *
- * @param type {@code "http"} for a remote SPARQL endpoint; other target types (local file, SHACL)
- *     are added in later milestones.
- * @param url the SPARQL query endpoint URL.
- * @param updateUrl the SPARQL Update endpoint URL. {@code null}/blank means this target has no
- *     configured update endpoint, so a cell that parses as a SPARQL Update is rejected with {@link
- *     ErrorCode#UPDATE_NOT_ALLOWED} rather than silently reusing {@link #url()}.
- */
-record ExecuteTarget(String type, String url, String updateUrl) {
+import java.util.List;
 
-  /** The only target {@link #type()} understood in this milestone. */
+/**
+ * The endpoint or local files a cell is executed against, resolved client-side from the cell's
+ * {@code # [endpoint=...]} directives (see {@code EndpointDirective} in the parent package).
+ *
+ * @param type {@code "http"} for a remote SPARQL endpoint, {@code "files"} for local RDF/CIMXML
+ *     files queried in-process.
+ * @param url the SPARQL query endpoint URL ({@code "http"} targets only).
+ * @param updateUrl the SPARQL Update endpoint URL ({@code "http"} targets only). {@code null}/blank
+ *     means this target has no configured update endpoint, so a cell that parses as a SPARQL Update
+ *     is rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED} rather than silently reusing {@link
+ *     #url()}.
+ * @param files the local files to query, exactly as written in the directives ({@code "files"}
+ *     targets only). Relative paths are resolved server-side against the directory of {@link
+ *     ExecuteRequest#notebookUri()}; multiple files are queried as one union store. Local files are
+ *     read-only — updates are rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED}.
+ */
+record ExecuteTarget(String type, String url, String updateUrl, List<String> files) {
+
+  /** Target {@link #type()}: a remote SPARQL endpoint. */
   static final String TYPE_HTTP = "http";
+
+  /** Target {@link #type()}: local RDF/CIMXML files queried in-process. */
+  static final String TYPE_FILES = "files";
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecutionStatus.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecutionStatus.java
@@ -1,0 +1,26 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/** Outcome of a single {@code cimvocabcheck.notebook.execute} call. */
+enum ExecutionStatus {
+  SUCCESS,
+  ERROR,
+  CANCELLED
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/FileGlobs.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/FileGlobs.java
@@ -1,0 +1,110 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Glob expansion for {@code # [endpoint=...]} file directives, matching the SPARQL Notebook
+ * extension's behavior: a directive value may be a glob pattern such as {@code ./rdf/*.ttl} or
+ * {@code ./rdf/{a,b}.ttl} that stands for every file it matches.
+ *
+ * <p>The pattern language is {@link java.nio.file.FileSystem#getPathMatcher glob} syntax ({@code
+ * *}, {@code ?}, {@code {a,b}}, {@code [...]}, and {@code **} for crossing directories). Directive
+ * values contain no spaces, so backslashes are treated as path separators (Windows-style paths),
+ * never as glob escapes.
+ */
+public final class FileGlobs {
+
+  private FileGlobs() {}
+
+  /** Directory levels {@code **} may descend into; plain patterns walk only their own depth. */
+  private static final int MAX_RECURSIVE_DEPTH = 64;
+
+  /** Whether a directive value is a glob pattern rather than a plain path. */
+  public static boolean isPattern(String value) {
+    if (value == null) {
+      return false;
+    }
+    return value.chars().anyMatch(c -> c == '*' || c == '?' || c == '{' || c == '[');
+  }
+
+  /**
+   * Expands a glob pattern to the regular files it matches, sorted by path. A relative pattern
+   * resolves against {@code base}. Returns an empty list when nothing matches, when the pattern's
+   * literal directory prefix does not exist, or when a relative pattern has no base.
+   *
+   * @throws java.util.regex.PatternSyntaxException if the pattern is not valid glob syntax
+   */
+  public static List<Path> expand(String pattern, Path base) {
+    String normalized = pattern.replace('\\', '/');
+    List<String> segments = List.of(normalized.split("/"));
+    int firstMeta = 0;
+    while (firstMeta < segments.size() && !isPattern(segments.get(firstMeta))) {
+      firstMeta++;
+    }
+    String literal = String.join("/", segments.subList(0, firstMeta));
+    String glob = String.join("/", segments.subList(firstMeta, segments.size()));
+    if (glob.isEmpty()) {
+      // Not actually a pattern — treat the whole value as one plain path.
+      Path p = resolveRoot(normalized, base);
+      return p != null && Files.isRegularFile(p) ? List.of(p) : List.of();
+    }
+    if (normalized.startsWith("/") && literal.isEmpty()) {
+      literal = "/";
+    }
+    Path root = resolveRoot(literal, base);
+    if (root == null || !Files.isDirectory(root)) {
+      return List.of();
+    }
+    PathMatcher matcher = root.getFileSystem().getPathMatcher("glob:" + glob);
+    int depth =
+        glob.contains("**")
+            ? MAX_RECURSIVE_DEPTH
+            : (int) glob.chars().filter(c -> c == '/').count() + 1;
+    try (Stream<Path> walk = Files.walk(root, depth)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(p -> matcher.matches(root.relativize(p)))
+          .sorted()
+          .toList();
+    } catch (IOException | UncheckedIOException e) {
+      return List.of();
+    }
+  }
+
+  /**
+   * The directory (or file) a pattern's literal prefix denotes, or {@code null} if unresolvable.
+   */
+  private static Path resolveRoot(String literal, Path base) {
+    Path p = literal.isEmpty() ? null : Path.of(literal);
+    if (p != null && p.isAbsolute()) {
+      return p.normalize();
+    }
+    if (base == null) {
+      return null;
+    }
+    return (p == null ? base : base.resolve(p)).normalize();
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
@@ -1,0 +1,289 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.net.http.HttpTimeoutException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.jena.atlas.web.HttpException;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
+import org.apache.jena.sparql.exec.http.UpdateExecutionHTTP;
+import org.apache.jena.update.UpdateExecution;
+import org.apache.jena.update.UpdateRequest;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a parsed SPARQL query or update against an HTTP endpoint, applying the request timeout,
+ * result truncation, and client-cancellation wiring.
+ *
+ * <p><b>Cancellation.</b> Jena's {@code QueryExecution.abort()} reliably interrupts an in-flight
+ * HTTP query — verified empirically against Jena 6.1.0 — but the symmetric {@code
+ * UpdateExecution.abort()} does not: an in-flight {@code UpdateExecutionHTTP.execute()} call keeps
+ * blocking until the request's own timeout elapses regardless of {@code abort()} being called from
+ * another thread. Rather than rely on that asymmetric, version-specific behavior, the blocking Jena
+ * call always runs on a background task ({@link #runCancellable}) raced against a {@link
+ * CancellationWatchdog}-driven signal: whichever finishes first — the real result, or the
+ * cancellation signal — determines the response. {@code abort()} is still called as a best-effort
+ * courtesy (it does help for queries, and costs nothing when it does not), but correctness of the
+ * client-visible CANCELLED outcome never depends on it. One consequence: a cancelled UPDATE's HTTP
+ * request may continue running against the endpoint in the background until it completes or times
+ * out; the notebook simply stops waiting for it.
+ */
+final class HttpQueryExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpQueryExecutor.class);
+
+  /** Default request timeout, matching {@code SchemaManager}'s remote-fetch timeout. */
+  static final int DEFAULT_TIMEOUT_MS = 30_000;
+
+  /** Default cap on returned rows/triples before the result is marked truncated. */
+  static final int DEFAULT_MAX_ROWS = 10_000;
+
+  private HttpQueryExecutor() {}
+
+  /**
+   * Resources a single execution needs for cancellation wiring, bundled to keep call sites short.
+   */
+  record ExecContext(
+      ExecutorService executionPool,
+      ScheduledExecutorService watchdogScheduler,
+      CancelChecker cancelChecker) {}
+
+  /**
+   * Executes a SELECT/ASK/CONSTRUCT/DESCRIBE query, returning a populated {@link ExecuteResponse}.
+   */
+  static ExecuteResponse executeQuery(
+      Query query, QueryKind kind, ExecuteTarget target, ExecuteOptions options, ExecContext ctx) {
+    ExecError targetError = checkTarget(target);
+    if (targetError != null) {
+      return ExecuteResponse.failed(targetError);
+    }
+
+    String url = target.url();
+    int maxRows = maxRows(options);
+    QueryExecution qe =
+        QueryExecutionHTTP.service(url)
+            .query(query)
+            .timeout(timeoutMs(options), TimeUnit.MILLISECONDS)
+            .build();
+    return runCancellable(
+        ctx,
+        qe::abort,
+        () -> {
+          try (qe) {
+            return runQuery(qe, kind, url, maxRows);
+          }
+        });
+  }
+
+  /** Executes a SPARQL Update request, returning a populated {@link ExecuteResponse}. */
+  static ExecuteResponse executeUpdate(
+      UpdateRequest update, ExecuteTarget target, ExecuteOptions options, ExecContext ctx) {
+    ExecError targetError = checkTarget(target);
+    if (targetError != null) {
+      return ExecuteResponse.failed(targetError);
+    }
+    String updateUrl = target.updateUrl();
+    if (isBlank(updateUrl)) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.UPDATE_NOT_ALLOWED,
+              "No update endpoint configured for this target.",
+              null,
+              null,
+              null));
+    }
+
+    UpdateExecution ue =
+        UpdateExecutionHTTP.service(updateUrl)
+            .update(update)
+            .timeout(timeoutMs(options), TimeUnit.MILLISECONDS)
+            .build();
+    return runCancellable(ctx, ue::abort, () -> runUpdate(ue, updateUrl));
+  }
+
+  // ---- query/update execution (runs on ctx.executionPool()) -------------------------------
+
+  private static ExecuteResponse runQuery(
+      QueryExecution qe, QueryKind kind, String url, int maxRows) {
+    long start = System.currentTimeMillis();
+    try {
+      return switch (kind) {
+        case SELECT -> {
+          ResultSerializer.Serialized s = ResultSerializer.selectToJson(qe.execSelect(), maxRows);
+          yield ExecuteResponse.successJson(
+              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
+        }
+        case ASK -> {
+          String json = ResultSerializer.askToJson(qe.execAsk());
+          yield ExecuteResponse.successJson(kind, json, stats(start, null, false, url));
+        }
+        case CONSTRUCT -> {
+          ResultSerializer.Serialized s =
+              ResultSerializer.constructToTurtle(qe.execConstructTriples(), maxRows);
+          yield ExecuteResponse.successTurtle(
+              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
+        }
+        case DESCRIBE -> {
+          ResultSerializer.Serialized s =
+              ResultSerializer.constructToTurtle(qe.execDescribeTriples(), maxRows);
+          yield ExecuteResponse.successTurtle(
+              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
+        }
+        case UPDATE ->
+            throw new IllegalStateException("UPDATE must be routed through executeUpdate(...)");
+      };
+    } catch (QueryExceptionHTTP e) {
+      return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
+    } catch (CancellationException e) {
+      // Expected fallout of runCancellable's best-effort qe.abort(): the cancelFuture race has
+      // already been won by the time this unwinds, so the returned value is discarded, but avoid
+      // logging a normal user-initiated cancellation as an unexpected internal error.
+      LOG.debug("{} query aborted after cancellation", kind);
+      return ExecuteResponse.cancelled();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error executing {} query: {}", kind, e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  private static ExecuteResponse runUpdate(UpdateExecution ue, String updateUrl) {
+    long start = System.currentTimeMillis();
+    try {
+      ue.execute();
+      return ExecuteResponse.successUpdate(stats(start, null, false, updateUrl));
+    } catch (HttpException e) {
+      return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
+    } catch (CancellationException e) {
+      // See the matching catch in runQuery: expected fallout of a best-effort abort() racing
+      // against (and losing to) cancelFuture, not a genuine internal error.
+      LOG.debug("Update aborted after cancellation");
+      return ExecuteResponse.cancelled();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error executing update: {}", e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  // ---- cancellation racing -----------------------------------------------------------------
+
+  /**
+   * Runs {@code work} on {@code ctx.executionPool()} and races it against cancellation of {@code
+   * ctx.cancelChecker()}, returning whichever resolves first. {@code bestEffortAbort} is invoked
+   * (on the watchdog thread) the moment cancellation is observed, as a courtesy to unblock {@code
+   * work} sooner where the underlying Jena execution supports it — see the class-level note on why
+   * this is not relied upon for correctness.
+   */
+  private static ExecuteResponse runCancellable(
+      ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work) {
+    CompletableFuture<ExecuteResponse> workFuture =
+        CompletableFuture.supplyAsync(work, ctx.executionPool());
+    CompletableFuture<ExecuteResponse> cancelFuture = new CompletableFuture<>();
+
+    ScheduledFuture<?> watchdogTask =
+        CancellationWatchdog.watch(
+            ctx.watchdogScheduler(),
+            ctx.cancelChecker(),
+            () -> {
+              // Complete cancelFuture before aborting: aborting can itself unblock the blocked
+              // Jena call on ctx.executionPool(), which would otherwise race workFuture's own
+              // completion against cancelFuture below. Signalling cancellation first guarantees
+              // workFuture cannot win that race as a side effect of the abort it triggers.
+              cancelFuture.complete(ExecuteResponse.cancelled());
+              bestEffortAbort.run();
+            });
+    try {
+      return workFuture.applyToEither(cancelFuture, Function.identity()).join();
+    } finally {
+      watchdogTask.cancel(true);
+    }
+  }
+
+  // ---- error classification ----------------------------------------------------------------
+
+  private static ExecError classify(int statusCode, String message, Throwable causeChain) {
+    if (hasCause(causeChain, HttpTimeoutException.class)) {
+      return new ExecError(ErrorCode.TIMEOUT, "Request timed out.", message, null, null);
+    }
+    if (statusCode == 401 || statusCode == 403) {
+      return new ExecError(
+          ErrorCode.AUTH_FAILED,
+          "Authentication failed (HTTP " + statusCode + ").",
+          message,
+          null,
+          null);
+    }
+    return new ExecError(ErrorCode.HTTP_ERROR, message, null, null, null);
+  }
+
+  private static boolean hasCause(Throwable t, Class<? extends Throwable> type) {
+    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      if (type.isInstance(cur)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // ---- small helpers ------------------------------------------------------------------------
+
+  private static ExecError checkTarget(ExecuteTarget target) {
+    if (target == null || isBlank(target.url())) {
+      return new ExecError(
+          ErrorCode.NO_TARGET,
+          "No endpoint configured. Add a `# [endpoint=<url>]` directive to the cell.",
+          null,
+          null,
+          null);
+    }
+    return null;
+  }
+
+  private static ExecStats stats(
+      long startMs, Integer rowCount, boolean truncated, String resolvedTarget) {
+    return new ExecStats(System.currentTimeMillis() - startMs, rowCount, truncated, resolvedTarget);
+  }
+
+  private static long timeoutMs(ExecuteOptions options) {
+    return options != null && options.timeoutMs() != null
+        ? options.timeoutMs()
+        : DEFAULT_TIMEOUT_MS;
+  }
+
+  private static int maxRows(ExecuteOptions options) {
+    return options != null && options.maxRows() != null ? options.maxRows() : DEFAULT_MAX_ROWS;
+  }
+
+  private static boolean isBlank(String s) {
+    return s == null || s.isBlank();
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
@@ -26,7 +26,9 @@ import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
 import org.apache.jena.sparql.exec.http.UpdateExecutionHTTP;
+import org.apache.jena.sparql.exec.http.UpdateExecutionHTTPBuilder;
 import org.apache.jena.update.UpdateExecution;
 import org.apache.jena.update.UpdateRequest;
 import org.slf4j.Logger;
@@ -63,11 +65,15 @@ final class HttpQueryExecutor {
 
     String url = target.url();
     int maxRows = ExecSupport.maxRows(options);
-    QueryExecution qe =
+    QueryExecutionHTTPBuilder builder =
         QueryExecutionHTTP.service(url)
             .query(query)
-            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS)
-            .build();
+            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS);
+    String authHeader = ExecSupport.basicAuthHeader(target.auth());
+    if (authHeader != null) {
+      builder.httpHeader("Authorization", authHeader);
+    }
+    QueryExecution qe = builder.build();
     return ExecSupport.runCancellable(
         ctx,
         qe::abort,
@@ -96,11 +102,15 @@ final class HttpQueryExecutor {
               null));
     }
 
-    UpdateExecution ue =
+    UpdateExecutionHTTPBuilder builder =
         UpdateExecutionHTTP.service(updateUrl)
             .update(update)
-            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS)
-            .build();
+            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS);
+    String authHeader = ExecSupport.basicAuthHeader(target.auth());
+    if (authHeader != null) {
+      builder.httpHeader("Authorization", authHeader);
+    }
+    UpdateExecution ue = builder.build();
     return ExecSupport.runCancellable(ctx, ue::abort, () -> runUpdate(ue, updateUrl));
   }
 

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
@@ -20,13 +20,7 @@ package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
 import java.net.http.HttpTimeoutException;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
@@ -35,7 +29,6 @@ import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
 import org.apache.jena.sparql.exec.http.UpdateExecutionHTTP;
 import org.apache.jena.update.UpdateExecution;
 import org.apache.jena.update.UpdateRequest;
-import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,33 +41,15 @@ import org.slf4j.LoggerFactory;
  * UpdateExecution.abort()} does not: an in-flight {@code UpdateExecutionHTTP.execute()} call keeps
  * blocking until the request's own timeout elapses regardless of {@code abort()} being called from
  * another thread. Rather than rely on that asymmetric, version-specific behavior, the blocking Jena
- * call always runs on a background task ({@link #runCancellable}) raced against a {@link
- * CancellationWatchdog}-driven signal: whichever finishes first — the real result, or the
- * cancellation signal — determines the response. {@code abort()} is still called as a best-effort
- * courtesy (it does help for queries, and costs nothing when it does not), but correctness of the
- * client-visible CANCELLED outcome never depends on it. One consequence: a cancelled UPDATE's HTTP
- * request may continue running against the endpoint in the background until it completes or times
- * out; the notebook simply stops waiting for it.
+ * call is raced against the cancellation signal via {@link ExecSupport#runCancellable}. One
+ * consequence: a cancelled UPDATE's HTTP request may continue running against the endpoint in the
+ * background until it completes or times out; the notebook simply stops waiting for it.
  */
 final class HttpQueryExecutor {
 
   private static final Logger LOG = LoggerFactory.getLogger(HttpQueryExecutor.class);
 
-  /** Default request timeout, matching {@code SchemaManager}'s remote-fetch timeout. */
-  static final int DEFAULT_TIMEOUT_MS = 30_000;
-
-  /** Default cap on returned rows/triples before the result is marked truncated. */
-  static final int DEFAULT_MAX_ROWS = 10_000;
-
   private HttpQueryExecutor() {}
-
-  /**
-   * Resources a single execution needs for cancellation wiring, bundled to keep call sites short.
-   */
-  record ExecContext(
-      ExecutorService executionPool,
-      ScheduledExecutorService watchdogScheduler,
-      CancelChecker cancelChecker) {}
 
   /**
    * Executes a SELECT/ASK/CONSTRUCT/DESCRIBE query, returning a populated {@link ExecuteResponse}.
@@ -87,13 +62,13 @@ final class HttpQueryExecutor {
     }
 
     String url = target.url();
-    int maxRows = maxRows(options);
+    int maxRows = ExecSupport.maxRows(options);
     QueryExecution qe =
         QueryExecutionHTTP.service(url)
             .query(query)
-            .timeout(timeoutMs(options), TimeUnit.MILLISECONDS)
+            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS)
             .build();
-    return runCancellable(
+    return ExecSupport.runCancellable(
         ctx,
         qe::abort,
         () -> {
@@ -111,7 +86,7 @@ final class HttpQueryExecutor {
       return ExecuteResponse.failed(targetError);
     }
     String updateUrl = target.updateUrl();
-    if (isBlank(updateUrl)) {
+    if (ExecSupport.isBlank(updateUrl)) {
       return ExecuteResponse.failed(
           new ExecError(
               ErrorCode.UPDATE_NOT_ALLOWED,
@@ -124,42 +99,17 @@ final class HttpQueryExecutor {
     UpdateExecution ue =
         UpdateExecutionHTTP.service(updateUrl)
             .update(update)
-            .timeout(timeoutMs(options), TimeUnit.MILLISECONDS)
+            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS)
             .build();
-    return runCancellable(ctx, ue::abort, () -> runUpdate(ue, updateUrl));
+    return ExecSupport.runCancellable(ctx, ue::abort, () -> runUpdate(ue, updateUrl));
   }
 
   // ---- query/update execution (runs on ctx.executionPool()) -------------------------------
 
   private static ExecuteResponse runQuery(
       QueryExecution qe, QueryKind kind, String url, int maxRows) {
-    long start = System.currentTimeMillis();
     try {
-      return switch (kind) {
-        case SELECT -> {
-          ResultSerializer.Serialized s = ResultSerializer.selectToJson(qe.execSelect(), maxRows);
-          yield ExecuteResponse.successJson(
-              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
-        }
-        case ASK -> {
-          String json = ResultSerializer.askToJson(qe.execAsk());
-          yield ExecuteResponse.successJson(kind, json, stats(start, null, false, url));
-        }
-        case CONSTRUCT -> {
-          ResultSerializer.Serialized s =
-              ResultSerializer.constructToTurtle(qe.execConstructTriples(), maxRows);
-          yield ExecuteResponse.successTurtle(
-              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
-        }
-        case DESCRIBE -> {
-          ResultSerializer.Serialized s =
-              ResultSerializer.constructToTurtle(qe.execDescribeTriples(), maxRows);
-          yield ExecuteResponse.successTurtle(
-              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
-        }
-        case UPDATE ->
-            throw new IllegalStateException("UPDATE must be routed through executeUpdate(...)");
-      };
+      return ExecSupport.successFor(qe, kind, url, maxRows);
     } catch (QueryExceptionHTTP e) {
       return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
     } catch (CancellationException e) {
@@ -179,7 +129,7 @@ final class HttpQueryExecutor {
     long start = System.currentTimeMillis();
     try {
       ue.execute();
-      return ExecuteResponse.successUpdate(stats(start, null, false, updateUrl));
+      return ExecuteResponse.successUpdate(ExecSupport.stats(start, null, false, updateUrl));
     } catch (HttpException e) {
       return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
     } catch (CancellationException e) {
@@ -191,40 +141,6 @@ final class HttpQueryExecutor {
       LOG.error("Unexpected error executing update: {}", e.getMessage(), e);
       return ExecuteResponse.failed(
           new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
-    }
-  }
-
-  // ---- cancellation racing -----------------------------------------------------------------
-
-  /**
-   * Runs {@code work} on {@code ctx.executionPool()} and races it against cancellation of {@code
-   * ctx.cancelChecker()}, returning whichever resolves first. {@code bestEffortAbort} is invoked
-   * (on the watchdog thread) the moment cancellation is observed, as a courtesy to unblock {@code
-   * work} sooner where the underlying Jena execution supports it — see the class-level note on why
-   * this is not relied upon for correctness.
-   */
-  private static ExecuteResponse runCancellable(
-      ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work) {
-    CompletableFuture<ExecuteResponse> workFuture =
-        CompletableFuture.supplyAsync(work, ctx.executionPool());
-    CompletableFuture<ExecuteResponse> cancelFuture = new CompletableFuture<>();
-
-    ScheduledFuture<?> watchdogTask =
-        CancellationWatchdog.watch(
-            ctx.watchdogScheduler(),
-            ctx.cancelChecker(),
-            () -> {
-              // Complete cancelFuture before aborting: aborting can itself unblock the blocked
-              // Jena call on ctx.executionPool(), which would otherwise race workFuture's own
-              // completion against cancelFuture below. Signalling cancellation first guarantees
-              // workFuture cannot win that race as a side effect of the abort it triggers.
-              cancelFuture.complete(ExecuteResponse.cancelled());
-              bestEffortAbort.run();
-            });
-    try {
-      return workFuture.applyToEither(cancelFuture, Function.identity()).join();
-    } finally {
-      watchdogTask.cancel(true);
     }
   }
 
@@ -257,7 +173,7 @@ final class HttpQueryExecutor {
   // ---- small helpers ------------------------------------------------------------------------
 
   private static ExecError checkTarget(ExecuteTarget target) {
-    if (target == null || isBlank(target.url())) {
+    if (target == null || ExecSupport.isBlank(target.url())) {
       return new ExecError(
           ErrorCode.NO_TARGET,
           "No endpoint configured. Add a `# [endpoint=<url>]` directive to the cell.",
@@ -266,24 +182,5 @@ final class HttpQueryExecutor {
           null);
     }
     return null;
-  }
-
-  private static ExecStats stats(
-      long startMs, Integer rowCount, boolean truncated, String resolvedTarget) {
-    return new ExecStats(System.currentTimeMillis() - startMs, rowCount, truncated, resolvedTarget);
-  }
-
-  private static long timeoutMs(ExecuteOptions options) {
-    return options != null && options.timeoutMs() != null
-        ? options.timeoutMs()
-        : DEFAULT_TIMEOUT_MS;
-  }
-
-  private static int maxRows(ExecuteOptions options) {
-    return options != null && options.maxRows() != null ? options.maxRows() : DEFAULT_MAX_ROWS;
-  }
-
-  private static boolean isBlank(String s) {
-    return s == null || s.isBlank();
   }
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryCancelledException;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
@@ -122,10 +123,11 @@ final class HttpQueryExecutor {
       return ExecSupport.successFor(qe, kind, url, maxRows);
     } catch (QueryExceptionHTTP e) {
       return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
-    } catch (CancellationException e) {
-      // Expected fallout of runCancellable's best-effort qe.abort(): the cancelFuture race has
-      // already been won by the time this unwinds, so the returned value is discarded, but avoid
-      // logging a normal user-initiated cancellation as an unexpected internal error.
+    } catch (QueryCancelledException | CancellationException e) {
+      // Expected fallout of runCancellable's best-effort qe.abort(), which Jena signals with
+      // QueryCancelledException: the cancelFuture race has already been won by the time this
+      // unwinds, so the returned value is discarded, but avoid logging a normal user-initiated
+      // cancellation as an unexpected internal error.
       LOG.debug("{} query aborted after cancellation", kind);
       return ExecuteResponse.cancelled();
     } catch (RuntimeException e) {
@@ -142,7 +144,7 @@ final class HttpQueryExecutor {
       return ExecuteResponse.successUpdate(ExecSupport.stats(start, null, false, updateUrl));
     } catch (HttpException e) {
       return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
-    } catch (CancellationException e) {
+    } catch (QueryCancelledException | CancellationException e) {
       // See the matching catch in runQuery: expected fallout of a best-effort abort() racing
       // against (and losing to) cancelFuture, not a genuine internal error.
       LOG.debug("Update aborted after cancellation");

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpShaclClient.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpShaclClient.java
@@ -74,13 +74,17 @@ final class HttpShaclClient {
 
     HttpRequest request;
     try {
-      request =
+      HttpRequest.Builder builder =
           HttpRequest.newBuilder(URI.create(shaclUrl))
               .timeout(Duration.ofMillis(ExecSupport.timeoutMs(options)))
               .header("Content-Type", TEXT_TURTLE)
               .header("Accept", TEXT_TURTLE)
-              .POST(HttpRequest.BodyPublishers.ofString(shapesTurtle))
-              .build();
+              .POST(HttpRequest.BodyPublishers.ofString(shapesTurtle));
+      String authHeader = ExecSupport.basicAuthHeader(target.auth());
+      if (authHeader != null) {
+        builder.header("Authorization", authHeader);
+      }
+      request = builder.build();
     } catch (IllegalArgumentException e) {
       return ExecuteResponse.failed(
           new ExecError(

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpShaclClient.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpShaclClient.java
@@ -1,0 +1,160 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.shacl.ValidationReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates a SHACL cell against a remote SHACL service (Fuseki's {@code …/shacl} operation and
+ * compatibles): the cell's shapes are POSTed as {@code text/turtle} and the service validates its
+ * own data against them, answering with a validation report as Turtle. Any {@code ?graph=…} query
+ * parameter on the {@link ExecuteTarget#shaclUrl()} travels as-is, so a directive can pin the graph
+ * to validate.
+ *
+ * <p>The blocking HTTP call runs under the usual cancellation race ({@link
+ * ExecSupport#runCancellable}); the request timeout is enforced by the HTTP client itself.
+ */
+final class HttpShaclClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpShaclClient.class);
+
+  private static final String TEXT_TURTLE = "text/turtle";
+
+  /**
+   * One client for all SHACL requests. An {@link HttpClient} owns a selector thread and an
+   * executor, and is only released once it becomes unreachable — a per-request client would leave
+   * those threads behind on every SHACL cell run. The timeout is per-request ({@link
+   * HttpRequest#timeout()}), so nothing here needs to be per-execution.
+   */
+  private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+  private HttpShaclClient() {}
+
+  /** Validates {@code shapesTurtle} against the target's SHACL service. */
+  static ExecuteResponse validate(
+      String shapesTurtle, ExecuteTarget target, ExecuteOptions options, ExecContext ctx) {
+    String shaclUrl = target.shaclUrl();
+    if (ExecSupport.isBlank(shaclUrl)) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.NO_TARGET,
+              "This endpoint has no SHACL validation service configured.",
+              null,
+              null,
+              null));
+    }
+
+    HttpRequest request;
+    try {
+      request =
+          HttpRequest.newBuilder(URI.create(shaclUrl))
+              .timeout(Duration.ofMillis(ExecSupport.timeoutMs(options)))
+              .header("Content-Type", TEXT_TURTLE)
+              .header("Accept", TEXT_TURTLE)
+              .POST(HttpRequest.BodyPublishers.ofString(shapesTurtle))
+              .build();
+    } catch (IllegalArgumentException e) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.HTTP_ERROR, "Invalid SHACL service URL: " + shaclUrl, null, null, null));
+    }
+    return ExecSupport.runCancellable(ctx, () -> {}, () -> send(request, shaclUrl));
+  }
+
+  /** Runs on {@code ctx.executionPool()}. */
+  private static ExecuteResponse send(HttpRequest request, String shaclUrl) {
+    long start = System.currentTimeMillis();
+    try {
+      HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+      return toResponse(response, start, shaclUrl);
+    } catch (HttpTimeoutException e) {
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.TIMEOUT, "Request timed out.", e.getMessage(), null, null));
+    } catch (IOException e) {
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.HTTP_ERROR, e.getMessage(), null, null, null));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.debug("SHACL request interrupted after cancellation");
+      return ExecuteResponse.cancelled();
+    }
+  }
+
+  private static ExecuteResponse toResponse(
+      HttpResponse<String> response, long startMs, String shaclUrl) {
+    int status = response.statusCode();
+    String body = response.body();
+    if (status == 401 || status == 403) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.AUTH_FAILED,
+              "Authentication failed (HTTP " + status + ").",
+              trimmed(body),
+              null,
+              null));
+    }
+    if (status < 200 || status >= 300) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.HTTP_ERROR,
+              "SHACL service answered HTTP " + status + ".",
+              trimmed(body),
+              null,
+              null));
+    }
+
+    ValidationReport report;
+    try {
+      Model model = ModelFactory.createDefaultModel();
+      model.read(new StringReader(body), null, "TURTLE");
+      report = ValidationReport.fromModel(model);
+    } catch (RuntimeException e) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.HTTP_ERROR,
+              "SHACL service returned a report that could not be parsed: " + e.getMessage(),
+              trimmed(body),
+              null,
+              null));
+    }
+    // Keep the service's own serialization as the payload — it is what the user's endpoint said.
+    return ShaclExecutor.toResponse(report, body, startMs, shaclUrl);
+  }
+
+  /** Body excerpt for error details — services can answer with whole HTML error pages. */
+  private static String trimmed(String body) {
+    if (body == null || body.isBlank()) {
+      return null;
+    }
+    String trimmed = body.strip();
+    return trimmed.length() <= 1_000 ? trimmed : trimmed.substring(0, 1_000) + "…";
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ListConnectionsResponse.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ListConnectionsResponse.java
@@ -23,16 +23,13 @@ import java.util.List;
 /**
  * Result of the {@code cimvocabcheck.notebook.listConnections} workspace command: the notebook's
  * applicable {@code "cimnotebook"} config, resolved with nearest-config discovery. Contains no
- * secrets by construction (see {@link NotebookConnection}).
+ * secrets by construction (see {@link NotebookConnection}). The execution defaults
+ * (queryTimeoutSeconds/maxRows) are deliberately not part of the response — the server applies them
+ * itself when a request carries no explicit options.
  *
  * @param configPath the config file the connections came from, or {@code null} when no {@code
- *     opencgmes.jsonc} applies to the notebook.
+ *     opencgmes.jsonc} applies to the notebook. The client watches this file for changes when it
+ *     lies outside the workspace.
  * @param connections the declared connections; empty when there are none.
- * @param queryTimeoutSeconds workspace default execution timeout, or {@code null}.
- * @param maxRows workspace default result cap, or {@code null}.
  */
-record ListConnectionsResponse(
-    String configPath,
-    List<NotebookConnection> connections,
-    Integer queryTimeoutSeconds,
-    Integer maxRows) {}
+record ListConnectionsResponse(String configPath, List<NotebookConnection> connections) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ListConnectionsResponse.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ListConnectionsResponse.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.util.List;
+
+/**
+ * Result of the {@code cimvocabcheck.notebook.listConnections} workspace command: the notebook's
+ * applicable {@code "cimnotebook"} config, resolved with nearest-config discovery. Contains no
+ * secrets by construction (see {@link NotebookConnection}).
+ *
+ * @param configPath the config file the connections came from, or {@code null} when no {@code
+ *     opencgmes.jsonc} applies to the notebook.
+ * @param connections the declared connections; empty when there are none.
+ * @param queryTimeoutSeconds workspace default execution timeout, or {@code null}.
+ * @param maxRows workspace default result cap, or {@code null}.
+ */
+record ListConnectionsResponse(
+    String configPath,
+    List<NotebookConnection> connections,
+    Integer queryTimeoutSeconds,
+    Integer maxRows) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutor.java
@@ -1,0 +1,182 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryCancelledException;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a parsed SPARQL query in-process against local data files ({@link
+ * ExecuteTarget#TYPE_FILES}): RDF files and CIMXML models, parsed and cached by {@link
+ * LocalStoreManager}. Local files are read-only — SPARQL updates are rejected by {@code
+ * NotebookCommandHandler} before reaching this class.
+ *
+ * <p>Relative paths are resolved against the directory of {@link ExecuteRequest#notebookUri()},
+ * matching how validation resolves relative {@code # [endpoint=...]} directives, so the same
+ * directive means the same file for both.
+ *
+ * <p>Cancellation uses the same racing scheme as {@link HttpQueryExecutor} (via {@link
+ * ExecSupport#runCancellable}); for the in-process engine {@code QueryExecution.abort()} and the
+ * timeout both surface as {@link QueryCancelledException}, told apart by whether the client
+ * actually cancelled.
+ */
+final class LocalQueryExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalQueryExecutor.class);
+
+  private LocalQueryExecutor() {}
+
+  /**
+   * Executes a SELECT/ASK/CONSTRUCT/DESCRIBE query against the request's local files, returning a
+   * populated {@link ExecuteResponse}.
+   */
+  static ExecuteResponse executeQuery(
+      Query query,
+      QueryKind kind,
+      ExecuteRequest request,
+      LocalStoreManager stores,
+      ExecContext ctx) {
+    ExecuteTarget target = request.target();
+    if (target.files() == null || target.files().isEmpty()) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.NO_TARGET,
+              "No endpoint configured. Add a `# [endpoint=<url or file>]` directive to the cell.",
+              null,
+              null,
+              null));
+    }
+
+    List<Path> paths;
+    DatasetGraph data;
+    try {
+      paths = resolvePaths(target.files(), notebookDir(request.notebookUri()));
+      data = stores.unionFor(paths);
+    } catch (LocalStoreManager.StoreException e) {
+      return ExecuteResponse.failed(new ExecError(e.code(), e.getMessage(), null, null, null));
+    }
+
+    // The stats line shows the files as the user wrote them in the directive, not the resolved
+    // absolute paths — the notebook-relative form is the meaningful one to a reader.
+    String resolvedTarget = String.join(", ", target.files());
+    int maxRows = ExecSupport.maxRows(request.options());
+    QueryExecution qe =
+        QueryExecution.dataset(DatasetFactory.wrap(data))
+            .query(query)
+            .timeout(ExecSupport.timeoutMs(request.options()), TimeUnit.MILLISECONDS)
+            .build();
+    return ExecSupport.runCancellable(
+        ctx,
+        qe::abort,
+        () -> {
+          try (qe) {
+            return runQuery(qe, kind, resolvedTarget, maxRows, ctx);
+          }
+        });
+  }
+
+  // ---- query execution (runs on ctx.executionPool()) ----------------------------------------
+
+  private static ExecuteResponse runQuery(
+      QueryExecution qe, QueryKind kind, String resolvedTarget, int maxRows, ExecContext ctx) {
+    try {
+      return ExecSupport.successFor(qe, kind, resolvedTarget, maxRows);
+    } catch (QueryCancelledException e) {
+      // The in-process engine raises the same exception for both ways an execution is cut short:
+      // the timeout, and the best-effort abort() runCancellable fires on client cancellation.
+      if (ctx.cancelChecker().isCanceled()) {
+        LOG.debug("{} query aborted after cancellation", kind);
+        return ExecuteResponse.cancelled();
+      }
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.TIMEOUT, "Query timed out.", e.getMessage(), null, null));
+    } catch (CancellationException e) {
+      LOG.debug("{} query aborted after cancellation", kind);
+      return ExecuteResponse.cancelled();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error executing local {} query: {}", kind, e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  // ---- path resolution -----------------------------------------------------------------------
+
+  private static List<Path> resolvePaths(List<String> files, Path notebookDir)
+      throws LocalStoreManager.StoreException {
+    List<Path> paths = new ArrayList<>(files.size());
+    for (String file : files) {
+      paths.add(resolvePath(file, notebookDir));
+    }
+    return paths;
+  }
+
+  private static Path resolvePath(String file, Path notebookDir)
+      throws LocalStoreManager.StoreException {
+    Path path;
+    try {
+      path = Path.of(file);
+    } catch (InvalidPathException e) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND, "Not a valid file path: " + file, e);
+    }
+    if (path.isAbsolute()) {
+      return path.normalize();
+    }
+    if (notebookDir == null) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND,
+          "Cannot resolve the relative path "
+              + file
+              + " — save the notebook first so relative paths have a base directory.",
+          null);
+    }
+    return notebookDir.resolve(path).normalize();
+  }
+
+  /** The notebook's directory, or {@code null} when the notebook has no on-disk location. */
+  private static Path notebookDir(String notebookUri) {
+    if (notebookUri == null || notebookUri.isBlank()) {
+      return null;
+    }
+    try {
+      URI uri = new URI(notebookUri);
+      if (!"file".equalsIgnoreCase(uri.getScheme())) {
+        return null;
+      }
+      return Path.of(uri).getParent();
+    } catch (URISyntaxException | IllegalArgumentException e) {
+      LOG.debug("Ignoring unusable notebook URI {}: {}", notebookUri, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutor.java
@@ -18,11 +18,7 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
@@ -76,10 +72,9 @@ final class LocalQueryExecutor {
               null));
     }
 
-    List<Path> paths;
     DatasetGraph data;
     try {
-      paths = resolvePaths(target.files(), notebookDir(request.notebookUri()));
+      List<Path> paths = NotebookPaths.resolvePaths(target.files(), request.notebookUri());
       data = stores.unionFor(paths);
     } catch (LocalStoreManager.StoreException e) {
       return ExecuteResponse.failed(new ExecError(e.code(), e.getMessage(), null, null, null));
@@ -126,57 +121,6 @@ final class LocalQueryExecutor {
       LOG.error("Unexpected error executing local {} query: {}", kind, e.getMessage(), e);
       return ExecuteResponse.failed(
           new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
-    }
-  }
-
-  // ---- path resolution -----------------------------------------------------------------------
-
-  private static List<Path> resolvePaths(List<String> files, Path notebookDir)
-      throws LocalStoreManager.StoreException {
-    List<Path> paths = new ArrayList<>(files.size());
-    for (String file : files) {
-      paths.add(resolvePath(file, notebookDir));
-    }
-    return paths;
-  }
-
-  private static Path resolvePath(String file, Path notebookDir)
-      throws LocalStoreManager.StoreException {
-    Path path;
-    try {
-      path = Path.of(file);
-    } catch (InvalidPathException e) {
-      throw new LocalStoreManager.StoreException(
-          ErrorCode.FILE_NOT_FOUND, "Not a valid file path: " + file, e);
-    }
-    if (path.isAbsolute()) {
-      return path.normalize();
-    }
-    if (notebookDir == null) {
-      throw new LocalStoreManager.StoreException(
-          ErrorCode.FILE_NOT_FOUND,
-          "Cannot resolve the relative path "
-              + file
-              + " — save the notebook first so relative paths have a base directory.",
-          null);
-    }
-    return notebookDir.resolve(path).normalize();
-  }
-
-  /** The notebook's directory, or {@code null} when the notebook has no on-disk location. */
-  private static Path notebookDir(String notebookUri) {
-    if (notebookUri == null || notebookUri.isBlank()) {
-      return null;
-    }
-    try {
-      URI uri = new URI(notebookUri);
-      if (!"file".equalsIgnoreCase(uri.getScheme())) {
-        return null;
-      }
-      return Path.of(uri).getParent();
-    } catch (URISyntaxException | IllegalArgumentException e) {
-      LOG.debug("Ignoring unusable notebook URI {}: {}", notebookUri, e.getMessage());
-      return null;
     }
   }
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManager.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManager.java
@@ -25,15 +25,10 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.compose.MultiUnion;
 import org.apache.jena.riot.RDFDataMgr;
@@ -53,10 +48,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p><b>Caching.</b> Entries are keyed by absolute path and invalidated when the file's
  * modification time or size changes, checked on every access — editing a model and re-running the
- * cell always queries the current file. The cache is future-valued so concurrent cells hitting the
- * same not-yet-parsed file share one parse instead of racing, and LRU-bounded ({@value
- * #DEFAULT_CAPACITY} files by default) because CIMXML models can be large; evicted files are simply
- * re-parsed on next use.
+ * cell always queries the current file. Lookups are serialized on the manager, so concurrent cells
+ * hitting the same not-yet-parsed file briefly queue up behind one parse instead of racing. The
+ * cache is LRU-bounded ({@value #DEFAULT_CAPACITY} files by default) because CIMXML models can be
+ * large; evicted files are simply re-parsed on next use.
  *
  * <p><b>Union semantics.</b> {@link #unionFor} exposes multiple files as one dataset: every named
  * graph of every file stays addressable via {@code GRAPH}, while the default graph is the union of
@@ -78,18 +73,19 @@ final class LocalStoreManager {
   /** A cached parse: the file's attributes at parse time, used to detect staleness on access. */
   private record CachedEntry(FileTime mtime, long size, DatasetGraph graph) {}
 
-  private final Map<Path, CompletableFuture<CachedEntry>> cache;
+  /** All access goes through the synchronized {@link #datasetGraphFor}. */
+  private final LruCache cache;
 
   LocalStoreManager() {
     this(DEFAULT_CAPACITY);
   }
 
   LocalStoreManager(int capacity) {
-    this.cache = Collections.synchronizedMap(new LruCache(capacity));
+    this.cache = new LruCache(capacity);
   }
 
   /** Access-ordered {@link LinkedHashMap} bounded at {@code capacity} entries. */
-  private static final class LruCache extends LinkedHashMap<Path, CompletableFuture<CachedEntry>> {
+  private static final class LruCache extends LinkedHashMap<Path, CachedEntry> {
 
     private static final long serialVersionUID = 1L;
 
@@ -101,7 +97,7 @@ final class LocalStoreManager {
     }
 
     @Override
-    protected boolean removeEldestEntry(Map.Entry<Path, CompletableFuture<CachedEntry>> eldest) {
+    protected boolean removeEldestEntry(Map.Entry<Path, CachedEntry> eldest) {
       boolean evict = size() > capacity;
       if (evict) {
         LOG.debug(
@@ -157,58 +153,22 @@ final class LocalStoreManager {
   }
 
   /**
-   * Returns the (possibly cached) parse of one file, re-parsing when the file changed on disk.
-   * Package-private so tests can observe cache behavior through instance identity.
+   * Returns the (possibly cached) parse of one file, re-parsing when the file changed on disk. A
+   * failed parse is not cached, so the next run retries (the file has usually been edited by then
+   * anyway). Package-private so tests can observe cache behavior through instance identity.
    */
-  DatasetGraph datasetGraphFor(Path file) throws StoreException {
-    while (true) {
-      BasicFileAttributes attrs = readAttributes(file);
-
-      AtomicBoolean isLoader = new AtomicBoolean();
-      CompletableFuture<CachedEntry> future =
-          cache.computeIfAbsent(
-              file,
-              p -> {
-                isLoader.set(true);
-                return new CompletableFuture<>();
-              });
-
-      if (isLoader.get()) {
-        // This thread inserted the future, so it owns the parse; concurrent callers of the same
-        // file are waiting on the future below. A failed parse is not cached — the mapping is
-        // removed so the next run retries (the file has usually been edited by then anyway).
-        try {
-          CachedEntry entry = new CachedEntry(attrs.lastModifiedTime(), attrs.size(), parse(file));
-          future.complete(entry);
-          return entry.graph();
-        } catch (StoreException | RuntimeException | Error e) {
-          cache.remove(file, future);
-          future.completeExceptionally(e);
-          throw e;
-        }
-      }
-
-      CachedEntry entry = awaitEntry(file, future);
+  synchronized DatasetGraph datasetGraphFor(Path file) throws StoreException {
+    BasicFileAttributes attrs = readAttributes(file);
+    CachedEntry entry = cache.get(file);
+    if (entry != null) {
       if (entry.mtime().equals(attrs.lastModifiedTime()) && entry.size() == attrs.size()) {
         return entry.graph();
       }
       LOG.debug("Cached store for {} is stale, re-parsing", file);
-      cache.remove(file, future);
     }
-  }
-
-  private static CachedEntry awaitEntry(Path file, CompletableFuture<CachedEntry> future)
-      throws StoreException {
-    try {
-      return future.join();
-    } catch (CompletionException | CancellationException e) {
-      Throwable cause = e.getCause();
-      if (cause instanceof StoreException storeException) {
-        throw storeException;
-      }
-      throw new StoreException(
-          ErrorCode.FILE_PARSE_ERROR, "Failed to parse " + file + ": " + e.getMessage(), e);
-    }
+    CachedEntry parsed = new CachedEntry(attrs.lastModifiedTime(), attrs.size(), parse(file));
+    cache.put(file, parsed);
+    return parsed.graph();
   }
 
   private static BasicFileAttributes readAttributes(Path file) throws StoreException {

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManager.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManager.java
@@ -1,0 +1,242 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import de.soptim.opencgmes.cimxml.parser.CimXmlParser;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.compose.MultiUnion;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphMapLink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parses local data files into query-ready {@link DatasetGraph}s for {@link LocalQueryExecutor},
+ * caching the parses so re-running a cell does not re-read a large model.
+ *
+ * <p><b>File formats.</b> {@code *.xml} is parsed as a IEC 61970-552 CIMXML model via {@link
+ * CimXmlParser} (header in a named graph, body in the default graph); everything else is handed to
+ * Jena's {@link RDFDataMgr}, which picks the parser from the extension ({@code .ttl}, {@code .rdf},
+ * {@code .owl}, {@code .nt}, {@code .nq}, {@code .trig}, …).
+ *
+ * <p><b>Caching.</b> Entries are keyed by absolute path and invalidated when the file's
+ * modification time or size changes, checked on every access — editing a model and re-running the
+ * cell always queries the current file. The cache is future-valued so concurrent cells hitting the
+ * same not-yet-parsed file share one parse instead of racing, and LRU-bounded ({@value
+ * #DEFAULT_CAPACITY} files by default) because CIMXML models can be large; evicted files are simply
+ * re-parsed on next use.
+ *
+ * <p><b>Union semantics.</b> {@link #unionFor} exposes multiple files as one dataset: every named
+ * graph of every file stays addressable via {@code GRAPH}, while the default graph is the union of
+ * <em>all</em> graphs (default and named) of all files, so a bare {@code ?s ?p ?o} sees everything
+ * — including a CIMXML model's header. Files with identical named-graph names (e.g. two CIMXML
+ * FullModel headers, both {@code md:FullModel}) collide in {@code GRAPH} lookups — the last file
+ * wins there — but remain fully visible in the default-graph union.
+ *
+ * <p>The returned datasets are read-only by convention: updates are rejected before execution (see
+ * {@link ErrorCode#UPDATE_NOT_ALLOWED}), and nothing else writes to the cached graphs.
+ */
+final class LocalStoreManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalStoreManager.class);
+
+  /** Default maximum number of parsed files kept in memory. */
+  static final int DEFAULT_CAPACITY = 8;
+
+  /** A cached parse: the file's attributes at parse time, used to detect staleness on access. */
+  private record CachedEntry(FileTime mtime, long size, DatasetGraph graph) {}
+
+  private final Map<Path, CompletableFuture<CachedEntry>> cache;
+
+  LocalStoreManager() {
+    this(DEFAULT_CAPACITY);
+  }
+
+  LocalStoreManager(int capacity) {
+    this.cache = Collections.synchronizedMap(new LruCache(capacity));
+  }
+
+  /** Access-ordered {@link LinkedHashMap} bounded at {@code capacity} entries. */
+  private static final class LruCache extends LinkedHashMap<Path, CompletableFuture<CachedEntry>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int capacity;
+
+    LruCache(int capacity) {
+      super(16, 0.75f, true);
+      this.capacity = capacity;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<Path, CompletableFuture<CachedEntry>> eldest) {
+      boolean evict = size() > capacity;
+      if (evict) {
+        LOG.debug(
+            "Evicting parsed store {} (cache holds at most {} files)", eldest.getKey(), capacity);
+      }
+      return evict;
+    }
+  }
+
+  /**
+   * A file could not be read or parsed; {@link #code()} says which of the two it was, and the
+   * message is already user-presentable (it names the file).
+   */
+  static final class StoreException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ErrorCode code;
+
+    StoreException(ErrorCode code, String message, Throwable cause) {
+      super(message, cause);
+      this.code = code;
+    }
+
+    ErrorCode code() {
+      return code;
+    }
+  }
+
+  /**
+   * Returns one queryable dataset over {@code files} (absolute paths), parsing or re-using cached
+   * parses per file — see the class comment for the union semantics.
+   */
+  DatasetGraph unionFor(List<Path> files) throws StoreException {
+    List<DatasetGraph> parts = new ArrayList<>(files.size());
+    for (Path file : files) {
+      parts.add(datasetGraphFor(file));
+    }
+
+    MultiUnion defaultUnion = new MultiUnion();
+    DatasetGraph union = new DatasetGraphMapLink(defaultUnion);
+    for (DatasetGraph part : parts) {
+      defaultUnion.addGraph(part.getDefaultGraph());
+      part.listGraphNodes()
+          .forEachRemaining(
+              name -> {
+                Graph graph = part.getGraph(name);
+                defaultUnion.addGraph(graph);
+                union.addGraph(name, graph);
+              });
+    }
+    return union;
+  }
+
+  /**
+   * Returns the (possibly cached) parse of one file, re-parsing when the file changed on disk.
+   * Package-private so tests can observe cache behavior through instance identity.
+   */
+  DatasetGraph datasetGraphFor(Path file) throws StoreException {
+    while (true) {
+      BasicFileAttributes attrs = readAttributes(file);
+
+      AtomicBoolean isLoader = new AtomicBoolean();
+      CompletableFuture<CachedEntry> future =
+          cache.computeIfAbsent(
+              file,
+              p -> {
+                isLoader.set(true);
+                return new CompletableFuture<>();
+              });
+
+      if (isLoader.get()) {
+        // This thread inserted the future, so it owns the parse; concurrent callers of the same
+        // file are waiting on the future below. A failed parse is not cached — the mapping is
+        // removed so the next run retries (the file has usually been edited by then anyway).
+        try {
+          CachedEntry entry = new CachedEntry(attrs.lastModifiedTime(), attrs.size(), parse(file));
+          future.complete(entry);
+          return entry.graph();
+        } catch (StoreException | RuntimeException | Error e) {
+          cache.remove(file, future);
+          future.completeExceptionally(e);
+          throw e;
+        }
+      }
+
+      CachedEntry entry = awaitEntry(file, future);
+      if (entry.mtime().equals(attrs.lastModifiedTime()) && entry.size() == attrs.size()) {
+        return entry.graph();
+      }
+      LOG.debug("Cached store for {} is stale, re-parsing", file);
+      cache.remove(file, future);
+    }
+  }
+
+  private static CachedEntry awaitEntry(Path file, CompletableFuture<CachedEntry> future)
+      throws StoreException {
+    try {
+      return future.join();
+    } catch (CompletionException | CancellationException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof StoreException storeException) {
+        throw storeException;
+      }
+      throw new StoreException(
+          ErrorCode.FILE_PARSE_ERROR, "Failed to parse " + file + ": " + e.getMessage(), e);
+    }
+  }
+
+  private static BasicFileAttributes readAttributes(Path file) throws StoreException {
+    try {
+      BasicFileAttributes attrs = Files.readAttributes(file, BasicFileAttributes.class);
+      if (!attrs.isRegularFile()) {
+        throw new StoreException(ErrorCode.FILE_NOT_FOUND, "Not a file: " + file, null);
+      }
+      return attrs;
+    } catch (IOException e) {
+      throw new StoreException(ErrorCode.FILE_NOT_FOUND, "File not found: " + file, e);
+    }
+  }
+
+  private static DatasetGraph parse(Path file) throws StoreException {
+    long start = System.currentTimeMillis();
+    try {
+      Path fileName = file.getFileName();
+      String name = fileName != null ? fileName.toString().toLowerCase(Locale.ROOT) : "";
+      DatasetGraph parsed =
+          name.endsWith(".xml")
+              ? new CimXmlParser().parseCimModel(file)
+              : RDFDataMgr.loadDatasetGraph(file.toUri().toString());
+      LOG.debug("Parsed {} in {} ms", file, System.currentTimeMillis() - start);
+      return parsed;
+    } catch (IOException | RuntimeException e) {
+      throw new StoreException(
+          ErrorCode.FILE_PARSE_ERROR, "Failed to parse " + file + ": " + e.getMessage(), e);
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -1,0 +1,153 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles the {@value #CMD_EXECUTE} workspace command: runs a notebook cell's SPARQL query or
+ * update against the endpoint resolved by the client, and returns an {@link ExecuteResponse}.
+ *
+ * <p>Wired into {@code SparqlWorkspaceService#executeCommand} by {@code SparqlLanguageServer},
+ * which also forwards {@link #shutdown()} from its own shutdown sequence.
+ */
+public final class NotebookCommandHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookCommandHandler.class);
+  private static final Gson GSON = new Gson();
+
+  /** Command id for cell execution (see {@link #executeCommand}). */
+  public static final String CMD_EXECUTE = "cimvocabcheck.notebook.execute";
+
+  /**
+   * Pool the blocking Jena HTTP call runs on. Must stay unbounded (cached, not fixed): {@link
+   * HttpQueryExecutor#executeQuery} submits its own nested task to this same pool and joins on it
+   * from the calling thread, so a fixed-size pool could deadlock once all threads are blocked
+   * waiting on a nested task that has no thread left to run on.
+   */
+  private final ExecutorService executionPool =
+      Executors.newCachedThreadPool(threadFactory("cimvocabcheck-notebook-exec"));
+
+  private final ScheduledExecutorService watchdogScheduler =
+      Executors.newSingleThreadScheduledExecutor(threadFactory("cimvocabcheck-notebook-watchdog"));
+
+  /**
+   * Handles one {@value #CMD_EXECUTE} invocation. {@code arguments} must have a single element that
+   * Gson-deserializes to an {@link ExecuteRequest}; over JSON-RPC this arrives as a {@link
+   * JsonElement}, while a direct in-process call may pass a JSON {@link String}.
+   */
+  public CompletableFuture<Object> executeCommand(List<Object> arguments) {
+    ExecuteRequest request;
+    try {
+      request = parseRequest(arguments);
+    } catch (RuntimeException e) {
+      return CompletableFuture.failedFuture(
+          new ResponseErrorException(
+              new ResponseError(
+                  ResponseErrorCode.InvalidParams,
+                  "Malformed " + CMD_EXECUTE + " argument: " + e.getMessage(),
+                  null)));
+    }
+    return CompletableFutures.computeAsync(
+        executionPool, cancelChecker -> doExecute(request, cancelChecker));
+  }
+
+  /** Releases the thread pools. Safe to call once during server shutdown. */
+  public void shutdown() {
+    executionPool.shutdown();
+    watchdogScheduler.shutdown();
+    try {
+      if (!executionPool.awaitTermination(2, TimeUnit.SECONDS)) {
+        executionPool.shutdownNow();
+      }
+      if (!watchdogScheduler.awaitTermination(2, TimeUnit.SECONDS)) {
+        watchdogScheduler.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      executionPool.shutdownNow();
+      watchdogScheduler.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private Object doExecute(ExecuteRequest request, CancelChecker cancelChecker) {
+    LOG.debug("Executing {} cell {}", request.languageId(), request.cellUri());
+    try {
+      var ctx = new HttpQueryExecutor.ExecContext(executionPool, watchdogScheduler, cancelChecker);
+      return switch (QueryKindDetector.detect(request.text())) {
+        case QueryKindDetector.AsQuery(var kind, var query) ->
+            HttpQueryExecutor.executeQuery(query, kind, request.target(), request.options(), ctx);
+        case QueryKindDetector.AsUpdate(var update) ->
+            HttpQueryExecutor.executeUpdate(update, request.target(), request.options(), ctx);
+        case QueryKindDetector.ParseFailure(var message, var line, var column) ->
+            ExecuteResponse.failed(
+                new ExecError(ErrorCode.PARSE_ERROR, message, null, line, column));
+      };
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error handling {}: {}", CMD_EXECUTE, e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  /**
+   * Extracts and deserializes the command's single argument. Over JSON-RPC, lsp4j delivers
+   * arguments as Gson {@link JsonElement}s; a direct in-process call may pass a JSON {@link String}
+   * instead — mirrors the dual-case handling in {@code SparqlWorkspaceService}.
+   */
+  private static ExecuteRequest parseRequest(List<Object> arguments) {
+    if (arguments == null || arguments.isEmpty() || arguments.get(0) == null) {
+      throw new IllegalArgumentException("missing required argument");
+    }
+    Object first = arguments.get(0);
+    ExecuteRequest request =
+        first instanceof JsonElement el
+            ? GSON.fromJson(el, ExecuteRequest.class)
+            : GSON.fromJson(first.toString(), ExecuteRequest.class);
+    if (request == null || request.text() == null) {
+      throw new IllegalArgumentException("missing required field 'text'");
+    }
+    return request;
+  }
+
+  private static ThreadFactory threadFactory(String namePrefix) {
+    AtomicInteger threadNum = new AtomicInteger(1);
+    return r -> {
+      Thread t = new Thread(r, namePrefix + "-" + threadNum.getAndIncrement());
+      t.setDaemon(true);
+      return t;
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -37,9 +37,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles the {@value #CMD_EXECUTE} workspace command: runs a notebook cell's SPARQL query or
- * update against the target resolved by the client — an HTTP endpoint ({@link HttpQueryExecutor})
- * or local RDF/CIMXML files ({@link LocalQueryExecutor}) — and returns an {@link ExecuteResponse}.
+ * Handles the {@value #CMD_EXECUTE} workspace command: runs a notebook cell — a SPARQL query or
+ * update, or a SHACL shapes cell ({@link ShaclExecutor}) — against the target resolved by the
+ * client, an HTTP endpoint ({@link HttpQueryExecutor}) or local RDF/CIMXML files ({@link
+ * LocalQueryExecutor}), and returns an {@link ExecuteResponse}.
  *
  * <p>Wired into {@code SparqlWorkspaceService#executeCommand} by {@code SparqlLanguageServer},
  * which also forwards {@link #shutdown()} from its own shutdown sequence.
@@ -109,6 +110,10 @@ public final class NotebookCommandHandler {
     LOG.debug("Executing {} cell {}", request.languageId(), request.cellUri());
     try {
       var ctx = new ExecContext(executionPool, watchdogScheduler, cancelChecker);
+      if ("shacl".equalsIgnoreCase(request.languageId())) {
+        // SHACL cells are Turtle shapes, not SPARQL — never route them through the query parser.
+        return ShaclExecutor.execute(request, localStores, ctx);
+      }
       boolean filesTarget =
           request.target() != null && ExecuteTarget.TYPE_FILES.equals(request.target().type());
       return switch (QueryKindDetector.detect(request.text())) {

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -53,6 +53,9 @@ public final class NotebookCommandHandler {
   /** Command id for cell execution (see {@link #executeCommand}). */
   public static final String CMD_EXECUTE = "cimvocabcheck.notebook.execute";
 
+  /** Command id for listing a notebook's configured connections (see {@link #listConnections}). */
+  public static final String CMD_LIST_CONNECTIONS = "cimvocabcheck.notebook.listConnections";
+
   /**
    * Pool the blocking Jena call runs on. Must stay unbounded (cached, not fixed): the executors'
    * {@link ExecSupport#runCancellable} racing submits its own nested task to this same pool and
@@ -88,6 +91,36 @@ public final class NotebookCommandHandler {
         executionPool, cancelChecker -> doExecute(request, cancelChecker));
   }
 
+  /**
+   * Handles one {@value #CMD_LIST_CONNECTIONS} invocation: answers the {@code "cimnotebook"} config
+   * that applies to the notebook named by the single argument's {@code notebookUri} field
+   * (nearest-config discovery; empty result when none applies). Never returns secrets — the config
+   * only ever declares an {@code authType}.
+   */
+  public CompletableFuture<Object> listConnections(List<Object> arguments) {
+    String notebookUri = null;
+    if (arguments != null && !arguments.isEmpty() && arguments.get(0) != null) {
+      Object first = arguments.get(0);
+      JsonElement el =
+          first instanceof JsonElement je ? je : GSON.fromJson(first.toString(), JsonElement.class);
+      if (el != null && el.isJsonObject() && el.getAsJsonObject().has("notebookUri")) {
+        notebookUri = el.getAsJsonObject().get("notebookUri").getAsString();
+      }
+    }
+    final String uri = notebookUri;
+    return CompletableFuture.supplyAsync(
+        () -> {
+          NotebookConfigLoader.Located located = NotebookConfigLoader.forNotebook(uri);
+          NotebookConfig config = located.config();
+          return new ListConnectionsResponse(
+              located.configPath() != null ? located.configPath().toString() : null,
+              config.connections(),
+              config.queryTimeoutSeconds(),
+              config.maxRows());
+        },
+        executionPool);
+  }
+
   /** Releases the thread pools. Safe to call once during server shutdown. */
   public void shutdown() {
     executionPool.shutdown();
@@ -106,9 +139,10 @@ public final class NotebookCommandHandler {
     }
   }
 
-  private Object doExecute(ExecuteRequest request, CancelChecker cancelChecker) {
-    LOG.debug("Executing {} cell {}", request.languageId(), request.cellUri());
+  private Object doExecute(ExecuteRequest rawRequest, CancelChecker cancelChecker) {
+    LOG.debug("Executing {} cell {}", rawRequest.languageId(), rawRequest.cellUri());
     try {
+      ExecuteRequest request = withConfigDefaults(rawRequest);
       var ctx = new ExecContext(executionPool, watchdogScheduler, cancelChecker);
       if ("shacl".equalsIgnoreCase(request.languageId())) {
         // SHACL cells are Turtle shapes, not SPARQL — never route them through the query parser.
@@ -142,6 +176,36 @@ public final class NotebookCommandHandler {
       return ExecuteResponse.failed(
           new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
     }
+  }
+
+  /**
+   * Fills unset execution options from the notebook's {@code "cimnotebook"} config
+   * (queryTimeoutSeconds/maxRows), so workspace-wide defaults apply without the client having to
+   * read the config itself. Explicit per-request options always win.
+   */
+  private static ExecuteRequest withConfigDefaults(ExecuteRequest request) {
+    ExecuteOptions options = request.options();
+    boolean needsTimeout = options == null || options.timeoutMs() == null;
+    boolean needsMaxRows = options == null || options.maxRows() == null;
+    if (!needsTimeout && !needsMaxRows) {
+      return request;
+    }
+    NotebookConfig config = NotebookConfigLoader.forNotebook(request.notebookUri()).config();
+    if (config.queryTimeoutSeconds() == null && config.maxRows() == null) {
+      return request;
+    }
+    Integer timeoutMs =
+        !needsTimeout
+            ? options.timeoutMs()
+            : config.queryTimeoutSeconds() != null ? config.queryTimeoutSeconds() * 1_000 : null;
+    Integer maxRows = !needsMaxRows ? options.maxRows() : config.maxRows();
+    return new ExecuteRequest(
+        request.cellUri(),
+        request.notebookUri(),
+        request.languageId(),
+        request.text(),
+        request.target(),
+        new ExecuteOptions(timeoutMs, maxRows));
   }
 
   /**

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -98,25 +98,17 @@ public final class NotebookCommandHandler {
    * only ever declares an {@code authType}.
    */
   public CompletableFuture<Object> listConnections(List<Object> arguments) {
-    String notebookUri = null;
-    if (arguments != null && !arguments.isEmpty() && arguments.get(0) != null) {
-      Object first = arguments.get(0);
-      JsonElement el =
-          first instanceof JsonElement je ? je : GSON.fromJson(first.toString(), JsonElement.class);
-      if (el != null && el.isJsonObject() && el.getAsJsonObject().has("notebookUri")) {
-        notebookUri = el.getAsJsonObject().get("notebookUri").getAsString();
-      }
-    }
-    final String uri = notebookUri;
+    JsonElement el = CommandArguments.firstAsJson(arguments);
+    final String uri =
+        el != null && el.isJsonObject() && el.getAsJsonObject().has("notebookUri")
+            ? el.getAsJsonObject().get("notebookUri").getAsString()
+            : null;
     return CompletableFuture.supplyAsync(
         () -> {
           NotebookConfigLoader.Located located = NotebookConfigLoader.forNotebook(uri);
-          NotebookConfig config = located.config();
           return new ListConnectionsResponse(
               located.configPath() != null ? located.configPath().toString() : null,
-              config.connections(),
-              config.queryTimeoutSeconds(),
-              config.maxRows());
+              located.config().connections());
         },
         executionPool);
   }
@@ -208,20 +200,13 @@ public final class NotebookCommandHandler {
         new ExecuteOptions(timeoutMs, maxRows));
   }
 
-  /**
-   * Extracts and deserializes the command's single argument. Over JSON-RPC, lsp4j delivers
-   * arguments as Gson {@link JsonElement}s; a direct in-process call may pass a JSON {@link String}
-   * instead — mirrors the dual-case handling in {@code SparqlWorkspaceService}.
-   */
+  /** Extracts and deserializes the command's single argument (see {@link CommandArguments}). */
   private static ExecuteRequest parseRequest(List<Object> arguments) {
-    if (arguments == null || arguments.isEmpty() || arguments.get(0) == null) {
+    JsonElement el = CommandArguments.firstAsJson(arguments);
+    if (el == null) {
       throw new IllegalArgumentException("missing required argument");
     }
-    Object first = arguments.get(0);
-    ExecuteRequest request =
-        first instanceof JsonElement el
-            ? GSON.fromJson(el, ExecuteRequest.class)
-            : GSON.fromJson(first.toString(), ExecuteRequest.class);
+    ExecuteRequest request = GSON.fromJson(el, ExecuteRequest.class);
     if (request == null || request.text() == null) {
       throw new IllegalArgumentException("missing required field 'text'");
     }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -38,7 +38,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@value #CMD_EXECUTE} workspace command: runs a notebook cell's SPARQL query or
- * update against the endpoint resolved by the client, and returns an {@link ExecuteResponse}.
+ * update against the target resolved by the client — an HTTP endpoint ({@link HttpQueryExecutor})
+ * or local RDF/CIMXML files ({@link LocalQueryExecutor}) — and returns an {@link ExecuteResponse}.
  *
  * <p>Wired into {@code SparqlWorkspaceService#executeCommand} by {@code SparqlLanguageServer},
  * which also forwards {@link #shutdown()} from its own shutdown sequence.
@@ -52,16 +53,18 @@ public final class NotebookCommandHandler {
   public static final String CMD_EXECUTE = "cimvocabcheck.notebook.execute";
 
   /**
-   * Pool the blocking Jena HTTP call runs on. Must stay unbounded (cached, not fixed): {@link
-   * HttpQueryExecutor#executeQuery} submits its own nested task to this same pool and joins on it
-   * from the calling thread, so a fixed-size pool could deadlock once all threads are blocked
-   * waiting on a nested task that has no thread left to run on.
+   * Pool the blocking Jena call runs on. Must stay unbounded (cached, not fixed): the executors'
+   * {@link ExecSupport#runCancellable} racing submits its own nested task to this same pool and
+   * joins on it from the calling thread, so a fixed-size pool could deadlock once all threads are
+   * blocked waiting on a nested task that has no thread left to run on.
    */
   private final ExecutorService executionPool =
       Executors.newCachedThreadPool(threadFactory("cimvocabcheck-notebook-exec"));
 
   private final ScheduledExecutorService watchdogScheduler =
       Executors.newSingleThreadScheduledExecutor(threadFactory("cimvocabcheck-notebook-watchdog"));
+
+  private final LocalStoreManager localStores = new LocalStoreManager();
 
   /**
    * Handles one {@value #CMD_EXECUTE} invocation. {@code arguments} must have a single element that
@@ -105,12 +108,26 @@ public final class NotebookCommandHandler {
   private Object doExecute(ExecuteRequest request, CancelChecker cancelChecker) {
     LOG.debug("Executing {} cell {}", request.languageId(), request.cellUri());
     try {
-      var ctx = new HttpQueryExecutor.ExecContext(executionPool, watchdogScheduler, cancelChecker);
+      var ctx = new ExecContext(executionPool, watchdogScheduler, cancelChecker);
+      boolean filesTarget =
+          request.target() != null && ExecuteTarget.TYPE_FILES.equals(request.target().type());
       return switch (QueryKindDetector.detect(request.text())) {
         case QueryKindDetector.AsQuery(var kind, var query) ->
-            HttpQueryExecutor.executeQuery(query, kind, request.target(), request.options(), ctx);
+            filesTarget
+                ? LocalQueryExecutor.executeQuery(query, kind, request, localStores, ctx)
+                : HttpQueryExecutor.executeQuery(
+                    query, kind, request.target(), request.options(), ctx);
         case QueryKindDetector.AsUpdate(var update) ->
-            HttpQueryExecutor.executeUpdate(update, request.target(), request.options(), ctx);
+            filesTarget
+                ? ExecuteResponse.failed(
+                    new ExecError(
+                        ErrorCode.UPDATE_NOT_ALLOWED,
+                        "Local files are read-only — running a SPARQL Update needs an HTTP"
+                            + " endpoint.",
+                        null,
+                        null,
+                        null))
+                : HttpQueryExecutor.executeUpdate(update, request.target(), request.options(), ctx);
         case QueryKindDetector.ParseFailure(var message, var line, var column) ->
             ExecuteResponse.failed(
                 new ExecError(ErrorCode.PARSE_ERROR, message, null, line, column));

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfig.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfig.java
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.util.List;
+
+/**
+ * The {@code "cimnotebook"} section of {@code opencgmes.jsonc} — a sibling of the {@code
+ * "cimvocabcheck"} section the validator reads, parsed by {@link NotebookConfigLoader}.
+ *
+ * @param connections named endpoint connections; never {@code null} after loading.
+ * @param queryTimeoutSeconds workspace default for the execution timeout; {@code null} keeps the
+ *     built-in default ({@link ExecSupport#DEFAULT_TIMEOUT_MS}).
+ * @param maxRows workspace default for the result row/triple cap; {@code null} keeps the built-in
+ *     default ({@link ExecSupport#DEFAULT_MAX_ROWS}).
+ */
+public record NotebookConfig(
+    List<NotebookConnection> connections, Integer queryTimeoutSeconds, Integer maxRows) {
+
+  static final NotebookConfig EMPTY = new NotebookConfig(List.of(), null, null);
+
+  /** Normalizes an absent {@code connections} array to an immutable empty list. */
+  public NotebookConfig {
+    connections = connections == null ? List.of() : List.copyOf(connections);
+  }
+
+  /** The connection marked {@code "default": true}, or {@code null} if none is. */
+  public NotebookConnection defaultConnection() {
+    return connections.stream().filter(NotebookConnection::isDefault).findFirst().orElse(null);
+  }
+
+  /** The connection with the given name (exact match), or {@code null}. */
+  public NotebookConnection byName(String name) {
+    return connections.stream()
+        .filter(c -> name != null && name.equals(c.name()))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfigLoader.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfigLoader.java
@@ -1,0 +1,135 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reads the {@code "cimnotebook"} section from the nearest {@code opencgmes.jsonc} — the same
+ * git-style nearest-config discovery and lenient JSONC parsing (comments, trailing commas) as the
+ * validator's {@link ConfigLoader}, which owns the {@code "cimvocabcheck"} sibling section and is
+ * untouched by this loader.
+ *
+ * <p>Reads are deliberately forgiving: a missing file, missing section, or unparseable file all
+ * yield {@link NotebookConfig#EMPTY} (with a log line for the parse failure) — the validator
+ * already surfaces config syntax problems to the user, notebooks don't need to pile on.
+ *
+ * <p><b>Caching.</b> Parsed configs are cached per file and invalidated when its modification time
+ * or size changes, because this sits on the interactive path: a notebook cell without its own
+ * {@code # [endpoint=...]} directive resolves its schema through here on every completion, hover,
+ * and validation — i.e. on every keystroke. Only the parse is cached; the nearest-config discovery
+ * still runs each time (a handful of {@code stat} calls), so a newly created {@code
+ * opencgmes.jsonc} takes effect immediately.
+ */
+public final class NotebookConfigLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookConfigLoader.class);
+
+  private static final String SECTION = "cimnotebook";
+
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .configure(JsonReadFeature.ALLOW_JAVA_COMMENTS.mappedFeature(), true)
+          .configure(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature(), true);
+
+  /** A cached parse: the file's attributes at parse time, used to detect staleness on access. */
+  private record CachedConfig(FileTime mtime, long size, NotebookConfig config) {}
+
+  private static final Map<Path, CachedConfig> CACHE = new ConcurrentHashMap<>();
+
+  private NotebookConfigLoader() {}
+
+  /** A loaded config together with the file it came from ({@code null} when none was found). */
+  public record Located(NotebookConfig config, Path configPath) {
+
+    static final Located NONE = new Located(NotebookConfig.EMPTY, null);
+  }
+
+  /** Loads the config that applies to a notebook, via its directory. */
+  static Located forNotebook(String notebookUri) {
+    return forDirectory(NotebookPaths.notebookDir(notebookUri));
+  }
+
+  /** Loads the config that applies to documents in {@code dir} ({@code null} → none). */
+  public static Located forDirectory(Path dir) {
+    if (dir == null) {
+      return Located.NONE;
+    }
+    Optional<Path> configFile = ConfigLoader.discoverFile(dir);
+    return configFile.map(f -> new Located(load(f), f)).orElse(Located.NONE);
+  }
+
+  /**
+   * The config file's {@code "cimnotebook"} section, from the cache when the file is unchanged
+   * since it was last parsed. Forgiving as documented above.
+   */
+  static NotebookConfig load(Path configFile) {
+    BasicFileAttributes attrs = readAttributes(configFile);
+    if (attrs == null) {
+      CACHE.remove(configFile);
+      return NotebookConfig.EMPTY;
+    }
+    CachedConfig cached = CACHE.get(configFile);
+    if (cached != null
+        && cached.mtime().equals(attrs.lastModifiedTime())
+        && cached.size() == attrs.size()) {
+      return cached.config();
+    }
+    NotebookConfig config = parse(configFile);
+    CACHE.put(configFile, new CachedConfig(attrs.lastModifiedTime(), attrs.size(), config));
+    return config;
+  }
+
+  private static NotebookConfig parse(Path configFile) {
+    try {
+      JsonNode root = MAPPER.readTree(configFile.toFile());
+      JsonNode section = root == null ? null : root.get(SECTION);
+      if (section == null || section.isNull()) {
+        return NotebookConfig.EMPTY;
+      }
+      return MAPPER.treeToValue(section, NotebookConfig.class);
+    } catch (IOException | RuntimeException e) {
+      LOG.warn("Ignoring unreadable {} section in {}: {}", SECTION, configFile, e.getMessage());
+      return NotebookConfig.EMPTY;
+    }
+  }
+
+  private static BasicFileAttributes readAttributes(Path configFile) {
+    try {
+      return Files.readAttributes(configFile, BasicFileAttributes.class);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConnection.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConnection.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * One named connection from the {@code "cimnotebook"} section of {@code opencgmes.jsonc}, read by
+ * {@link NotebookConfigLoader} (Jackson) and answered to the client by the {@code
+ * cimvocabcheck.notebook.listConnections} command (lsp4j's Gson) — hence the double annotations on
+ * {@code isDefault}, whose JSON name {@code default} is a Java keyword.
+ *
+ * <p>Deliberately carries <b>no credentials</b>: the config file only declares the {@code
+ * authType}, and the client keeps secrets in VS Code SecretStorage — passwords never live in {@code
+ * opencgmes.jsonc} and never leave the client except inside an execute request.
+ *
+ * @param name the connection's name, referenced by {@code # [endpoint=<name>]} directives.
+ * @param url the SPARQL query endpoint URL.
+ * @param updateUrl optional SPARQL Update endpoint; {@code null} lets the client derive it.
+ * @param shaclUrl optional SHACL service endpoint; {@code null} lets the client derive it.
+ * @param authType {@code "basic"} when the endpoint needs credentials, else {@code null}/"none".
+ * @param isDefault whether cells without a directive use this connection ({@code "default"} in
+ *     JSON).
+ */
+public record NotebookConnection(
+    String name,
+    String url,
+    String updateUrl,
+    String shaclUrl,
+    String authType,
+    @JsonProperty("default") @SerializedName("default") boolean isDefault) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
@@ -22,15 +22,17 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.regex.PatternSyntaxException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Resolves the file paths of a {@link ExecuteTarget#TYPE_FILES} target against the notebook's
  * directory — the same base validation uses for relative {@code # [endpoint=...]} directives.
- * Shared by {@link LocalQueryExecutor} and {@link ShaclExecutor}.
+ * Directive values may be glob patterns ({@code ./rdf/*.ttl}, {@code ./rdf/{a,b}.ttl}), expanded
+ * via {@link FileGlobs}. Shared by {@link LocalQueryExecutor} and {@link ShaclExecutor}.
  */
 final class NotebookPaths {
 
@@ -38,15 +40,53 @@ final class NotebookPaths {
 
   private NotebookPaths() {}
 
-  /** Resolves each directive path, relative ones against {@code notebookDir(notebookUri)}. */
+  /**
+   * Resolves each directive path, relative ones against {@code notebookDir(notebookUri)}, expanding
+   * glob patterns and dropping duplicates (a file matched by two patterns is queried once).
+   */
   static List<Path> resolvePaths(List<String> files, String notebookUri)
       throws LocalStoreManager.StoreException {
     Path notebookDir = notebookDir(notebookUri);
-    List<Path> paths = new ArrayList<>(files.size());
+    LinkedHashSet<Path> paths = new LinkedHashSet<>();
     for (String file : files) {
-      paths.add(resolvePath(file, notebookDir));
+      if (FileGlobs.isPattern(file)) {
+        paths.addAll(expandPattern(file, notebookDir));
+      } else {
+        paths.add(resolvePath(file, notebookDir));
+      }
     }
-    return paths;
+    return List.copyOf(paths);
+  }
+
+  /** Expands one glob directive; matching nothing is an error, not a silently empty target. */
+  private static List<Path> expandPattern(String pattern, Path notebookDir)
+      throws LocalStoreManager.StoreException {
+    if (notebookDir == null && !isAbsolutePattern(pattern)) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND,
+          "Cannot resolve the relative pattern "
+              + pattern
+              + " — save the notebook first so relative paths have a base directory.",
+          null);
+    }
+    List<Path> matched;
+    try {
+      matched = FileGlobs.expand(pattern, notebookDir);
+    } catch (PatternSyntaxException e) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND, "Invalid file pattern: " + pattern, e);
+    }
+    if (matched.isEmpty()) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND, "No files match the pattern " + pattern, null);
+    }
+    return matched;
+  }
+
+  /** Whether a pattern starts from a filesystem root (Unix {@code /} or a Windows drive). */
+  private static boolean isAbsolutePattern(String pattern) {
+    String normalized = pattern.replace('\\', '/');
+    return normalized.startsWith("/") || normalized.matches("^[A-Za-z]:/.*");
   }
 
   private static Path resolvePath(String file, Path notebookDir)

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
@@ -73,7 +73,7 @@ final class NotebookPaths {
   }
 
   /** The notebook's directory, or {@code null} when the notebook has no on-disk location. */
-  private static Path notebookDir(String notebookUri) {
+  static Path notebookDir(String notebookUri) {
     if (notebookUri == null || notebookUri.isBlank()) {
       return null;
     }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
@@ -1,0 +1,91 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the file paths of a {@link ExecuteTarget#TYPE_FILES} target against the notebook's
+ * directory — the same base validation uses for relative {@code # [endpoint=...]} directives.
+ * Shared by {@link LocalQueryExecutor} and {@link ShaclExecutor}.
+ */
+final class NotebookPaths {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookPaths.class);
+
+  private NotebookPaths() {}
+
+  /** Resolves each directive path, relative ones against {@code notebookDir(notebookUri)}. */
+  static List<Path> resolvePaths(List<String> files, String notebookUri)
+      throws LocalStoreManager.StoreException {
+    Path notebookDir = notebookDir(notebookUri);
+    List<Path> paths = new ArrayList<>(files.size());
+    for (String file : files) {
+      paths.add(resolvePath(file, notebookDir));
+    }
+    return paths;
+  }
+
+  private static Path resolvePath(String file, Path notebookDir)
+      throws LocalStoreManager.StoreException {
+    Path path;
+    try {
+      path = Path.of(file);
+    } catch (InvalidPathException e) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND, "Not a valid file path: " + file, e);
+    }
+    if (path.isAbsolute()) {
+      return path.normalize();
+    }
+    if (notebookDir == null) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND,
+          "Cannot resolve the relative path "
+              + file
+              + " — save the notebook first so relative paths have a base directory.",
+          null);
+    }
+    return notebookDir.resolve(path).normalize();
+  }
+
+  /** The notebook's directory, or {@code null} when the notebook has no on-disk location. */
+  private static Path notebookDir(String notebookUri) {
+    if (notebookUri == null || notebookUri.isBlank()) {
+      return null;
+    }
+    try {
+      URI uri = new URI(notebookUri);
+      if (!"file".equalsIgnoreCase(uri.getScheme())) {
+        return null;
+      }
+      return Path.of(uri).getParent();
+    } catch (URISyntaxException | IllegalArgumentException e) {
+      LOG.debug("Ignoring unusable notebook URI {}: {}", notebookUri, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKind.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKind.java
@@ -1,0 +1,28 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/** The kind of SPARQL operation a cell's text was classified as by {@link QueryKindDetector}. */
+enum QueryKind {
+  SELECT,
+  ASK,
+  CONSTRUCT,
+  DESCRIBE,
+  UPDATE
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKindDetector.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKindDetector.java
@@ -1,0 +1,87 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import de.soptim.opencgmes.cimvocabcheck.core.InvalidQueryException;
+import de.soptim.opencgmes.cimvocabcheck.core.analysis.SparqlQueryAnalyzer;
+import org.apache.jena.query.Query;
+import org.apache.jena.update.UpdateRequest;
+
+/**
+ * Classifies a cell's text as a SPARQL query (with its {@link QueryKind}) or a SPARQL Update
+ * request, by attempting both parses in turn.
+ *
+ * <p>Reuses {@link SparqlQueryAnalyzer#parse} / {@link SparqlQueryAnalyzer#parseUpdate} directly
+ * rather than a separate parsing path, so notebook execution shares the same base-IRI policy
+ * ({@link SparqlQueryAnalyzer#RELATIVE_IRI_BASE}) as validation.
+ */
+final class QueryKindDetector {
+
+  private QueryKindDetector() {}
+
+  /** Outcome of classifying a cell's text. */
+  sealed interface Result {}
+
+  /** The text parsed as a SPARQL query of the given {@link QueryKind}. */
+  record AsQuery(QueryKind kind, Query query) implements Result {}
+
+  /** The text parsed as a SPARQL Update request. */
+  record AsUpdate(UpdateRequest update) implements Result {}
+
+  /** The text is neither a valid query nor a valid update. */
+  record ParseFailure(String message, Integer line, Integer column) implements Result {}
+
+  /**
+   * Attempts to parse {@code text} as a SPARQL query first, then as a SPARQL Update request. If
+   * both fail, the <em>query</em> parser's error is reported — matching the fallback precedent in
+   * {@code SparqlValidationApi#validateAutoDetectRaw}.
+   */
+  static Result detect(String text) {
+    SparqlQueryAnalyzer analyzer = new SparqlQueryAnalyzer();
+    InvalidQueryException queryError;
+    try {
+      Query query = analyzer.parse(text);
+      return new AsQuery(kindOf(query), query);
+    } catch (InvalidQueryException e) {
+      queryError = e;
+    }
+    try {
+      return new AsUpdate(analyzer.parseUpdate(text));
+    } catch (InvalidQueryException ignored) {
+      // Neither parse succeeded — report the query error, per SparqlValidationApi precedent.
+      return new ParseFailure(queryError.getMessage(), queryError.line(), queryError.column());
+    }
+  }
+
+  private static QueryKind kindOf(Query query) {
+    if (query.isSelectType()) {
+      return QueryKind.SELECT;
+    }
+    if (query.isAskType()) {
+      return QueryKind.ASK;
+    }
+    if (query.isConstructType()) {
+      return QueryKind.CONSTRUCT;
+    }
+    if (query.isDescribeType()) {
+      return QueryKind.DESCRIBE;
+    }
+    throw new IllegalStateException("Unknown query type: " + query);
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ResultSerializer.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ResultSerializer.java
@@ -1,0 +1,139 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.io.StringWriter;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+
+/**
+ * Serializes Jena query results to the wire formats used by {@link ExecuteResponse}: SPARQL 1.1
+ * Query Results JSON for SELECT/ASK, Turtle for CONSTRUCT/DESCRIBE.
+ *
+ * <p>SELECT and CONSTRUCT/DESCRIBE results are truncated at a caller-supplied row/triple limit.
+ * Jena's {@code ResultSetFormatter} has no such limit and no boolean/ASK overload, so results are
+ * hand-built here; CONSTRUCT/DESCRIBE consume the streaming {@code execConstructTriples()} / {@code
+ * execDescribeTriples()} iterators (not the materializing {@code execConstruct()} / {@code
+ * execDescribe()}) so an oversized result is never fully loaded into memory.
+ */
+final class ResultSerializer {
+
+  /** A literal's datatype is omitted from the JSON output when it is this (RDF 1.1 default). */
+  private static final String XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+  private ResultSerializer() {}
+
+  /** A serialized result payload together with truncation bookkeeping for {@link ExecStats}. */
+  record Serialized(String payload, int count, boolean truncated) {}
+
+  /** Serializes a SELECT result to SPARQL 1.1 Query Results JSON, truncated at {@code maxRows}. */
+  static Serialized selectToJson(ResultSet rs, int maxRows) {
+    List<String> varNames = rs.getResultVars();
+
+    JsonObject head = new JsonObject();
+    JsonArray vars = new JsonArray();
+    varNames.forEach(vars::add);
+    head.add("vars", vars);
+
+    JsonArray bindings = new JsonArray();
+    int count = 0;
+    while (rs.hasNext() && count < maxRows) {
+      QuerySolution sol = rs.next();
+      JsonObject binding = new JsonObject();
+      for (String var : varNames) {
+        RDFNode node = sol.get(var);
+        if (node != null) {
+          binding.add(var, termToJson(node));
+        }
+      }
+      bindings.add(binding);
+      count++;
+    }
+
+    JsonObject results = new JsonObject();
+    results.add("bindings", bindings);
+
+    JsonObject root = new JsonObject();
+    root.add("head", head);
+    root.add("results", results);
+    return new Serialized(root.toString(), count, rs.hasNext());
+  }
+
+  /** Serializes an ASK result to SPARQL 1.1 Query Results JSON. */
+  static String askToJson(boolean result) {
+    JsonObject root = new JsonObject();
+    root.add("head", new JsonObject());
+    root.addProperty("boolean", result);
+    return root.toString();
+  }
+
+  /**
+   * Serializes a CONSTRUCT/DESCRIBE triple stream to Turtle, truncated at {@code maxTriples}. Pulls
+   * at most {@code maxTriples} elements from {@code triples} via {@code next()}; the truncation
+   * check afterward is a plain {@code hasNext()} peek, so an oversized or streaming result is never
+   * fully materialized just to detect truncation.
+   */
+  static Serialized constructToTurtle(Iterator<Triple> triples, int maxTriples) {
+    Model model = ModelFactory.createDefaultModel();
+    int count = 0;
+    while (triples.hasNext() && count < maxTriples) {
+      model.getGraph().add(triples.next());
+      count++;
+    }
+    boolean truncated = triples.hasNext();
+
+    StringWriter sw = new StringWriter();
+    RDFDataMgr.write(sw, model, RDFFormat.TURTLE_PRETTY);
+    return new Serialized(sw.toString(), count, truncated);
+  }
+
+  private static JsonObject termToJson(RDFNode node) {
+    JsonObject obj = new JsonObject();
+    if (node.isURIResource()) {
+      obj.addProperty("type", "uri");
+      obj.addProperty("value", node.asResource().getURI());
+    } else if (node.isAnon()) {
+      obj.addProperty("type", "bnode");
+      obj.addProperty("value", node.asResource().getId().getLabelString());
+    } else {
+      Literal literal = node.asLiteral();
+      obj.addProperty("type", "literal");
+      obj.addProperty("value", literal.getLexicalForm());
+      String lang = literal.getLanguage();
+      String datatype = literal.getDatatypeURI();
+      if (lang != null && !lang.isEmpty()) {
+        obj.addProperty("xml:lang", lang);
+      } else if (datatype != null && !XSD_STRING.equals(datatype)) {
+        obj.addProperty("datatype", datatype);
+      }
+    }
+    return obj;
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutor.java
@@ -1,0 +1,248 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.riot.system.ErrorHandler;
+import org.apache.jena.shacl.ShaclValidator;
+import org.apache.jena.shacl.Shapes;
+import org.apache.jena.shacl.ValidationReport;
+import org.apache.jena.shacl.validation.ReportEntry;
+import org.apache.jena.shacl.validation.Severity;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a notebook SHACL cell: the cell text is the <em>shapes graph</em> (Turtle), validated
+ * against the cell's target data. Local-file targets are validated in-process with jena-shacl over
+ * the {@link LocalStoreManager} union graph; HTTP targets hand the shapes to the endpoint's SHACL
+ * service via {@link HttpShaclClient}. Either way the response carries the full validation report
+ * as Turtle plus a {@link ShaclSummary} for the client's verdict banner.
+ *
+ * <p>A completed validation is a <em>successful</em> execution even when the data does not conform
+ * — non-conformance is the result, not an error.
+ *
+ * <p>In-process validation has no native timeout or abort hook, so it runs under the timeout-aware
+ * {@link ExecSupport#runCancellable} variant: cancellation and timeout resolve the response while
+ * the validation itself finishes in the background (same trade-off as a cancelled UPDATE,
+ * documented on {@link HttpQueryExecutor}).
+ */
+final class ShaclExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ShaclExecutor.class);
+
+  private ShaclExecutor() {}
+
+  /** Executes a SHACL cell, returning a populated {@link ExecuteResponse}. */
+  static ExecuteResponse execute(
+      ExecuteRequest request, LocalStoreManager stores, ExecContext ctx) {
+    Graph shapesGraph;
+    try {
+      shapesGraph = parseShapesTurtle(request.text());
+    } catch (ShapesSyntaxException e) {
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.PARSE_ERROR, e.getMessage(), null, e.line, e.column));
+    }
+
+    ExecuteTarget target = request.target();
+    if (target == null) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.NO_TARGET,
+              "No data to validate. Add a `# [endpoint=<url or file>]` directive to the cell.",
+              null,
+              null,
+              null));
+    }
+    if (ExecuteTarget.TYPE_FILES.equals(target.type())) {
+      return validateLocal(shapesGraph, request, stores, ctx);
+    }
+    return HttpShaclClient.validate(request.text(), target, request.options(), ctx);
+  }
+
+  // ---- local validation ------------------------------------------------------------------------
+
+  private static ExecuteResponse validateLocal(
+      Graph shapesGraph, ExecuteRequest request, LocalStoreManager stores, ExecContext ctx) {
+    ExecuteTarget target = request.target();
+    if (target.files() == null || target.files().isEmpty()) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.NO_TARGET,
+              "No data to validate. Add a `# [endpoint=<url or file>]` directive to the cell.",
+              null,
+              null,
+              null));
+    }
+
+    Shapes shapes;
+    try {
+      shapes = ShaclValidator.get().parse(shapesGraph);
+    } catch (RuntimeException e) {
+      // Syntactically valid Turtle that is not a well-formed shapes graph (e.g. a broken
+      // sh:property) — jena-shacl reports this without source positions.
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.PARSE_ERROR, "Invalid SHACL shapes: " + e.getMessage(), null, null, null));
+    }
+
+    DatasetGraph data;
+    try {
+      List<Path> paths = NotebookPaths.resolvePaths(target.files(), request.notebookUri());
+      data = stores.unionFor(paths);
+    } catch (LocalStoreManager.StoreException e) {
+      return ExecuteResponse.failed(new ExecError(e.code(), e.getMessage(), null, null, null));
+    }
+
+    // The union's default graph spans all graphs of all files (see LocalStoreManager), so the
+    // shapes validate everything the user pointed the cell at.
+    Graph dataGraph = data.getDefaultGraph();
+    String resolvedTarget = String.join(", ", target.files());
+    return ExecSupport.runCancellable(
+        ctx,
+        () -> {},
+        () -> runValidation(shapes, dataGraph, resolvedTarget),
+        ExecSupport.timeoutMs(request.options()));
+  }
+
+  /** Runs on {@code ctx.executionPool()}. */
+  private static ExecuteResponse runValidation(
+      Shapes shapes, Graph dataGraph, String resolvedTarget) {
+    long start = System.currentTimeMillis();
+    try {
+      ValidationReport report = ShaclValidator.get().validate(shapes, dataGraph);
+      return toResponse(report, reportTurtle(report), start, resolvedTarget);
+    } catch (CancellationException e) {
+      LOG.debug("SHACL validation aborted after cancellation");
+      return ExecuteResponse.cancelled();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error during SHACL validation: {}", e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  // ---- shared report handling (also used by HttpShaclClient) ------------------------------------
+
+  /** Builds the SUCCESS response for a completed validation, whatever produced the report. */
+  static ExecuteResponse toResponse(
+      ValidationReport report, String reportTurtle, long startMs, String resolvedTarget) {
+    int violations = 0;
+    int warnings = 0;
+    int infos = 0;
+    for (ReportEntry entry : report.getEntries()) {
+      Severity severity = entry.severity();
+      if (Severity.Warning.equals(severity)) {
+        warnings++;
+      } else if (Severity.Info.equals(severity)) {
+        infos++;
+      } else {
+        violations++; // sh:Violation is also the SHACL default for unknown severities
+      }
+    }
+    ShaclSummary summary = new ShaclSummary(report.conforms(), violations, warnings, infos);
+    ExecStats stats = ExecSupport.stats(startMs, report.getEntries().size(), false, resolvedTarget);
+    return ExecuteResponse.successShacl(reportTurtle, summary, stats);
+  }
+
+  static String reportTurtle(ValidationReport report) {
+    StringWriter sw = new StringWriter();
+    RDFDataMgr.write(sw, report.getModel(), RDFFormat.TURTLE_PRETTY);
+    return sw.toString();
+  }
+
+  // ---- shapes parsing
+  // ----------------------------------------------------------------------------
+
+  /** The cell text is not valid Turtle; position is 1-based where the parser reported one. */
+  private static final class ShapesSyntaxException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Integer line;
+    private final Integer column;
+
+    ShapesSyntaxException(String message, Integer line, Integer column) {
+      super(message);
+      this.line = line;
+      this.column = column;
+    }
+  }
+
+  private static Graph parseShapesTurtle(String text) throws ShapesSyntaxException {
+    Graph graph = GraphFactory.createDefaultGraph();
+    PositionErrorHandler errors = new PositionErrorHandler();
+    try {
+      RDFParser.create()
+          .source(new StringReader(text))
+          .lang(Lang.TTL)
+          .errorHandler(errors)
+          .parse(graph);
+    } catch (RiotException e) {
+      throw new ShapesSyntaxException(
+          errors.message != null ? errors.message : e.getMessage(), errors.line, errors.column);
+    }
+    return graph;
+  }
+
+  /** Records the first reported parse error's message and 1-based position. */
+  private static final class PositionErrorHandler implements ErrorHandler {
+
+    private String message;
+    private Integer line;
+    private Integer column;
+
+    @Override
+    public void warning(String message, long line, long col) {
+      // Warnings don't fail the parse.
+    }
+
+    @Override
+    public void error(String message, long line, long col) {
+      record(message, line, col);
+      throw new RiotException(message);
+    }
+
+    @Override
+    public void fatal(String message, long line, long col) {
+      record(message, line, col);
+      throw new RiotException(message);
+    }
+
+    private void record(String message, long line, long col) {
+      if (this.message == null) {
+        this.message = message;
+        this.line = line > 0 ? (int) line : null;
+        this.column = col > 0 ? (int) col : null;
+      }
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclSummary.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclSummary.java
@@ -19,14 +19,12 @@
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
 /**
- * The kind of operation a cell was classified as: for SPARQL cells, by {@link QueryKindDetector};
- * {@link #SHACL} is assigned directly from the cell's language id (see {@code ShaclExecutor}).
+ * Aggregated outcome of a SHACL validation run, so the client can render a verdict banner without
+ * parsing the report graph in {@link ExecuteResponse#turtle()}.
+ *
+ * @param conforms the report's {@code sh:conforms} value.
+ * @param violations number of report entries with severity {@code sh:Violation}.
+ * @param warnings number of report entries with severity {@code sh:Warning}.
+ * @param infos number of report entries with severity {@code sh:Info}.
  */
-enum QueryKind {
-  SELECT,
-  ASK,
-  CONSTRUCT,
-  DESCRIBE,
-  UPDATE,
-  SHACL
-}
+record ShaclSummary(boolean conforms, int violations, int warnings, int infos) {}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/EndpointDirectiveTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/EndpointDirectiveTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -84,5 +85,23 @@ public class EndpointDirectiveTest {
   @Test
   public void absentForNullText() {
     assertTrue(EndpointDirective.parse(null).isEmpty());
+  }
+
+  @Test
+  public void parseAllReturnsEveryDirectiveInOrder() {
+    String text = "# [endpoint=./first.ttl]\n# [endpoint=./second.ttl]\nSELECT * {}";
+    assertEquals(List.of("./first.ttl", "./second.ttl"), EndpointDirective.parseAll(text));
+  }
+
+  @Test
+  public void parseAllKeepsGlobPatterns() {
+    String text = "# [endpoint=./rdf/{a,b}.ttl]\n# [endpoint=./rdf/*.ttl]\nSELECT * {}";
+    assertEquals(List.of("./rdf/{a,b}.ttl", "./rdf/*.ttl"), EndpointDirective.parseAll(text));
+  }
+
+  @Test
+  public void parseAllIsEmptyWithoutDirectives() {
+    assertEquals(List.of(), EndpointDirective.parseAll("SELECT * {}"));
+    assertEquals(List.of(), EndpointDirective.parseAll(null));
   }
 }

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaultEndpointTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaultEndpointTest.java
@@ -1,0 +1,280 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BooleanSupplier;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the schema source of a notebook cell that carries <em>no</em> {@code # [endpoint=...]}
+ * directive of its own.
+ *
+ * <p>Such a cell still has a target: the notebook default the client remembers (its <em>Set Cell
+ * Endpoint → Notebook default</em> scope), or the {@code "cimnotebook"} connection marked {@code
+ * "default": true}. Both are how the cell is <em>executed</em>, so both must also be how it is
+ * <em>validated</em> — otherwise the cell runs fine but the editor shows syntax-only diagnostics,
+ * no completion and no go-to-definition, because the server only ever saw the cell text.
+ */
+public class NotebookDefaultEndpointTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private static final String CIM16 = "http://iec.ch/TC57/2013/CIM-schema-cim16#";
+  private static final long TIMEOUT_MS = 10_000;
+
+  /** Minimal CIM 16 RDFS that passes profile detection, plus one real class declaration. */
+  private static final String SCHEMA_RDF =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+               xmlns:cims="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#"
+               xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+               xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#">
+        <rdf:Description rdf:about="http://entsoe.eu/TestExt#TestVersion.shortName">
+          <rdfs:domain rdf:resource="http://entsoe.eu/TestExt#TestVersion"/>
+          <cims:isFixed rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TST</cims:isFixed>
+        </rdf:Description>
+        <rdf:Description rdf:about="http://entsoe.eu/TestExt#TestVersion.entsoeURI">
+          <rdfs:domain rdf:resource="http://entsoe.eu/TestExt#TestVersion"/>
+          <cims:isFixed rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://example.org/TestProfile/1</cims:isFixed>
+        </rdf:Description>
+        <rdfs:Class rdf:about="http://iec.ch/TC57/2013/CIM-schema-cim16#TestClass">
+          <rdfs:label>TestClass</rdfs:label>
+        </rdfs:Class>
+      </rdf:RDF>
+      """;
+
+  /** A cell whose only schema-dependent finding is the unknown class — no syntax errors. */
+  private static final String CELL_WITH_UNKNOWN_CLASS =
+      "PREFIX cim: <" + CIM16 + ">\nSELECT * WHERE { ?s a cim:NoSuchClass }";
+
+  /** The same notebook, mid-completion: the cursor sits right after the "cim:" prefix. */
+  private static final String CELL_MID_COMPLETION =
+      "PREFIX cim: <" + CIM16 + ">\nSELECT * WHERE { ?s a cim: }";
+
+  private final List<PublishDiagnosticsParams> published = new CopyOnWriteArrayList<>();
+  private final List<MessageParams> messages = new CopyOnWriteArrayList<>();
+
+  private SchemaManager schemaManager;
+  private SparqlTextDocumentService service;
+  private NotebookDefaults notebookDefaults;
+
+  private void startServer() {
+    schemaManager = new SchemaManager();
+    notebookDefaults = new NotebookDefaults();
+    service = new SparqlTextDocumentService(schemaManager, notebookDefaults);
+    // The same wiring SparqlLanguageServer does: a changed default revalidates the open cells.
+    notebookDefaults.addOnChangeCallback(service::revalidateAll);
+    LanguageClient client = recordingClient();
+    schemaManager.setClient(client);
+    service.setClient(client);
+  }
+
+  @After
+  public void tearDown() {
+    if (service != null) {
+      service.shutdown();
+    }
+    if (schemaManager != null) {
+      schemaManager.shutdown();
+    }
+  }
+
+  @Test
+  public void notebookDefaultGivesDirectivelessCellsTheirSchema() throws Exception {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("schema.rdf"), SCHEMA_RDF);
+    Path notebook = dir.resolve("analysis.cimnb.md");
+    startServer();
+
+    String queryCell = cellUri(notebook, "c1");
+    String completionCell = cellUri(notebook, "c2");
+    open(queryCell, CELL_WITH_UNKNOWN_CLASS);
+    open(completionCell, CELL_MID_COMPLETION);
+
+    // Before: the cell has no directive and there is no config, so nothing but syntax is checked.
+    awaitTrue("a first (syntax-only) publish", () -> lastDiagnostics(queryCell) != null);
+    assertEquals(
+        "without a schema the cell is syntax-only — no semantic findings",
+        List.of(),
+        lastDiagnostics(queryCell));
+    assertEquals("and no completion is offered", List.of(), completeAfterPrefix(completionCell));
+
+    // The user picks "Notebook default" in *Set Cell Endpoint*; the client pushes it to us.
+    notebookDefaults.set(notebook.toUri().toString(), "./schema.rdf");
+
+    awaitTrue(
+        "the unknown class must be reported once the notebook default supplies a schema",
+        () -> diagnosticsMention(queryCell, "NoSuchClass"));
+    List<CompletionItem> items = completeAfterPrefix(completionCell);
+    assertTrue(
+        "completion must now offer the schema's terms, got: " + labels(items),
+        labels(items).contains("cim:TestClass"));
+  }
+
+  @Test
+  public void defaultConnectionGivesDirectivelessCellsTheirSchema() throws Exception {
+    Path dir = tmp.getRoot().toPath();
+    // Deliberately unreachable: what matters is that the cell's schema is fetched from the default
+    // connection's endpoint at all — observable through the "loading schema from endpoint" notice.
+    String url = "http://localhost:9/none/query";
+    Files.writeString(
+        dir.resolve("opencgmes.jsonc"),
+        """
+        { "cimnotebook": { "connections": [
+            { "name": "local-fuseki", "url": "%s", "default": true }
+        ] } }
+        """
+            .formatted(url));
+    startServer();
+
+    open(cellUri(dir.resolve("analysis.cimnb.md"), "c1"), CELL_WITH_UNKNOWN_CLASS);
+
+    awaitTrue(
+        "a directive-less cell must validate against the default connection's endpoint",
+        () -> messages.stream().anyMatch(m -> m.getMessage().contains(url)));
+  }
+
+  @Test
+  public void plainFilesIgnoreTheNotebookFallbacks() throws Exception {
+    Path dir = tmp.getRoot().toPath();
+    String url = "http://localhost:9/none/query";
+    Files.writeString(
+        dir.resolve("opencgmes.jsonc"),
+        """
+        { "cimnotebook": { "connections": [
+            { "name": "local-fuseki", "url": "%s", "default": true }
+        ] } }
+        """
+            .formatted(url));
+    startServer();
+
+    // A stand-alone query file is not part of any notebook: it keeps its workspace schema (here:
+    // none) rather than borrowing the notebook connection's endpoint.
+    String fileUri = dir.resolve("query.rq").toUri().toString();
+    open(fileUri, CELL_WITH_UNKNOWN_CLASS);
+
+    awaitTrue("a publish for the file", () -> lastDiagnostics(fileUri) != null);
+    assertFalse(
+        "a plain .rq file must not load the notebook default connection's schema: " + messages,
+        messages.stream().anyMatch(m -> m.getMessage().contains(url)));
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------
+
+  /** The URI VS Code gives a cell: the notebook's path plus a cell-id fragment. */
+  private static String cellUri(Path notebook, String cellId) {
+    return "vscode-notebook-cell:" + notebook + "#" + cellId;
+  }
+
+  private void open(String uri, String text) {
+    service.didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, "sparql", 1, text)));
+  }
+
+  /** Completions offered with the cursor right behind the {@code cim:} prefix of line 1. */
+  private List<CompletionItem> completeAfterPrefix(String uri) throws Exception {
+    String line = CELL_MID_COMPLETION.split("\n")[1];
+    Position cursor = new Position(1, line.indexOf("cim:") + "cim:".length());
+    return service
+        .completion(new CompletionParams(new TextDocumentIdentifier(uri), cursor))
+        .get()
+        .getLeft();
+  }
+
+  private static List<String> labels(List<CompletionItem> items) {
+    return items.stream().map(CompletionItem::getLabel).toList();
+  }
+
+  /** The diagnostics of the most recent publish for {@code uri}, or {@code null} if none yet. */
+  private List<Diagnostic> lastDiagnostics(String uri) {
+    return published.stream()
+        .filter(p -> p.getUri().equals(uri))
+        .reduce((first, second) -> second)
+        .map(PublishDiagnosticsParams::getDiagnostics)
+        .orElse(null);
+  }
+
+  private boolean diagnosticsMention(String uri, String term) {
+    List<Diagnostic> diagnostics = lastDiagnostics(uri);
+    return diagnostics != null
+        && diagnostics.stream().anyMatch(d -> d.getMessage().getLeft().contains(term));
+  }
+
+  /** Waits for a debounced (and, for endpoints, asynchronous) result to appear. */
+  private static void awaitTrue(String what, BooleanSupplier condition) throws Exception {
+    long deadline = System.nanoTime() + TIMEOUT_MS * 1_000_000L;
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(25);
+    }
+    throw new AssertionError("Timed out waiting for " + what);
+  }
+
+  private LanguageClient recordingClient() {
+    return new LanguageClient() {
+      @Override
+      public void telemetryEvent(Object object) {}
+
+      @Override
+      public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+        published.add(diagnostics);
+      }
+
+      @Override
+      public void showMessage(MessageParams messageParams) {
+        messages.add(messageParams);
+      }
+
+      @Override
+      public CompletableFuture<MessageActionItem> showMessageRequest(
+          ShowMessageRequestParams requestParams) {
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      public void logMessage(MessageParams message) {}
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaultsTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaultsTest.java
@@ -1,0 +1,112 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.gson.JsonParser;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/**
+ * Covers {@link NotebookDefaults}: the client sets a default on the <em>notebook</em> URI, while
+ * every lookup comes from a <em>cell</em> URI — the two must agree on a key, or a notebook's
+ * directive-less cells silently fall back to syntax-only validation.
+ */
+public class NotebookDefaultsTest {
+
+  private static final String NOTEBOOK_URI = "file:///home/u/proj/analysis.cimnb.md";
+  private static final String CELL_URI = "vscode-notebook-cell:/home/u/proj/analysis.cimnb.md#W0s";
+  private static final String OTHER_CELL_URI = "vscode-notebook-cell:/home/u/proj/other.cimnb.md#A";
+
+  @Test
+  public void cellsOfTheNotebookSeeItsDefault() {
+    NotebookDefaults defaults = new NotebookDefaults();
+
+    defaults.set(NOTEBOOK_URI, "./schema.ttl");
+
+    assertEquals("./schema.ttl", defaults.forCell(CELL_URI));
+    assertNull("a cell of another notebook is unaffected", defaults.forCell(OTHER_CELL_URI));
+  }
+
+  @Test
+  public void blankEndpointClearsTheDefault() {
+    NotebookDefaults defaults = new NotebookDefaults();
+    defaults.set(NOTEBOOK_URI, "http://localhost:3030/ds/query");
+
+    defaults.set(NOTEBOOK_URI, null);
+
+    assertNull(defaults.forCell(CELL_URI));
+  }
+
+  @Test
+  public void unsavedNotebooksKeyOnTheirOpaqueUri() {
+    NotebookDefaults defaults = new NotebookDefaults();
+
+    defaults.set("untitled:Untitled-1", "http://localhost:3030/ds/query");
+
+    assertEquals(
+        "http://localhost:3030/ds/query",
+        defaults.forCell("vscode-notebook-cell:Untitled-1#W0sZmlsZQ"));
+  }
+
+  @Test
+  public void applyParsesTheCommandArgumentAndNotifies() {
+    NotebookDefaults defaults = new NotebookDefaults();
+    AtomicInteger changes = new AtomicInteger();
+    defaults.addOnChangeCallback(changes::incrementAndGet);
+
+    defaults.apply(
+        List.of(
+            JsonParser.parseString(
+                """
+                { "notebookUri": "%s", "endpoint": "local-fuseki" }
+                """
+                    .formatted(NOTEBOOK_URI))));
+
+    assertEquals("local-fuseki", defaults.forCell(CELL_URI));
+    assertEquals("open cells must be revalidated against the new default", 1, changes.get());
+
+    // A null endpoint is how the client clears a default.
+    defaults.apply(
+        List.of(
+            JsonParser.parseString(
+                """
+                { "notebookUri": "%s", "endpoint": null }
+                """
+                    .formatted(NOTEBOOK_URI))));
+
+    assertNull(defaults.forCell(CELL_URI));
+    assertEquals(2, changes.get());
+  }
+
+  @Test
+  public void malformedArgumentsAreIgnored() {
+    NotebookDefaults defaults = new NotebookDefaults();
+
+    defaults.apply(null);
+    defaults.apply(List.of());
+    defaults.apply(List.of(JsonParser.parseString("\"not-an-object\"")));
+    defaults.apply(List.of(JsonParser.parseString("{ \"endpoint\": \"http://x/query\" }")));
+
+    assertNull(defaults.forCell(CELL_URI));
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerConnectionNameTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerConnectionNameTest.java
@@ -1,0 +1,116 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the connection-name coherence in {@link SchemaManager#resolveSchema}: a {@code #
+ * [endpoint=<name>]} directive naming a {@code "cimnotebook"} connection must resolve the schema
+ * from that connection's URL (the remote-endpoint path), so validation and notebook execution agree
+ * on what the directive means. An unknown name falls through to the old behavior (and, with no
+ * extension, ends in the quiet workspace-schema fallback).
+ */
+public class SchemaManagerConnectionNameTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  @Test
+  public void connectionNameDirectiveResolvesTheSchemaFromTheConnectionUrl() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    // Deliberately unreachable URL: what matters is that the remote-schema path is entered for
+    // the connection's URL, observable through the synchronous "loading schema from endpoint"
+    // notification. The async load then fails quietly (negative-cached), which is fine here.
+    String url = "http://localhost:9/none/query";
+    Files.writeString(
+        docDir.resolve("opencgmes.jsonc"),
+        """
+        { "cimnotebook": { "connections": [ { "name": "local-fuseki", "url": "%s" } ] } }
+        """
+            .formatted(url));
+
+    List<MessageParams> messages = new CopyOnWriteArrayList<>();
+    SchemaManager manager = new SchemaManager();
+    manager.setClient(recordingClient(messages));
+    try {
+      var resolved = manager.resolveSchema("local-fuseki", docDir);
+
+      assertTrue("remote loads are async — nothing is resolved yet", resolved.isEmpty());
+      assertTrue(
+          "the remote-schema path must be entered for the connection's URL; messages: " + messages,
+          messages.stream().anyMatch(m -> m.getMessage().contains(url)));
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  @Test
+  public void unknownNameFallsBackQuietlyToTheWorkspaceSchema() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    Files.writeString(docDir.resolve("opencgmes.jsonc"), "{ \"cimnotebook\": {} }");
+
+    List<MessageParams> messages = new CopyOnWriteArrayList<>();
+    SchemaManager manager = new SchemaManager();
+    manager.setClient(recordingClient(messages));
+    try {
+      assertTrue(manager.resolveSchema("no-such-connection", docDir).isEmpty());
+      assertTrue("no user-facing noise for an unknown name: " + messages, messages.isEmpty());
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  private static LanguageClient recordingClient(List<MessageParams> messages) {
+    return new LanguageClient() {
+      @Override
+      public void telemetryEvent(Object object) {}
+
+      @Override
+      public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {}
+
+      @Override
+      public void showMessage(MessageParams messageParams) {
+        messages.add(messageParams);
+      }
+
+      @Override
+      public CompletableFuture<MessageActionItem> showMessageRequest(
+          ShowMessageRequestParams requestParams) {
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      public void logMessage(MessageParams message) {}
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerInstanceDataGuardTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerInstanceDataGuardTest.java
@@ -1,0 +1,117 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the dual-semantics guard in {@link SchemaManager#resolveSchema}: a {@code #
+ * [endpoint=...]} directive is both validation schema source and notebook execution data target,
+ * and when it names <em>instance data</em> — a CIMXML {@code .xml} model, an {@code .nt} dump —
+ * validation must fall back to the workspace schema instead of loading the data file as a schema.
+ * Without the guard, a CIMXML model (valid RDF/XML!) silently loads as an empty-ish schema and
+ * every {@code cim:} term in the cell turns into a false diagnostic.
+ */
+public class SchemaManagerInstanceDataGuardTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  /** A perfectly valid CIMXML instance model — which is exactly why it must not become a schema. */
+  private static final String CIMXML_MODEL =
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+       <md:FullModel rdf:about="urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6">
+         <md:Model.profile>http://soptim.de/CIM/MyProfile/1.1</md:Model.profile>
+       </md:FullModel>
+       <cim:MyEquipment rdf:ID="_f67fc354-9e39-4191-a456-67537399bc48">
+         <cim:IdentifiedObject.name>My Custom Equipment</cim:IdentifiedObject.name>
+       </cim:MyEquipment>
+      </rdf:RDF>
+      """;
+
+  @Test
+  public void instanceDataDirectivesFallBackToTheWorkspaceSchema() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    Files.writeString(docDir.resolve("model.xml"), CIMXML_MODEL);
+    Files.writeString(
+        docDir.resolve("data.nt"),
+        "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n");
+
+    List<MessageParams> messages = new CopyOnWriteArrayList<>();
+    SchemaManager manager = new SchemaManager();
+    manager.setClient(recordingClient(messages));
+    try {
+      // No opencgmes.jsonc anywhere near docDir, so the workspace-schema fallback is empty —
+      // syntax-only validation. Before the guard, the .xml resolved to a garbage schema (or, when
+      // schema construction rejected it, a user-facing load-failure notification) instead.
+      assertTrue(
+          "a CIMXML model directive must not load as an endpoint schema",
+          manager.resolveSchema("./model.xml", docDir).isEmpty());
+      assertTrue(
+          "an N-Triples data directive must not load as an endpoint schema",
+          manager.resolveSchema("./data.nt", docDir).isEmpty());
+      assertEquals(
+          "the quiet fallback must not raise schema-load notifications: " + messages,
+          List.of(),
+          messages);
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  private static LanguageClient recordingClient(List<MessageParams> messages) {
+    return new LanguageClient() {
+      @Override
+      public void telemetryEvent(Object object) {}
+
+      @Override
+      public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {}
+
+      @Override
+      public void showMessage(MessageParams messageParams) {
+        messages.add(messageParams);
+      }
+
+      @Override
+      public CompletableFuture<MessageActionItem> showMessageRequest(
+          ShowMessageRequestParams requestParams) {
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      public void logMessage(MessageParams message) {}
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerMultiFileEndpointTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerMultiFileEndpointTest.java
@@ -1,0 +1,174 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the multi-file validation side: several {@code # [endpoint=...]} file directives — or one
+ * glob directive like {@code ./rdf/{a,b}.ttl} — load as a <em>union</em> schema, so a cell querying
+ * across multiple profiles gets completion/hover/diagnostics for all of them.
+ */
+public class SchemaManagerMultiFileEndpointTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private static final String CIM16 = "http://iec.ch/TC57/2013/CIM-schema-cim16#";
+
+  /** Minimal CIM 16 RDF that passes profile detection, plus one real class declaration. */
+  private static String schemaRdf(String profileTag, String className) {
+    return """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:cims="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#"
+             xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+             xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#">
+      <rdf:Description rdf:about="http://entsoe.eu/TestExt%1$s#TestVersion.shortName">
+        <rdfs:domain rdf:resource="http://entsoe.eu/TestExt%1$s#TestVersion"/>
+        <cims:isFixed rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T%1$s</cims:isFixed>
+      </rdf:Description>
+      <rdf:Description rdf:about="http://entsoe.eu/TestExt%1$s#TestVersion.entsoeURI">
+        <rdfs:domain rdf:resource="http://entsoe.eu/TestExt%1$s#TestVersion"/>
+        <cims:isFixed rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://example.org/TestProfile%1$s/1</cims:isFixed>
+      </rdf:Description>
+      <rdfs:Class rdf:about="http://iec.ch/TC57/2013/CIM-schema-cim16#%2$s">
+        <rdfs:label>%2$s</rdfs:label>
+      </rdfs:Class>
+    </rdf:RDF>
+    """
+        .formatted(profileTag, className);
+  }
+
+  /** A valid CIMXML instance model — must be skipped in a union, never loaded as a schema. */
+  private static final String CIMXML_MODEL =
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+       <md:FullModel rdf:about="urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6">
+         <md:Model.profile>http://soptim.de/CIM/MyProfile/1.1</md:Model.profile>
+       </md:FullModel>
+      </rdf:RDF>
+      """;
+
+  @Test
+  public void multipleFileDirectivesLoadAsOneUnionSchema() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    Files.writeString(docDir.resolve("a.rdf"), schemaRdf("A", "ClassA"));
+    Files.writeString(docDir.resolve("b.rdf"), schemaRdf("B", "ClassB"));
+
+    SchemaManager manager = new SchemaManager();
+    try {
+      var rsOpt = manager.resolveSchema(List.of("./a.rdf", "./b.rdf"), docDir);
+
+      assertTrue("the union schema must resolve", rsOpt.isPresent());
+      ResolvedSchema rs = rsOpt.get();
+      assertClassKnown(rs, "ClassA");
+      assertClassKnown(rs, "ClassB");
+
+      // Go-to-definition must jump into the file that actually declares the class.
+      assertNotNull("local files must yield a DefinitionIndex", rs.definitionIndex());
+      var loc = rs.definitionIndex().locationOf(cimClass("ClassB"));
+      assertTrue(loc.isPresent());
+      assertTrue(loc.get().getUri().endsWith("b.rdf"));
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  @Test
+  public void globAndBraceDirectivesExpandToMatchingSchemas() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    Files.writeString(docDir.resolve("a.rdf"), schemaRdf("A", "ClassA"));
+    Files.writeString(docDir.resolve("b.rdf"), schemaRdf("B", "ClassB"));
+    Files.writeString(docDir.resolve("c.rdf"), schemaRdf("C", "ClassC"));
+
+    SchemaManager manager = new SchemaManager();
+    try {
+      var all = manager.resolveSchema(List.of("./*.rdf"), docDir);
+      assertTrue(all.isPresent());
+      assertClassKnown(all.get(), "ClassA");
+      assertClassKnown(all.get(), "ClassB");
+      assertClassKnown(all.get(), "ClassC");
+
+      var some = manager.resolveSchema(List.of("./{a,b}.rdf"), docDir);
+      assertTrue(some.isPresent());
+      assertClassKnown(some.get(), "ClassA");
+      assertClassKnown(some.get(), "ClassB");
+      assertTrue(
+          "a brace pattern must not load files outside its alternatives",
+          some.get().api().schemaIndex().findClass(cimClass("ClassC")).isEmpty());
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  @Test
+  public void instanceDataInAUnionIsSkippedNotLoadedAsSchema() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    Files.writeString(docDir.resolve("a.rdf"), schemaRdf("A", "ClassA"));
+    Files.writeString(docDir.resolve("model.xml"), CIMXML_MODEL);
+
+    SchemaManager manager = new SchemaManager();
+    try {
+      // The cell runs against schema + model, but validates against the schema file only.
+      var rsOpt = manager.resolveSchema(List.of("./model.xml", "./a.rdf"), docDir);
+      assertTrue(rsOpt.isPresent());
+      assertClassKnown(rsOpt.get(), "ClassA");
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  @Test
+  public void conflictingDirectivesFallBackToTheWorkspaceSchema() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    Files.writeString(docDir.resolve("a.rdf"), schemaRdf("A", "ClassA"));
+
+    SchemaManager manager = new SchemaManager();
+    try {
+      // A URL mixed with a file has no single meaning (the client refuses to execute such a
+      // cell); with no opencgmes.jsonc near docDir the workspace fallback is empty.
+      assertTrue(
+          manager.resolveSchema(List.of("https://example.org/query", "./a.rdf"), docDir).isEmpty());
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  private static Node cimClass(String className) {
+    return NodeFactory.createURI(CIM16 + className);
+  }
+
+  private static void assertClassKnown(ResolvedSchema rs, String className) {
+    assertFalse(
+        className + " must be known to the union schema",
+        rs.api().schemaIndex().findClass(cimClass(className)).isEmpty());
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/BasicAuthTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/BasicAuthTest.java
@@ -1,0 +1,187 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pins the preemptive basic-auth behavior across all three HTTP paths (query, update, SHACL): the
+ * exact {@code Authorization} header the endpoint receives, and its absence for anonymous targets.
+ * Uses a header-capturing JDK HttpServer rather than a secured Fuseki — what matters is the request
+ * we send, not any particular server's challenge dance.
+ */
+public class BasicAuthTest {
+
+  /** {@code Basic base64("alice:secret")}. */
+  private static final String EXPECTED_HEADER = "Basic YWxpY2U6c2VjcmV0";
+
+  private static final ExecAuth AUTH = new ExecAuth("basic", "alice", "secret");
+
+  private static final CancelChecker NEVER_CANCELLED =
+      new CancelChecker() {
+        @Override
+        public void checkCanceled() {}
+
+        @Override
+        public boolean isCanceled() {
+          return false;
+        }
+      };
+
+  private ExecutorService executionPool;
+  private ScheduledExecutorService watchdogScheduler;
+  private HttpServer server;
+  private final AtomicReference<String> seenAuthorization = new AtomicReference<>();
+
+  @Before
+  public void setUp() throws IOException {
+    executionPool = Executors.newCachedThreadPool();
+    watchdogScheduler = Executors.newSingleThreadScheduledExecutor();
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext(
+        "/",
+        exchange -> {
+          seenAuthorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+          byte[] body;
+          String contentType;
+          if (exchange.getRequestURI().getPath().contains("shacl")) {
+            body =
+                """
+                PREFIX sh: <http://www.w3.org/ns/shacl#>
+                [] a sh:ValidationReport ; sh:conforms true .
+                """
+                    .getBytes(StandardCharsets.UTF_8);
+            contentType = "text/turtle";
+          } else {
+            body = "{\"head\":{},\"boolean\":true}".getBytes(StandardCharsets.UTF_8);
+            contentType = "application/sparql-results+json";
+          }
+          exchange.getResponseHeaders().set("Content-Type", contentType);
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+    server.start();
+  }
+
+  @After
+  public void tearDown() {
+    server.stop(0);
+    executionPool.shutdownNow();
+    watchdogScheduler.shutdownNow();
+  }
+
+  @Test
+  public void queryCarriesThePreemptiveBasicAuthHeader() {
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            QueryFactory.create("ASK {}"), QueryKind.ASK, target(url("/query"), AUTH), null, ctx());
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(EXPECTED_HEADER, seenAuthorization.get());
+  }
+
+  @Test
+  public void queryWithoutCredentialsSendsNoAuthorizationHeader() {
+    HttpQueryExecutor.executeQuery(
+        QueryFactory.create("ASK {}"), QueryKind.ASK, target(url("/query"), null), null, ctx());
+
+    assertNull(seenAuthorization.get());
+  }
+
+  @Test
+  public void updateCarriesThePreemptiveBasicAuthHeader() {
+    HttpQueryExecutor.executeUpdate(
+        UpdateFactory.create("INSERT DATA { <urn:s> <urn:p> 1 }"),
+        new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url("/query"), url("/update"), null, null, AUTH),
+        null,
+        ctx());
+
+    assertEquals(EXPECTED_HEADER, seenAuthorization.get());
+  }
+
+  @Test
+  public void shaclValidationCarriesThePreemptiveBasicAuthHeader() {
+    ExecuteResponse response =
+        HttpShaclClient.validate(
+            "PREFIX sh: <http://www.w3.org/ns/shacl#>",
+            new ExecuteTarget(
+                ExecuteTarget.TYPE_HTTP,
+                url("/query"),
+                null,
+                url("/shacl?graph=default"),
+                null,
+                AUTH),
+            null,
+            ctx());
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(EXPECTED_HEADER, seenAuthorization.get());
+  }
+
+  @Test
+  public void basicAuthHeaderIsNullForUnusableCredentials() {
+    assertNull(ExecSupport.basicAuthHeader(null));
+    assertNull(ExecSupport.basicAuthHeader(new ExecAuth("bearer", "alice", "secret")));
+    assertNull(ExecSupport.basicAuthHeader(new ExecAuth("basic", null, "secret")));
+    assertEquals(
+        "an empty password must still authenticate as user:",
+        "Basic YWxpY2U6",
+        ExecSupport.basicAuthHeader(new ExecAuth("basic", "alice", null)));
+  }
+
+  @Test
+  public void toStringNeverLeaksCredentials() {
+    String s = AUTH.toString();
+    assertEquals(-1, s.indexOf("alice"));
+    assertEquals(-1, s.indexOf("secret"));
+  }
+
+  // ---- helpers -------------------------------------------------------------------------------
+
+  private String url(String pathAndQuery) {
+    return "http://localhost:" + server.getAddress().getPort() + pathAndQuery;
+  }
+
+  private static ExecuteTarget target(String url, ExecAuth auth) {
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, null, null, null, auth);
+  }
+
+  private ExecContext ctx() {
+    return new ExecContext(executionPool, watchdogScheduler, NEVER_CANCELLED);
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CancellationWatchdogTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CancellationWatchdogTest.java
@@ -1,0 +1,141 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CancellationWatchdogTest {
+
+  private ScheduledExecutorService scheduler;
+
+  @Before
+  public void setUp() {
+    scheduler = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  @After
+  public void tearDown() {
+    scheduler.shutdownNow();
+  }
+
+  @Test
+  public void firesOnCancelWhenCancelCheckerReportsCancelled() throws InterruptedException {
+    CountDownLatch fired = new CountDownLatch(1);
+    FlagCancelChecker checker = new FlagCancelChecker();
+    checker.cancel();
+
+    ScheduledFuture<?> task = CancellationWatchdog.watch(scheduler, checker, fired::countDown);
+    try {
+      assertTrue(
+          "onCancel should fire shortly after cancellation", fired.await(2, TimeUnit.SECONDS));
+    } finally {
+      task.cancel(true);
+    }
+  }
+
+  @Test
+  public void neverFiresWhenNeverCancelled() throws InterruptedException {
+    CountDownLatch fired = new CountDownLatch(1);
+    FlagCancelChecker checker = new FlagCancelChecker();
+
+    ScheduledFuture<?> task = CancellationWatchdog.watch(scheduler, checker, fired::countDown);
+    try {
+      assertFalse(
+          "onCancel must not fire while never cancelled", fired.await(600, TimeUnit.MILLISECONDS));
+    } finally {
+      task.cancel(true);
+    }
+  }
+
+  @Test
+  public void firesOnCancelExactlyOnceAcrossMultiplePolls() throws InterruptedException {
+    AtomicInteger fireCount = new AtomicInteger();
+    FlagCancelChecker checker = new FlagCancelChecker();
+    checker.cancel();
+
+    ScheduledFuture<?> task =
+        CancellationWatchdog.watch(scheduler, checker, fireCount::incrementAndGet);
+    try {
+      // Let several poll intervals elapse; the guard must keep the callback to a single firing.
+      Thread.sleep(900);
+      assertEquals(1, fireCount.get());
+    } finally {
+      task.cancel(true);
+    }
+  }
+
+  @Test
+  public void exceptionFromOnCancelIsSwallowed() throws InterruptedException {
+    FlagCancelChecker checker = new FlagCancelChecker();
+    checker.cancel();
+    CountDownLatch invoked = new CountDownLatch(1);
+
+    ScheduledFuture<?> task =
+        CancellationWatchdog.watch(
+            scheduler,
+            checker,
+            () -> {
+              invoked.countDown();
+              throw new IllegalStateException("boom — guarded operation already finished");
+            });
+    try {
+      // The callback running (and throwing) must not propagate out of the scheduler or prevent
+      // the scheduled task itself from remaining alive/cancellable.
+      assertTrue(invoked.await(2, TimeUnit.SECONDS));
+      assertFalse(task.isDone());
+    } finally {
+      task.cancel(true);
+    }
+  }
+
+  /** A simple settable {@link CancelChecker} test double. */
+  private static final class FlagCancelChecker implements CancelChecker {
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    void cancel() {
+      cancelled.set(true);
+    }
+
+    @Override
+    public void checkCanceled() {
+      if (cancelled.get()) {
+        throw new RuntimeException("cancelled");
+      }
+    }
+
+    @Override
+    public boolean isCanceled() {
+      return cancelled.get();
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/FileGlobsTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/FileGlobsTest.java
@@ -1,0 +1,116 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class FileGlobsTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  @Test
+  public void plainPathsAreNotPatterns() {
+    assertFalse(FileGlobs.isPattern("./rdf/a.ttl"));
+    assertFalse(FileGlobs.isPattern("model.xml"));
+    assertFalse(FileGlobs.isPattern("https://example.org/query"));
+    assertFalse(FileGlobs.isPattern(null));
+  }
+
+  @Test
+  public void globMetacharactersMakeAPattern() {
+    assertTrue(FileGlobs.isPattern("./rdf/*.ttl"));
+    assertTrue(FileGlobs.isPattern("./rdf/{a,b}.ttl"));
+    assertTrue(FileGlobs.isPattern("file?.ttl"));
+    assertTrue(FileGlobs.isPattern("file[ab].ttl"));
+  }
+
+  @Test
+  public void starMatchesFilesInOneDirectorySorted() throws IOException {
+    Path base = tmp.getRoot().toPath();
+    Path b = write(base, "rdf/b.ttl");
+    Path a = write(base, "rdf/a.ttl");
+    write(base, "rdf/c.nt");
+    write(base, "rdf/deeper/d.ttl"); // a single * must not cross directories
+
+    assertEquals(List.of(a, b), FileGlobs.expand("./rdf/*.ttl", base));
+  }
+
+  @Test
+  public void bracesSelectAlternatives() throws IOException {
+    Path base = tmp.getRoot().toPath();
+    Path a = write(base, "rdf/a.ttl");
+    Path b = write(base, "rdf/b.ttl");
+    write(base, "rdf/c.ttl");
+
+    assertEquals(List.of(a, b), FileGlobs.expand("./rdf/{a,b}.ttl", base));
+  }
+
+  @Test
+  public void doubleStarCrossesDirectories() throws IOException {
+    Path base = tmp.getRoot().toPath();
+    Path top = write(base, "rdf/a.ttl");
+    Path deep = write(base, "rdf/deeper/d.ttl");
+
+    assertEquals(List.of(top, deep), FileGlobs.expand("rdf/**.ttl", base));
+  }
+
+  @Test
+  public void absolutePatternsIgnoreTheBase() throws IOException {
+    Path base = tmp.getRoot().toPath();
+    Path a = write(base, "rdf/a.ttl");
+
+    assertEquals(List.of(a), FileGlobs.expand(base + "/rdf/*.ttl", Path.of("/nonexistent")));
+  }
+
+  @Test
+  public void noMatchesAndMissingDirectoriesYieldEmpty() throws IOException {
+    Path base = tmp.getRoot().toPath();
+    write(base, "rdf/a.ttl");
+
+    assertEquals(List.of(), FileGlobs.expand("./rdf/*.owl", base));
+    assertEquals(List.of(), FileGlobs.expand("./nope/*.ttl", base));
+    assertEquals(List.of(), FileGlobs.expand("./rdf/*.ttl", null));
+  }
+
+  @Test
+  public void directoriesThemselvesNeverMatch() throws IOException {
+    Path base = tmp.getRoot().toPath();
+    Files.createDirectories(base.resolve("rdf/sub.ttl")); // a directory with a matching name
+    Path a = write(base, "rdf/a.ttl");
+
+    assertEquals(List.of(a), FileGlobs.expand("./rdf/*.ttl", base));
+  }
+
+  private static Path write(Path base, String relative) throws IOException {
+    Path file = base.resolve(relative);
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, "# data\n");
+    return file;
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
@@ -426,7 +426,7 @@ public class HttpQueryExecutorTest {
   }
 
   private static ExecuteTarget target(String url, String updateUrl) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null, null);
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null, null, null);
   }
 
   private static String uniqueSubject() {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
@@ -421,12 +421,12 @@ public class HttpQueryExecutorTest {
 
   // ---- helpers ---------------------------------------------------------------------------------
 
-  private HttpQueryExecutor.ExecContext ctx(CancelChecker checker) {
-    return new HttpQueryExecutor.ExecContext(executionPool, watchdogScheduler, checker);
+  private ExecContext ctx(CancelChecker checker) {
+    return new ExecContext(executionPool, watchdogScheduler, checker);
   }
 
   private static ExecuteTarget target(String url, String updateUrl) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl);
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null);
   }
 
   private static String uniqueSubject() {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
@@ -426,7 +426,7 @@ public class HttpQueryExecutorTest {
   }
 
   private static ExecuteTarget target(String url, String updateUrl) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null);
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null, null);
   }
 
   private static String uniqueSubject() {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
@@ -1,0 +1,521 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class HttpQueryExecutorTest {
+
+  private static final String EX = "http://example.org/";
+  private static final AtomicInteger SUBJECT_COUNTER = new AtomicInteger();
+
+  private static final CancelChecker NEVER_CANCELLED =
+      new CancelChecker() {
+        @Override
+        public void checkCanceled() {}
+
+        @Override
+        public boolean isCanceled() {
+          return false;
+        }
+      };
+
+  private static FusekiServer fuseki;
+  private static String queryUrl;
+  private static String updateUrl;
+
+  private ExecutorService executionPool;
+  private ScheduledExecutorService watchdogScheduler;
+
+  @BeforeClass
+  public static void startFuseki() {
+    fuseki =
+        FusekiServer.create()
+            .port(0)
+            .add("/ds", DatasetGraphFactory.createTxnMem())
+            .build()
+            .start();
+    queryUrl = fuseki.serverURL() + "ds";
+    updateUrl = fuseki.serverURL() + "ds/update";
+  }
+
+  @AfterClass
+  public static void stopFuseki() {
+    fuseki.stop();
+  }
+
+  @Before
+  public void setUp() {
+    executionPool = Executors.newCachedThreadPool();
+    watchdogScheduler = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  @After
+  public void tearDown() {
+    executionPool.shutdownNow();
+    watchdogScheduler.shutdownNow();
+  }
+
+  // ---- happy paths (against the shared in-process Fuseki dataset) --------------------------
+
+  @Test
+  public void executeUpdateInsertsDataVisibleToASubsequentQuery() {
+    String subject = uniqueSubject();
+    var update = UpdateFactory.create("INSERT DATA { <" + subject + "> <" + EX + "p> \"v\" }");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(
+            update, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.UPDATE.name(), response.queryKind());
+    assertNull(response.error());
+    assertNotNull(response.stats());
+    assertEquals(updateUrl, response.stats().resolvedTarget());
+
+    Query ask = QueryFactory.create("ASK { <" + subject + "> <" + EX + "p> \"v\" }");
+    ExecuteResponse askResponse =
+        HttpQueryExecutor.executeQuery(
+            ask, QueryKind.ASK, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+    assertEquals(ExecutionStatus.SUCCESS.name(), askResponse.status());
+    assertTrue(asBoolean(askResponse));
+  }
+
+  @Test
+  public void executeQueryAskReturnsFalseWhenNoMatch() {
+    Query ask = QueryFactory.create("ASK { <" + EX + "does-not-exist> <" + EX + "p> ?o }");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            ask, QueryKind.ASK, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertFalse(asBoolean(response));
+  }
+
+  @Test
+  public void executeQuerySelectReturnsAllRowsUnderTheLimit() {
+    String subject = uniqueSubject();
+    insertTriples(subject, 3);
+    Query select = QueryFactory.create("SELECT ?o WHERE { <" + subject + "> <" + EX + "p> ?o }");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            select, QueryKind.SELECT, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.SELECT.name(), response.queryKind());
+    assertNotNull(response.resultsJson());
+    assertNull(response.turtle());
+    assertFalse(response.stats().truncated());
+    assertEquals(3, response.stats().rowCount().intValue());
+    assertEquals(
+        3,
+        JsonParser.parseString(response.resultsJson())
+            .getAsJsonObject()
+            .getAsJsonObject("results")
+            .getAsJsonArray("bindings")
+            .size());
+  }
+
+  @Test
+  public void executeQuerySelectTruncatesAtConfiguredMaxRows() {
+    String subject = uniqueSubject();
+    insertTriples(subject, 5);
+    Query select = QueryFactory.create("SELECT ?o WHERE { <" + subject + "> <" + EX + "p> ?o }");
+    var options = new ExecuteOptions(null, 2);
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            select, QueryKind.SELECT, target(queryUrl, updateUrl), options, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertTrue(response.stats().truncated());
+    assertEquals(2, response.stats().rowCount().intValue());
+  }
+
+  @Test
+  public void executeQueryConstructReturnsParseableTurtle() {
+    String subject = uniqueSubject();
+    insertTriples(subject, 2);
+    Query construct =
+        QueryFactory.create(
+            "CONSTRUCT { <"
+                + subject
+                + "> <"
+                + EX
+                + "p> ?o } WHERE { <"
+                + subject
+                + "> <"
+                + EX
+                + "p> ?o }");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            construct,
+            QueryKind.CONSTRUCT,
+            target(queryUrl, updateUrl),
+            null,
+            ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.CONSTRUCT.name(), response.queryKind());
+    assertNull(response.resultsJson());
+    assertNotNull(response.turtle());
+    assertEquals(2, parseTurtle(response.turtle()).size());
+  }
+
+  @Test
+  public void executeQueryDescribeReturnsParseableTurtle() {
+    String subject = uniqueSubject();
+    insertTriples(subject, 1);
+    Query describe = QueryFactory.create("DESCRIBE <" + subject + ">");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            describe, QueryKind.DESCRIBE, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertNotNull(response.turtle());
+    assertEquals(1, parseTurtle(response.turtle()).size());
+  }
+
+  // ---- target/validation errors --------------------------------------------------------------
+
+  @Test
+  public void executeQueryFailsWithNoTargetWhenTargetIsNull() {
+    Query ask = QueryFactory.create("ASK {}");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(ask, QueryKind.ASK, null, null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  @Test
+  public void executeQueryFailsWithNoTargetWhenUrlIsBlank() {
+    Query ask = QueryFactory.create("ASK {}");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            ask, QueryKind.ASK, target("   ", null), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  @Test
+  public void executeUpdateFailsWithUpdateNotAllowedWhenUpdateUrlIsBlank() {
+    var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(update, target(queryUrl, null), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.UPDATE_NOT_ALLOWED.name(), response.error().code());
+  }
+
+  @Test
+  public void executeUpdateFailsWithNoTargetWhenTargetIsNull() {
+    var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(update, null, null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  @Test
+  public void executeUpdateFailsWithNoTargetWhenQueryUrlIsBlankEvenIfUpdateUrlIsSet() {
+    // The query url is the base "is anything configured at all" check and applies uniformly to
+    // both executeQuery and executeUpdate; a blank query url is NO_TARGET even when updateUrl is
+    // present. In practice the client always derives both urls from the same directive, so this
+    // combination should not arise, but the precedence is worth pinning down explicitly.
+    var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(
+            update, target(null, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  // ---- transport-level failures (against a throwaway JDK HttpServer) ------------------------
+
+  @Test
+  public void executeQueryReportsAuthFailedOn401() throws IOException {
+    HttpServer server = respondingWith(401, "unauthorized");
+    try {
+      Query ask = QueryFactory.create("ASK {}");
+      ExecuteResponse response =
+          HttpQueryExecutor.executeQuery(
+              ask, QueryKind.ASK, target(baseUrl(server), null), null, ctx(NEVER_CANCELLED));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.AUTH_FAILED.name(), response.error().code());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void executeQueryReportsHttpErrorOnServerError() throws IOException {
+    HttpServer server = respondingWith(500, "boom");
+    try {
+      Query ask = QueryFactory.create("ASK {}");
+      ExecuteResponse response =
+          HttpQueryExecutor.executeQuery(
+              ask, QueryKind.ASK, target(baseUrl(server), null), null, ctx(NEVER_CANCELLED));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.HTTP_ERROR.name(), response.error().code());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void executeQueryReportsHttpErrorOnConnectionRefused() throws IOException {
+    int freePort;
+    try (ServerSocket probe = new ServerSocket(0)) {
+      freePort = probe.getLocalPort();
+    }
+    Query ask = QueryFactory.create("ASK {}");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            ask,
+            QueryKind.ASK,
+            target("http://localhost:" + freePort + "/nope", null),
+            null,
+            ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.HTTP_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void executeQueryReportsTimeoutWhenEndpointIsSlow() throws IOException {
+    HttpServer server = sleepingFor(2_000);
+    try {
+      Query ask = QueryFactory.create("ASK {}");
+      var options = new ExecuteOptions(200, null);
+
+      ExecuteResponse response =
+          HttpQueryExecutor.executeQuery(
+              ask, QueryKind.ASK, target(baseUrl(server), null), options, ctx(NEVER_CANCELLED));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.TIMEOUT.name(), response.error().code());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void executeUpdateReportsTimeoutWhenEndpointIsSlow() throws IOException {
+    HttpServer server = sleepingFor(2_000);
+    try {
+      var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+      var options = new ExecuteOptions(200, null);
+
+      ExecuteResponse response =
+          HttpQueryExecutor.executeUpdate(
+              update, target(queryUrl, baseUrl(server)), options, ctx(NEVER_CANCELLED));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.TIMEOUT.name(), response.error().code());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  // ---- cancellation ---------------------------------------------------------------------------
+
+  @Test
+  public void executeQueryReturnsCancelledBeforeTheSlowEndpointResponds() throws IOException {
+    HttpServer server = sleepingFor(5_000);
+    try {
+      Query ask = QueryFactory.create("ASK {}");
+      var options = new ExecuteOptions(20_000, null);
+
+      long start = System.nanoTime();
+      ExecuteResponse response =
+          HttpQueryExecutor.executeQuery(
+              ask, QueryKind.ASK, target(baseUrl(server), null), options, ctx(cancelAfter(300)));
+      long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+      assertEquals(ExecutionStatus.CANCELLED.name(), response.status());
+      assertEquals(ErrorCode.CANCELLED.name(), response.error().code());
+      assertTrue(
+          "expected to return well before the 5s server delay, took " + elapsedMs + "ms",
+          elapsedMs < 4_000);
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void executeUpdateReturnsCancelledEvenThoughAbortCannotUnblockIt() throws IOException {
+    // Regression test for the abort()-asymmetry documented on HttpQueryExecutor: unlike queries,
+    // UpdateExecution.abort() does not unblock a blocked execute() call, so this only passes
+    // because the race against the watchdog signal — not abort() — decides the outcome.
+    HttpServer server = sleepingFor(5_000);
+    try {
+      var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+      var options = new ExecuteOptions(20_000, null);
+
+      long start = System.nanoTime();
+      ExecuteResponse response =
+          HttpQueryExecutor.executeUpdate(
+              update, target(queryUrl, baseUrl(server)), options, ctx(cancelAfter(300)));
+      long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+      assertEquals(ExecutionStatus.CANCELLED.name(), response.status());
+      assertTrue(
+          "expected to return well before the 5s server delay, took " + elapsedMs + "ms",
+          elapsedMs < 4_000);
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------------
+
+  private HttpQueryExecutor.ExecContext ctx(CancelChecker checker) {
+    return new HttpQueryExecutor.ExecContext(executionPool, watchdogScheduler, checker);
+  }
+
+  private static ExecuteTarget target(String url, String updateUrl) {
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl);
+  }
+
+  private static String uniqueSubject() {
+    return EX + "s" + SUBJECT_COUNTER.incrementAndGet();
+  }
+
+  private void insertTriples(String subject, int count) {
+    StringBuilder sb = new StringBuilder("INSERT DATA { ");
+    for (int i = 0; i < count; i++) {
+      sb.append('<').append(subject).append("> <").append(EX).append("p> ").append(i).append(" . ");
+    }
+    sb.append('}');
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(
+            UpdateFactory.create(sb.toString()),
+            target(queryUrl, updateUrl),
+            null,
+            ctx(NEVER_CANCELLED));
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+  }
+
+  private static boolean asBoolean(ExecuteResponse response) {
+    return JsonParser.parseString(response.resultsJson())
+        .getAsJsonObject()
+        .get("boolean")
+        .getAsBoolean();
+  }
+
+  private static Model parseTurtle(String turtle) {
+    Model model = ModelFactory.createDefaultModel();
+    model.read(new java.io.StringReader(turtle), null, "TURTLE");
+    return model;
+  }
+
+  /** A {@link CancelChecker} that reports cancelled once {@code delayMs} has elapsed. */
+  private static CancelChecker cancelAfter(long delayMs) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayMs);
+    return new CancelChecker() {
+      @Override
+      public void checkCanceled() {}
+
+      @Override
+      public boolean isCanceled() {
+        return System.nanoTime() >= deadlineNanos;
+      }
+    };
+  }
+
+  private static String baseUrl(HttpServer server) {
+    return "http://localhost:" + server.getAddress().getPort() + "/endpoint";
+  }
+
+  private static HttpServer respondingWith(int status, String body) throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    server.createContext(
+        "/endpoint",
+        exchange -> {
+          try {
+            exchange.sendResponseHeaders(status, bytes.length);
+            exchange.getResponseBody().write(bytes);
+          } finally {
+            exchange.close();
+          }
+        });
+    server.setExecutor(Executors.newCachedThreadPool());
+    server.start();
+    return server;
+  }
+
+  private static HttpServer sleepingFor(long millis) throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext(
+        "/endpoint",
+        exchange -> {
+          try {
+            Thread.sleep(millis);
+            byte[] bytes = "{\"head\":{},\"boolean\":true}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/sparql-results+json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            exchange.close();
+          }
+        });
+    server.setExecutor(Executors.newCachedThreadPool());
+    server.start();
+    return server;
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
@@ -138,6 +138,56 @@ public class LocalQueryExecutorTest {
   }
 
   @Test
+  public void globDirectiveExpandsToAllMatchingFiles() throws IOException {
+    dataFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    dataFile("b.ttl", "<" + EX + "b> <" + EX + "p> 2 .");
+    dataFile("c.nt", "<" + EX + "c> <" + EX + "p> <" + EX + "o> .\n");
+    String notebookUri = tmp.getRoot().toPath().resolve("demo.cimnb.md").toUri().toString();
+
+    ExecuteResponse response =
+        execute(
+            "SELECT ?s WHERE { ?s <" + EX + "p> ?o }",
+            QueryKind.SELECT,
+            request(notebookUri, "./*.ttl"));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(2, bindings(response).size());
+    assertEquals("./*.ttl", response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void bracePatternSelectsTheNamedFiles() throws IOException {
+    dataFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    dataFile("b.ttl", "<" + EX + "b> <" + EX + "p> 2 .");
+    dataFile("c.ttl", "<" + EX + "c> <" + EX + "p> 3 .");
+    String notebookUri = tmp.getRoot().toPath().resolve("demo.cimnb.md").toUri().toString();
+
+    ExecuteResponse response =
+        execute(
+            "SELECT ?s WHERE { ?s <" + EX + "p> ?o }",
+            QueryKind.SELECT,
+            request(notebookUri, "./{a,b}.ttl"));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(2, bindings(response).size());
+  }
+
+  @Test
+  public void fileMatchedTwiceIsQueriedOnce() throws IOException {
+    Path a = dataFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    String notebookUri = tmp.getRoot().toPath().resolve("demo.cimnb.md").toUri().toString();
+
+    ExecuteResponse response =
+        execute(
+            "SELECT ?s WHERE { ?s <" + EX + "p> ?o }",
+            QueryKind.SELECT,
+            request(notebookUri, "./*.ttl", a.toString()));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(1, bindings(response).size());
+  }
+
+  @Test
   public void constructReturnsTheResultGraphAsTurtle() throws IOException {
     Path file = dataFile("data.ttl", "<" + EX + "s> <" + EX + "p> \"v\" .");
 
@@ -207,6 +257,26 @@ public class LocalQueryExecutorTest {
 
     assertEquals(ExecutionStatus.ERROR.name(), response.status());
     assertEquals(ErrorCode.FILE_PARSE_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void patternMatchingNothingReportsFileNotFound() {
+    String notebookUri = tmp.getRoot().toPath().resolve("demo.cimnb.md").toUri().toString();
+
+    ExecuteResponse response = execute("ASK {}", QueryKind.ASK, request(notebookUri, "./*.ttl"));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.name(), response.error().code());
+    assertTrue(response.error().message().contains("No files match"));
+  }
+
+  @Test
+  public void relativePatternWithoutANotebookLocationAsksToSaveFirst() {
+    ExecuteResponse response = execute("ASK {}", QueryKind.ASK, request(null, "./*.ttl"));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.name(), response.error().code());
+    assertTrue(response.error().message().contains("save the notebook"));
   }
 
   @Test

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
@@ -1,0 +1,350 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises {@link LocalQueryExecutor}: in-process query kinds over local files, relative-path
+ * resolution against the notebook URI, the {@link LocalStoreManager} failure modes surfacing as
+ * responses, and timeout/cancellation of the in-process engine. File parsing and union/cache
+ * mechanics themselves are covered by {@link LocalStoreManagerTest}.
+ */
+public class LocalQueryExecutorTest {
+
+  private static final String EX = "http://example.org/";
+
+  private static final CancelChecker NEVER_CANCELLED =
+      new CancelChecker() {
+        @Override
+        public void checkCanceled() {}
+
+        @Override
+        public boolean isCanceled() {
+          return false;
+        }
+      };
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private ExecutorService executionPool;
+  private ScheduledExecutorService watchdogScheduler;
+  private LocalStoreManager stores;
+
+  @Before
+  public void setUp() {
+    executionPool = Executors.newCachedThreadPool();
+    watchdogScheduler = Executors.newSingleThreadScheduledExecutor();
+    stores = new LocalStoreManager();
+  }
+
+  @After
+  public void tearDown() {
+    executionPool.shutdownNow();
+    watchdogScheduler.shutdownNow();
+  }
+
+  // ---- happy paths -----------------------------------------------------------------------------
+
+  @Test
+  public void selectAgainstAnAbsolutePathReturnsBindings() throws IOException {
+    Path file = dataFile("data.ttl", "<" + EX + "s> <" + EX + "p> \"v\" .");
+
+    ExecuteResponse response =
+        execute(
+            "SELECT ?o WHERE { <" + EX + "s> <" + EX + "p> ?o }",
+            QueryKind.SELECT,
+            request(null, file.toString()));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.SELECT.name(), response.queryKind());
+    assertNull(response.error());
+    JsonArray bindings = bindings(response);
+    assertEquals(1, bindings.size());
+    assertEquals(
+        "v", bindings.get(0).getAsJsonObject().getAsJsonObject("o").get("value").getAsString());
+    assertEquals(Integer.valueOf(1), response.stats().rowCount());
+    assertEquals(file.toString(), response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void relativePathsResolveAgainstTheNotebookDirectory() throws IOException {
+    dataFile("data.ttl", "<" + EX + "s> <" + EX + "p> \"v\" .");
+    String notebookUri = tmp.getRoot().toPath().resolve("demo.cimnb.md").toUri().toString();
+
+    ExecuteResponse response =
+        execute("ASK { ?s ?p ?o }", QueryKind.ASK, request(notebookUri, "./data.ttl"));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertTrue(
+        JsonParser.parseString(response.resultsJson())
+            .getAsJsonObject()
+            .get("boolean")
+            .getAsBoolean());
+    assertEquals("./data.ttl", response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void multipleFilesAreQueriedAsOneUnion() throws IOException {
+    Path a = dataFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    Path b = dataFile("b.ttl", "<" + EX + "b> <" + EX + "p> 2 .");
+
+    ExecuteResponse response =
+        execute(
+            "SELECT ?s WHERE { ?s <" + EX + "p> ?o }",
+            QueryKind.SELECT,
+            request(null, a.toString(), b.toString()));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(2, bindings(response).size());
+    assertEquals(a + ", " + b, response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void constructReturnsTheResultGraphAsTurtle() throws IOException {
+    Path file = dataFile("data.ttl", "<" + EX + "s> <" + EX + "p> \"v\" .");
+
+    ExecuteResponse response =
+        execute(
+            "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+            QueryKind.CONSTRUCT,
+            request(null, file.toString()));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.CONSTRUCT.name(), response.queryKind());
+    assertTrue(response.turtle().contains(EX + "s"));
+  }
+
+  @Test
+  public void selectOverACimxmlModelSeesBodyAndHeader() throws IOException {
+    Path model = dataFile("model.xml", CIMXML_FULL_MODEL);
+
+    ExecuteResponse names =
+        execute(
+            "SELECT ?name WHERE { ?s <http://iec.ch/TC57/CIM100#IdentifiedObject.name> ?name }",
+            QueryKind.SELECT,
+            request(null, model.toString()));
+    assertEquals(ExecutionStatus.SUCCESS.name(), names.status());
+    assertEquals(
+        "My Custom Equipment",
+        bindings(names)
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonObject("name")
+            .get("value")
+            .getAsString());
+
+    ExecuteResponse header =
+        execute(
+            "ASK { ?m <http://iec.ch/TC57/61970-552/ModelDescription/1#Model.profile> ?p }",
+            QueryKind.ASK,
+            request(null, model.toString()));
+    assertTrue(
+        "the model header must be visible to bare patterns via the union default graph",
+        JsonParser.parseString(header.resultsJson())
+            .getAsJsonObject()
+            .get("boolean")
+            .getAsBoolean());
+  }
+
+  // ---- failure modes ---------------------------------------------------------------------------
+
+  @Test
+  public void missingFileReportsFileNotFound() {
+    ExecuteResponse response =
+        execute(
+            "ASK {}",
+            QueryKind.ASK,
+            request(null, tmp.getRoot().toPath().resolve("nope.ttl").toString()));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.name(), response.error().code());
+    assertTrue(response.error().message().contains("nope.ttl"));
+  }
+
+  @Test
+  public void unparseableFileReportsFileParseError() throws IOException {
+    Path file = dataFile("broken.ttl", "not turtle @@@");
+
+    ExecuteResponse response = execute("ASK {}", QueryKind.ASK, request(null, file.toString()));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_PARSE_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void relativePathWithoutANotebookLocationReportsFileNotFound() {
+    ExecuteResponse response = execute("ASK {}", QueryKind.ASK, request(null, "./data.ttl"));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.name(), response.error().code());
+    assertTrue(response.error().message().contains("save the notebook"));
+  }
+
+  @Test
+  public void emptyFileListReportsNoTarget() {
+    ExecuteResponse response = execute("ASK {}", QueryKind.ASK, request(null));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  // ---- timeout and cancellation ----------------------------------------------------------------
+
+  @Test
+  public void slowQueryReportsTimeout() throws IOException {
+    ExecuteResponse response =
+        execute(PATHOLOGICAL_QUERY, QueryKind.SELECT, slowRequest(50), NEVER_CANCELLED);
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.TIMEOUT.name(), response.error().code());
+  }
+
+  @Test
+  public void cancellationWinsOverASlowQuery() throws IOException {
+    long start = System.nanoTime();
+    ExecuteResponse response =
+        execute(PATHOLOGICAL_QUERY, QueryKind.SELECT, slowRequest(60_000), cancelAfter(300));
+    long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+    assertEquals(ExecutionStatus.CANCELLED.name(), response.status());
+    assertEquals(ErrorCode.CANCELLED.name(), response.error().code());
+    assertTrue(
+        "expected cancellation well before the timeout, took " + elapsedMs + "ms",
+        elapsedMs < 30_000);
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------------
+
+  /**
+   * A COUNT over an unrestricted five-way cross join (120⁵ ≈ 2.5 × 10¹⁰ combinations on the fixture
+   * data): the aggregation forces the whole join to be exhausted before the first row can be
+   * emitted, so — unlike a plain SELECT, which streams rows immediately and would finish within the
+   * row cap — this reliably still runs when the timeout or cancellation fires.
+   */
+  private static final String PATHOLOGICAL_QUERY =
+      "SELECT (COUNT(*) AS ?n) WHERE { ?a ?p1 ?o1 . ?b ?p2 ?o2 . ?c ?p3 ?o3 . ?d ?p4 ?o4 ."
+          + " ?e ?p5 ?o5 }";
+
+  /** From the CIMXML FullModel structure exercised in the cimxml module's own tests. */
+  private static final String CIMXML_FULL_MODEL =
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+       <md:FullModel rdf:about="urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6">
+         <md:Model.profile>http://soptim.de/CIM/MyProfile/1.1</md:Model.profile>
+       </md:FullModel>
+       <cim:MyEquipment rdf:ID="_f67fc354-9e39-4191-a456-67537399bc48">
+         <cim:IdentifiedObject.name>My Custom Equipment</cim:IdentifiedObject.name>
+       </cim:MyEquipment>
+      </rdf:RDF>
+      """;
+
+  private ExecuteRequest slowRequest(int timeoutMs) throws IOException {
+    StringBuilder turtle = new StringBuilder();
+    for (int i = 0; i < 120; i++) {
+      turtle
+          .append('<')
+          .append(EX)
+          .append('s')
+          .append(i)
+          .append("> <")
+          .append(EX)
+          .append("p> ")
+          .append(i)
+          .append(" .\n");
+    }
+    Path file = dataFile("big.ttl", turtle.toString());
+    return new ExecuteRequest(
+        "file:///cell1.sparql",
+        null,
+        "sparql",
+        PATHOLOGICAL_QUERY,
+        filesTarget(file.toString()),
+        new ExecuteOptions(timeoutMs, null));
+  }
+
+  private ExecuteResponse execute(String queryText, QueryKind kind, ExecuteRequest request) {
+    return execute(queryText, kind, request, NEVER_CANCELLED);
+  }
+
+  private ExecuteResponse execute(
+      String queryText, QueryKind kind, ExecuteRequest request, CancelChecker checker) {
+    Query query = QueryFactory.create(queryText);
+    return LocalQueryExecutor.executeQuery(
+        query, kind, request, stores, new ExecContext(executionPool, watchdogScheduler, checker));
+  }
+
+  private static ExecuteRequest request(String notebookUri, String... files) {
+    return new ExecuteRequest(
+        "file:///cell1.sparql", notebookUri, "sparql", "unused", filesTarget(files), null);
+  }
+
+  private static ExecuteTarget filesTarget(String... files) {
+    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, List.of(files));
+  }
+
+  private Path dataFile(String name, String content) throws IOException {
+    Path file = tmp.getRoot().toPath().resolve(name);
+    Files.writeString(file, content);
+    return file;
+  }
+
+  private static JsonArray bindings(ExecuteResponse response) {
+    return JsonParser.parseString(response.resultsJson())
+        .getAsJsonObject()
+        .getAsJsonObject("results")
+        .getAsJsonArray("bindings");
+  }
+
+  /** A {@link CancelChecker} that reports cancelled once {@code delayMs} has elapsed. */
+  private static CancelChecker cancelAfter(long delayMs) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayMs);
+    return new CancelChecker() {
+      @Override
+      public void checkCanceled() {}
+
+      @Override
+      public boolean isCanceled() {
+        return System.nanoTime() >= deadlineNanos;
+      }
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
@@ -318,7 +318,7 @@ public class LocalQueryExecutorTest {
   }
 
   private static ExecuteTarget filesTarget(String... files) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files));
+    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files), null);
   }
 
   private Path dataFile(String name, String content) throws IOException {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
@@ -318,7 +318,7 @@ public class LocalQueryExecutorTest {
   }
 
   private static ExecuteTarget filesTarget(String... files) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, List.of(files));
+    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files));
   }
 
   private Path dataFile(String name, String content) throws IOException {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManagerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManagerTest.java
@@ -1,0 +1,243 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.List;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises {@link LocalStoreManager}: format dispatch (Turtle/TriG via Jena, {@code .xml} via the
+ * CIMXML parser), the union semantics documented on the class, and the cache behavior (reuse,
+ * mtime/size invalidation, LRU eviction, failed parses not cached).
+ */
+public class LocalStoreManagerTest {
+
+  private static final String EX = "http://example.org/";
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private final LocalStoreManager manager = new LocalStoreManager();
+
+  // ---- parsing and union semantics ------------------------------------------------------------
+
+  @Test
+  public void parsesTurtleIntoTheDefaultGraph() throws Exception {
+    Path file = turtleFile("data.ttl", "<" + EX + "s> <" + EX + "p> <" + EX + "o> .");
+
+    DatasetGraph union = manager.unionFor(List.of(file));
+
+    assertTrue(union.getDefaultGraph().contains(uri(EX + "s"), uri(EX + "p"), uri(EX + "o")));
+  }
+
+  @Test
+  public void unionOfTwoFilesSeesTriplesFromBoth() throws Exception {
+    Path a = turtleFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    Path b = turtleFile("b.ttl", "<" + EX + "b> <" + EX + "p> 2 .");
+
+    Graph defaultGraph = manager.unionFor(List.of(a, b)).getDefaultGraph();
+
+    assertTrue(defaultGraph.contains(uri(EX + "a"), uri(EX + "p"), null));
+    assertTrue(defaultGraph.contains(uri(EX + "b"), uri(EX + "p"), null));
+  }
+
+  @Test
+  public void namedGraphsStayAddressableAndJoinTheDefaultUnion() throws Exception {
+    Path file = write("data.trig", "<" + EX + "g> { <" + EX + "s> <" + EX + "p> <" + EX + "o> . }");
+
+    DatasetGraph union = manager.unionFor(List.of(file));
+
+    assertTrue("GRAPH lookup must still work", union.containsGraph(uri(EX + "g")));
+    assertTrue(union.getGraph(uri(EX + "g")).contains(uri(EX + "s"), uri(EX + "p"), uri(EX + "o")));
+    assertTrue(
+        "a bare triple pattern must see named-graph data",
+        union.getDefaultGraph().contains(uri(EX + "s"), uri(EX + "p"), uri(EX + "o")));
+  }
+
+  @Test
+  public void parsesCimxmlModelWithBodyAndHeaderVisibleInTheUnion() throws Exception {
+    Path file = write("model.xml", CIMXML_FULL_MODEL);
+
+    Graph defaultGraph = manager.unionFor(List.of(file)).getDefaultGraph();
+
+    assertTrue(
+        "model body must be queryable",
+        defaultGraph.contains(
+            uri("urn:uuid:f67fc354-9e39-4191-a456-67537399bc48"),
+            uri("http://iec.ch/TC57/CIM100#IdentifiedObject.name"),
+            null));
+    assertTrue(
+        "the FullModel header (a named graph in the parsed dataset) must join the union",
+        defaultGraph.contains(
+            uri("urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6"),
+            uri("http://iec.ch/TC57/61970-552/ModelDescription/1#Model.profile"),
+            null));
+  }
+
+  // ---- failure modes ---------------------------------------------------------------------------
+
+  @Test
+  public void missingFileReportsFileNotFound() {
+    Path missing = tmp.getRoot().toPath().resolve("nope.ttl");
+
+    LocalStoreManager.StoreException e = expectStoreException(List.of(missing));
+
+    assertEquals(ErrorCode.FILE_NOT_FOUND, e.code());
+    assertTrue(e.getMessage().contains("nope.ttl"));
+  }
+
+  @Test
+  public void directoryReportsFileNotFound() throws IOException {
+    Path dir = tmp.newFolder("adir").toPath();
+
+    assertEquals(ErrorCode.FILE_NOT_FOUND, expectStoreException(List.of(dir)).code());
+  }
+
+  @Test
+  public void unparseableFileReportsFileParseErrorAndIsRetriedAfterAFix() throws Exception {
+    Path file = turtleFile("broken.ttl", "this is not turtle @@@");
+
+    LocalStoreManager.StoreException e = expectStoreException(List.of(file));
+    assertEquals(ErrorCode.FILE_PARSE_ERROR, e.code());
+    assertTrue("message should name the file", e.getMessage().contains("broken.ttl"));
+
+    Files.writeString(file, "<" + EX + "s> <" + EX + "p> <" + EX + "o> .");
+    assertTrue(
+        "a failed parse must not be cached",
+        manager
+            .unionFor(List.of(file))
+            .getDefaultGraph()
+            .contains(uri(EX + "s"), uri(EX + "p"), uri(EX + "o")));
+  }
+
+  // ---- caching ---------------------------------------------------------------------------------
+
+  // Cache reuse vs re-parse is observed through the identity of the per-file DatasetGraph
+  // (datasetGraphFor is package-private for exactly this): a cache hit returns the identical
+  // instance, a re-parse a fresh one. (Instance identity of getDefaultGraph() would not work —
+  // in-memory datasets hand out a new GraphView wrapper on every call.)
+
+  @Test
+  public void unchangedFileIsServedFromTheCache() throws Exception {
+    Path file = turtleFile("data.ttl", "<" + EX + "s> <" + EX + "p> 1 .");
+
+    assertSame(manager.datasetGraphFor(file), manager.datasetGraphFor(file));
+  }
+
+  @Test
+  public void changedMtimeInvalidatesTheCachedParse() throws Exception {
+    Path file = turtleFile("data.ttl", "<" + EX + "s> <" + EX + "p> 1 .");
+    DatasetGraph before = manager.datasetGraphFor(file);
+
+    // Same byte length, different content: only the modification time reveals the change.
+    Files.writeString(file, "<" + EX + "s> <" + EX + "p> 2 .");
+    FileTime bumped = FileTime.fromMillis(Files.getLastModifiedTime(file).toMillis() + 2_000);
+    Files.setLastModifiedTime(file, bumped);
+
+    DatasetGraph after = manager.datasetGraphFor(file);
+    assertNotSame(before, after);
+    assertTrue(
+        "the re-parse must expose the new content",
+        after.getDefaultGraph().contains(uri(EX + "s"), uri(EX + "p"), integerLiteral("2")));
+  }
+
+  @Test
+  public void changedSizeInvalidatesTheCachedParse() throws Exception {
+    Path file = turtleFile("data.ttl", "<" + EX + "s> <" + EX + "p> 1 .");
+    FileTime originalMtime = Files.getLastModifiedTime(file);
+    DatasetGraph before = manager.datasetGraphFor(file);
+
+    Files.writeString(file, "<" + EX + "s> <" + EX + "p> 1 . <" + EX + "s2> <" + EX + "p> 2 .");
+    // Pin the mtime back to the cached one so only the size reveals the change.
+    Files.setLastModifiedTime(file, originalMtime);
+
+    assertNotSame(before, manager.datasetGraphFor(file));
+  }
+
+  @Test
+  public void leastRecentlyUsedEntryIsEvictedBeyondCapacity() throws Exception {
+    LocalStoreManager small = new LocalStoreManager(1);
+    Path a = turtleFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    Path b = turtleFile("b.ttl", "<" + EX + "b> <" + EX + "p> 2 .");
+
+    DatasetGraph firstParse = small.datasetGraphFor(a);
+    assertSame("sanity: a cache hit while still resident", firstParse, small.datasetGraphFor(a));
+    small.datasetGraphFor(b); // capacity 1: evicts a
+    assertNotSame("evicted file must be re-parsed", firstParse, small.datasetGraphFor(a));
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------------
+
+  /** From the CIMXML FullModel structure exercised in the cimxml module's own tests. */
+  private static final String CIMXML_FULL_MODEL =
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+       <md:FullModel rdf:about="urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6">
+         <md:Model.profile>http://soptim.de/CIM/MyProfile/1.1</md:Model.profile>
+       </md:FullModel>
+       <cim:MyEquipment rdf:ID="_f67fc354-9e39-4191-a456-67537399bc48">
+         <cim:IdentifiedObject.name>My Custom Equipment</cim:IdentifiedObject.name>
+       </cim:MyEquipment>
+      </rdf:RDF>
+      """;
+
+  private Path turtleFile(String name, String turtle) throws IOException {
+    return write(name, turtle);
+  }
+
+  private Path write(String name, String content) throws IOException {
+    Path file = tmp.getRoot().toPath().resolve(name);
+    Files.writeString(file, content);
+    return file;
+  }
+
+  private LocalStoreManager.StoreException expectStoreException(List<Path> files) {
+    try {
+      manager.unionFor(files);
+      fail("expected a StoreException for " + files);
+      throw new AssertionError("unreachable");
+    } catch (LocalStoreManager.StoreException e) {
+      return e;
+    }
+  }
+
+  private static org.apache.jena.graph.Node uri(String uri) {
+    return NodeFactory.createURI(uri);
+  }
+
+  private static org.apache.jena.graph.Node integerLiteral(String lexicalForm) {
+    return NodeFactory.createLiteralDT(lexicalForm, XSDDatatype.XSDinteger);
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -204,6 +204,47 @@ public class NotebookCommandHandlerTest {
     }
   }
 
+  // ---- SHACL cells -----------------------------------------------------------------------------
+
+  @Test
+  public void executeCommandRoutesShaclCellsByLanguageIdAndPinsTheSummaryWireShape()
+      throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-shacl");
+    try {
+      Files.writeString(
+          dir.resolve("data.ttl"), "@prefix ex: <http://example.org/> . ex:bob a ex:Person .");
+      String shapes =
+          """
+          PREFIX sh: <http://www.w3.org/ns/shacl#>
+          PREFIX ex: <http://example.org/>
+          ex:PersonShape a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+          """;
+      JsonObject arg = filesRequestJson(shapes, dir, "./data.ttl");
+      arg.addProperty("languageId", "shacl");
+
+      ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+      assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+      assertEquals(QueryKind.SHACL.name(), response.queryKind());
+
+      // Wire shape of the summary, as the TS client parses it (see endpoint.ts).
+      Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
+      JsonObject json = wireGson.toJsonTree(response).getAsJsonObject();
+      assertEquals("SHACL", json.get("queryKind").getAsString());
+      JsonObject summary = json.getAsJsonObject("shaclSummary");
+      assertFalse(summary.get("conforms").getAsBoolean());
+      assertEquals(1, summary.get("violations").getAsInt());
+      assertEquals(0, summary.get("warnings").getAsInt());
+      assertEquals(0, summary.get("infos").getAsInt());
+      assertFalse(json.get("turtle").getAsString().isEmpty());
+    } finally {
+      try (var paths = Files.walk(dir)) {
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
   // ---- wire shape ----------------------------------------------------------------------------
 
   /**

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -273,7 +273,9 @@ public class NotebookCommandHandlerTest {
       Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
       JsonObject json = wireGson.toJsonTree(result).getAsJsonObject();
       assertTrue(json.get("configPath").getAsString().endsWith("opencgmes.jsonc"));
-      assertEquals(7, json.get("queryTimeoutSeconds").getAsInt());
+      assertFalse(
+          "execution defaults are applied server-side, not shipped to the client",
+          json.has("queryTimeoutSeconds"));
       JsonObject connection = json.getAsJsonArray("connections").get(0).getAsJsonObject();
       assertEquals("local-fuseki", connection.get("name").getAsString());
       assertEquals("basic", connection.get("authType").getAsString());

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -245,6 +245,86 @@ public class NotebookCommandHandlerTest {
     }
   }
 
+  // ---- connections and config defaults ---------------------------------------------------------
+
+  @Test
+  public void listConnectionsAnswersTheNotebookConfigAndPinsTheWireShape() throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-conn");
+    try {
+      Files.writeString(
+          dir.resolve("opencgmes.jsonc"),
+          """
+          {
+            "cimnotebook": {
+              "queryTimeoutSeconds": 7,
+              "connections": [
+                { "name": "local-fuseki", "url": "http://localhost:3030/ds/query",
+                  "authType": "basic", "default": true,
+                  "password": "must-never-be-echoed" }
+              ]
+            }
+          }
+          """);
+      JsonObject arg = new JsonObject();
+      arg.addProperty("notebookUri", dir.resolve("demo.cimnb.md").toUri().toString());
+
+      Object result = handler.listConnections(List.of(arg)).get();
+
+      Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
+      JsonObject json = wireGson.toJsonTree(result).getAsJsonObject();
+      assertTrue(json.get("configPath").getAsString().endsWith("opencgmes.jsonc"));
+      assertEquals(7, json.get("queryTimeoutSeconds").getAsInt());
+      JsonObject connection = json.getAsJsonArray("connections").get(0).getAsJsonObject();
+      assertEquals("local-fuseki", connection.get("name").getAsString());
+      assertEquals("basic", connection.get("authType").getAsString());
+      assertTrue(
+          "the keyword-named flag must serialize as 'default'",
+          connection.get("default").getAsBoolean());
+      assertFalse(
+          "secrets in the config must never be echoed back", json.toString().contains("password"));
+    } finally {
+      try (var paths = Files.walk(dir)) {
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
+  @Test
+  public void listConnectionsWithoutAConfigAnswersEmpty() throws Exception {
+    JsonObject arg = new JsonObject();
+    arg.addProperty("notebookUri", "untitled:Untitled-1");
+
+    Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
+    JsonObject json =
+        wireGson.toJsonTree(handler.listConnections(List.of(arg)).get()).getAsJsonObject();
+
+    assertFalse(json.has("configPath"));
+    assertEquals(0, json.getAsJsonArray("connections").size());
+  }
+
+  @Test
+  public void executeAppliesTheConfigMaxRowsWhenTheRequestHasNoOptions() throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-clamp");
+    try {
+      Files.writeString(dir.resolve("opencgmes.jsonc"), "{ \"cimnotebook\": { \"maxRows\": 1 } }");
+      Files.writeString(
+          dir.resolve("data.ttl"),
+          "<http://example.org/a> <http://example.org/p> 1 . "
+              + "<http://example.org/b> <http://example.org/p> 2 .");
+      JsonObject arg = filesRequestJson("SELECT ?s WHERE { ?s ?p ?o }", dir, "./data.ttl");
+
+      ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+      assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+      assertEquals(Integer.valueOf(1), response.stats().rowCount());
+      assertTrue("the config cap must truncate the result", response.stats().truncated());
+    } finally {
+      try (var paths = Files.walk(dir)) {
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
   // ---- wire shape ----------------------------------------------------------------------------
 
   /**

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -1,0 +1,268 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Exercises {@link NotebookCommandHandler#executeCommand} end to end, covering argument parsing
+ * (both the {@code JsonElement} and in-process {@code String} argument shapes handled by {@link
+ * NotebookCommandHandler}) and dispatch into {@link HttpQueryExecutor}. Query-execution behavior
+ * itself (timeouts, cancellation, HTTP error classification, etc.) is covered by {@link
+ * HttpQueryExecutorTest}; this class only needs enough of a real endpoint to prove that a
+ * successfully parsed request actually reaches it.
+ */
+public class NotebookCommandHandlerTest {
+
+  private static FusekiServer fuseki;
+  private static String queryUrl;
+  private static String updateUrl;
+
+  private NotebookCommandHandler handler;
+
+  @BeforeClass
+  public static void startFuseki() {
+    fuseki =
+        FusekiServer.create()
+            .port(0)
+            .add("/ds", DatasetGraphFactory.createTxnMem())
+            .build()
+            .start();
+    queryUrl = fuseki.serverURL() + "ds";
+    updateUrl = fuseki.serverURL() + "ds/update";
+  }
+
+  @AfterClass
+  public static void stopFuseki() {
+    fuseki.stop();
+  }
+
+  @Before
+  public void setUp() {
+    handler = new NotebookCommandHandler();
+  }
+
+  @After
+  public void tearDown() {
+    handler.shutdown();
+  }
+
+  // ---- malformed arguments (never reach HttpQueryExecutor) -----------------------------------
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenArgumentsIsNull() {
+    assertInvalidParams(handler.executeCommand(null));
+  }
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenArgumentsIsEmpty() {
+    assertInvalidParams(handler.executeCommand(List.of()));
+  }
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenFirstArgumentIsNull() {
+    List<Object> args = new ArrayList<>();
+    args.add(null);
+    assertInvalidParams(handler.executeCommand(args));
+  }
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenArgumentIsNotValidJson() {
+    assertInvalidParams(handler.executeCommand(List.of("not json at all")));
+  }
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenTextFieldIsMissing() {
+    JsonObject arg = new JsonObject();
+    arg.addProperty("cellUri", "file:///cell1.sparql");
+    assertInvalidParams(handler.executeCommand(List.of(arg)));
+  }
+
+  // ---- successful dispatch ---------------------------------------------------------------------
+
+  @Test
+  public void executeCommandDispatchesJsonElementArgumentAndExecutesAskQuery() throws Exception {
+    JsonObject arg = requestJson("ASK {}", queryUrl, updateUrl);
+
+    ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.ASK.name(), response.queryKind());
+  }
+
+  @Test
+  public void executeCommandDispatchesStringArgumentAndExecutesAskQuery() throws Exception {
+    // Mirrors a direct in-process call (as opposed to a JsonElement arriving over JSON-RPC): the
+    // same request serialized to a plain JSON string.
+    JsonObject arg = requestJson("ASK {}", queryUrl, updateUrl);
+
+    ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg.toString())));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.ASK.name(), response.queryKind());
+  }
+
+  // ---- requests that parse as arguments but fail during execution --------------------------
+
+  @Test
+  public void executeCommandReturnsParseErrorResponseWhenTextIsNotValidSparql() throws Exception {
+    JsonObject arg = requestJson("this is not sparql at all", null, null);
+
+    ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.PARSE_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void executeCommandReturnsNoTargetResponseWhenTargetIsMissing() throws Exception {
+    JsonObject arg = requestJson("ASK {}", null, null);
+
+    ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  // ---- wire shape ----------------------------------------------------------------------------
+
+  /**
+   * Pins the JSON the VS Code client actually parses: lsp4j encodes the {@link ExecuteResponse}
+   * returned from {@code workspace/executeCommand} with its message Gson, so record component names
+   * become the JSON keys and enums serialize as their names. The TypeScript mirror of this contract
+   * lives in {@code cimnotebook/vscode/src/notebook/endpoint.ts}.
+   */
+  @Test
+  public void executeResponseSerializesToTheWireShapeTheClientParses() throws Exception {
+    Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
+
+    JsonObject success =
+        wireGson
+            .toJsonTree(
+                getResponse(
+                    handler.executeCommand(
+                        List.of(
+                            requestJson(
+                                "SELECT ?s WHERE { VALUES ?s { <http://example.org/x> } }",
+                                queryUrl,
+                                updateUrl)))))
+            .getAsJsonObject();
+    assertEquals("SUCCESS", success.get("status").getAsString());
+    assertEquals("SELECT", success.get("queryKind").getAsString());
+    assertFalse("gson must omit the null error field", success.has("error"));
+    JsonObject stats = success.getAsJsonObject("stats");
+    assertTrue(stats.get("durationMs").getAsLong() >= 0);
+    assertEquals(queryUrl, stats.get("resolvedTarget").getAsString());
+    JsonObject results =
+        JsonParser.parseString(success.get("resultsJson").getAsString()).getAsJsonObject();
+    JsonObject binding =
+        results
+            .getAsJsonObject("results")
+            .getAsJsonArray("bindings")
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonObject("s");
+    assertEquals("uri", binding.get("type").getAsString());
+    assertEquals("http://example.org/x", binding.get("value").getAsString());
+
+    JsonObject failure =
+        wireGson
+            .toJsonTree(
+                getResponse(handler.executeCommand(List.of(requestJson("not sparql", null, null)))))
+            .getAsJsonObject();
+    assertEquals("ERROR", failure.get("status").getAsString());
+    JsonObject error = failure.getAsJsonObject("error");
+    assertEquals("PARSE_ERROR", error.get("code").getAsString());
+    assertFalse(error.get("message").getAsString().isEmpty());
+    if (error.has("line")) {
+      assertTrue(error.get("line").getAsInt() >= 1);
+    }
+  }
+
+  // ---- shutdown ----------------------------------------------------------------------------
+
+  @Test
+  public void shutdownIsIdempotent() {
+    handler.shutdown();
+    handler.shutdown();
+    // tearDown() below calls shutdown() a third time; ExecutorService#shutdown() is documented to
+    // have no additional effect once already shut down, so repeated calls must not throw.
+  }
+
+  // ---- helpers ------------------------------------------------------------------------------
+
+  private static JsonObject requestJson(String text, String url, String updateUrl) {
+    JsonObject arg = new JsonObject();
+    arg.addProperty("cellUri", "file:///cell1.sparql");
+    arg.addProperty("languageId", "sparql");
+    arg.addProperty("text", text);
+    if (url != null) {
+      JsonObject target = new JsonObject();
+      target.addProperty("type", ExecuteTarget.TYPE_HTTP);
+      target.addProperty("url", url);
+      if (updateUrl != null) {
+        target.addProperty("updateUrl", updateUrl);
+      }
+      arg.add("target", target);
+    }
+    return arg;
+  }
+
+  private static ExecuteResponse getResponse(CompletableFuture<Object> future) throws Exception {
+    return (ExecuteResponse) future.get();
+  }
+
+  private static void assertInvalidParams(CompletableFuture<Object> future) {
+    try {
+      future.get();
+      fail("expected the future to fail with InvalidParams");
+    } catch (ExecutionException e) {
+      assertTrue(
+          "expected a ResponseErrorException, got " + e.getCause(),
+          e.getCause() instanceof ResponseErrorException);
+      ResponseErrorException rex = (ResponseErrorException) e.getCause();
+      assertEquals(ResponseErrorCode.InvalidParams.getValue(), rex.getResponseError().getCode());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      fail("interrupted while waiting for the future");
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -24,8 +24,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -162,6 +165,45 @@ public class NotebookCommandHandlerTest {
     assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
   }
 
+  // ---- local-file targets ----------------------------------------------------------------------
+
+  @Test
+  public void executeCommandRoutesFilesTargetToTheLocalExecutor() throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-handler");
+    try {
+      Files.writeString(
+          dir.resolve("data.ttl"), "<http://example.org/s> <http://example.org/p> \"v\" .");
+      JsonObject arg = filesRequestJson("ASK { ?s ?p ?o }", dir, "./data.ttl");
+
+      ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+      assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+      assertEquals(QueryKind.ASK.name(), response.queryKind());
+      assertEquals("./data.ttl", response.stats().resolvedTarget());
+    } finally {
+      try (var paths = Files.walk(dir)) {
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
+  @Test
+  public void executeCommandRejectsUpdatesAgainstFilesTargets() throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-handler");
+    try {
+      JsonObject arg =
+          filesRequestJson(
+              "INSERT DATA { <http://example.org/s> <http://example.org/p> 1 }", dir, "./data.ttl");
+
+      ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.UPDATE_NOT_ALLOWED.name(), response.error().code());
+    } finally {
+      Files.delete(dir);
+    }
+  }
+
   // ---- wire shape ----------------------------------------------------------------------------
 
   /**
@@ -228,6 +270,23 @@ public class NotebookCommandHandlerTest {
   }
 
   // ---- helpers ------------------------------------------------------------------------------
+
+  private static JsonObject filesRequestJson(String text, Path notebookDir, String... files) {
+    JsonObject arg = new JsonObject();
+    arg.addProperty("cellUri", "file:///cell1.sparql");
+    arg.addProperty("notebookUri", notebookDir.resolve("demo.cimnb.md").toUri().toString());
+    arg.addProperty("languageId", "sparql");
+    arg.addProperty("text", text);
+    JsonObject target = new JsonObject();
+    target.addProperty("type", ExecuteTarget.TYPE_FILES);
+    JsonArray fileArray = new JsonArray();
+    for (String file : files) {
+      fileArray.add(file);
+    }
+    target.add("files", fileArray);
+    arg.add("target", target);
+    return arg;
+  }
 
   private static JsonObject requestJson(String text, String url, String updateUrl) {
     JsonObject arg = new JsonObject();

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfigLoaderTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfigLoaderTest.java
@@ -1,0 +1,174 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises {@link NotebookConfigLoader}: the lenient JSONC parsing of the {@code "cimnotebook"}
+ * section (comments, trailing commas, the {@code "default"} keyword-named flag), git-style
+ * nearest-config discovery, and the deliberately forgiving failure modes.
+ */
+public class NotebookConfigLoaderTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private static final String CONFIG_JSONC =
+      """
+      {
+        // validator settings live in a sibling section and are irrelevant here
+        "cimvocabcheck": { "strictness": "strict" },
+        "cimnotebook": {
+          "queryTimeoutSeconds": 5,
+          "maxRows": 100,
+          "connections": [
+            {
+              "name": "local-fuseki",
+              "url": "http://localhost:3030/cgmes/query",
+              "updateUrl": "http://localhost:3030/cgmes/update",
+              "authType": "basic",
+              "default": true,
+            },
+            { "name": "prod", "url": "https://sparql.example.org/query" },
+          ],
+        },
+      }
+      """;
+
+  @Test
+  public void readsConnectionsTimeoutsAndTheDefaultFlag() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("opencgmes.jsonc"), CONFIG_JSONC);
+
+    NotebookConfigLoader.Located located = NotebookConfigLoader.forDirectory(dir);
+
+    assertEquals(dir.resolve("opencgmes.jsonc"), located.configPath());
+    NotebookConfig config = located.config();
+    assertEquals(Integer.valueOf(5), config.queryTimeoutSeconds());
+    assertEquals(Integer.valueOf(100), config.maxRows());
+    assertEquals(2, config.connections().size());
+
+    NotebookConnection fuseki = config.byName("local-fuseki");
+    assertEquals("http://localhost:3030/cgmes/query", fuseki.url());
+    assertEquals("http://localhost:3030/cgmes/update", fuseki.updateUrl());
+    assertNull(fuseki.shaclUrl());
+    assertEquals("basic", fuseki.authType());
+    assertTrue(fuseki.isDefault());
+    assertEquals(fuseki, config.defaultConnection());
+
+    NotebookConnection prod = config.byName("prod");
+    assertTrue(!prod.isDefault());
+    assertNull(config.byName("nope"));
+  }
+
+  @Test
+  public void discoveryWalksUpToTheNearestConfig() throws IOException {
+    Path root = tmp.getRoot().toPath();
+    Files.writeString(root.resolve("opencgmes.jsonc"), CONFIG_JSONC);
+    Path nested = Files.createDirectories(root.resolve("reports/2026"));
+
+    NotebookConfigLoader.Located located = NotebookConfigLoader.forDirectory(nested);
+
+    assertEquals(root.resolve("opencgmes.jsonc"), located.configPath());
+    assertEquals(2, located.config().connections().size());
+  }
+
+  @Test
+  public void missingSectionYieldsTheEmptyConfig() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("opencgmes.jsonc"), "{ \"cimvocabcheck\": {} }");
+
+    NotebookConfigLoader.Located located = NotebookConfigLoader.forDirectory(dir);
+
+    assertEquals(dir.resolve("opencgmes.jsonc"), located.configPath());
+    assertTrue(located.config().connections().isEmpty());
+    assertNull(located.config().queryTimeoutSeconds());
+    assertNull(located.config().defaultConnection());
+  }
+
+  @Test
+  public void missingConfigFileYieldsNone() {
+    NotebookConfigLoader.Located located =
+        NotebookConfigLoader.forDirectory(tmp.getRoot().toPath());
+
+    assertNull(located.configPath());
+    assertTrue(located.config().connections().isEmpty());
+  }
+
+  @Test
+  public void unparseableFileIsForgivinglyTreatedAsEmpty() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("opencgmes.jsonc"), "{ this is not json !!");
+
+    NotebookConfigLoader.Located located = NotebookConfigLoader.forDirectory(dir);
+
+    assertTrue(located.config().connections().isEmpty());
+  }
+
+  /**
+   * The parse is cached (it sits on the completion path), so an edit must still be seen. The mtime
+   * is set explicitly: two writes within the filesystem's timestamp granularity would otherwise be
+   * indistinguishable, which is a test-timing artefact rather than the behaviour under test.
+   */
+  @Test
+  public void anEditedConfigIsReParsedRatherThanServedFromTheCache() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Path configFile = dir.resolve("opencgmes.jsonc");
+    Files.writeString(configFile, CONFIG_JSONC);
+
+    assertEquals(2, NotebookConfigLoader.forDirectory(dir).config().connections().size());
+
+    Files.writeString(
+        configFile,
+        """
+        {
+          "cimnotebook": {
+            "connections": [{ "name": "only-one", "url": "http://localhost:3030/ds/query" }]
+          }
+        }
+        """);
+    Files.setLastModifiedTime(configFile, FileTime.fromMillis(System.currentTimeMillis() + 1_000));
+
+    NotebookConfig reloaded = NotebookConfigLoader.forDirectory(dir).config();
+    assertEquals(1, reloaded.connections().size());
+    assertEquals("only-one", reloaded.connections().get(0).name());
+  }
+
+  @Test
+  public void notebookUriResolvesViaTheNotebookDirectory() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("opencgmes.jsonc"), CONFIG_JSONC);
+    String notebookUri = dir.resolve("demo.cimnb.md").toUri().toString();
+
+    assertEquals(2, NotebookConfigLoader.forNotebook(notebookUri).config().connections().size());
+    assertTrue(NotebookConfigLoader.forNotebook(null).config().connections().isEmpty());
+    assertTrue(
+        NotebookConfigLoader.forNotebook("untitled:Untitled-1").config().connections().isEmpty());
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKindDetectorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKindDetectorTest.java
@@ -1,0 +1,104 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class QueryKindDetectorTest {
+
+  @Test
+  public void detectsSelect() {
+    var result = QueryKindDetector.detect("SELECT * WHERE { ?s ?p ?o }");
+    assertTrue(result instanceof QueryKindDetector.AsQuery);
+    var asQuery = (QueryKindDetector.AsQuery) result;
+    assertEquals(QueryKind.SELECT, asQuery.kind());
+  }
+
+  @Test
+  public void detectsAsk() {
+    var result = QueryKindDetector.detect("ASK { ?s ?p ?o }");
+    assertTrue(result instanceof QueryKindDetector.AsQuery);
+    assertEquals(QueryKind.ASK, ((QueryKindDetector.AsQuery) result).kind());
+  }
+
+  @Test
+  public void detectsConstruct() {
+    var result = QueryKindDetector.detect("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+    assertTrue(result instanceof QueryKindDetector.AsQuery);
+    assertEquals(QueryKind.CONSTRUCT, ((QueryKindDetector.AsQuery) result).kind());
+  }
+
+  @Test
+  public void detectsDescribe() {
+    var result = QueryKindDetector.detect("DESCRIBE <http://example.org/s>");
+    assertTrue(result instanceof QueryKindDetector.AsQuery);
+    assertEquals(QueryKind.DESCRIBE, ((QueryKindDetector.AsQuery) result).kind());
+  }
+
+  @Test
+  public void detectsInsertDataUpdate() {
+    var result =
+        QueryKindDetector.detect("INSERT DATA { <http://example.org/s> <http://example.org/p> 1 }");
+    assertTrue(result instanceof QueryKindDetector.AsUpdate);
+    assertNotNull(((QueryKindDetector.AsUpdate) result).update());
+  }
+
+  @Test
+  public void detectsDeleteWhereUpdate() {
+    var result = QueryKindDetector.detect("DELETE WHERE { ?s ?p ?o }");
+    assertTrue(result instanceof QueryKindDetector.AsUpdate);
+  }
+
+  @Test
+  public void reportsParseFailureWithPositionWhenTheParserProvidesOne() {
+    // An "expected token" parse error (as opposed to a lexical error, see below) carries a
+    // real 1-based line/column from Jena's parser.
+    var result = QueryKindDetector.detect("SELECT * WHERE { ?s ?p");
+    assertTrue(result instanceof QueryKindDetector.ParseFailure);
+    var failure = (QueryKindDetector.ParseFailure) result;
+    assertNotNull(failure.message());
+    assertEquals(Integer.valueOf(1), failure.line());
+    assertNotNull(failure.column());
+  }
+
+  @Test
+  public void reportsParseFailureWithoutPositionForLexicalErrors() {
+    // Jena reports some failures (e.g. a lexical error on completely non-SPARQL text) with
+    // line/column 0, which SparqlQueryAnalyzer normalizes to null rather than a misleading "0".
+    var result = QueryKindDetector.detect("this is not sparql at all");
+    assertTrue(result instanceof QueryKindDetector.ParseFailure);
+    var failure = (QueryKindDetector.ParseFailure) result;
+    assertNotNull(failure.message());
+    assertNull(failure.line());
+    assertNull(failure.column());
+  }
+
+  @Test
+  public void emptyTextParsesAsAnEmptySparqlUpdate() {
+    // A SPARQL Update request may contain zero operations, so blank/whitespace-only cell text
+    // is a valid (no-op) update rather than a parse failure.
+    var result = QueryKindDetector.detect("");
+    assertTrue(result instanceof QueryKindDetector.AsUpdate);
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ResultSerializerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ResultSerializerTest.java
@@ -1,0 +1,236 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.junit.Test;
+
+public class ResultSerializerTest {
+
+  private static final String EX = "http://example.org/";
+
+  @Test
+  public void selectToJsonSerializesEachTermKind() {
+    Model model = ModelFactory.createDefaultModel();
+    Resource s = model.createResource(EX + "s1");
+    Property p = model.createProperty(EX + "p");
+    s.addProperty(p, model.createResource(EX + "o1"));
+    s.addProperty(p, model.createResource());
+    s.addProperty(p, "plain");
+    s.addProperty(p, model.createLiteral("hello", "en"));
+    s.addProperty(p, model.createTypedLiteral("42", XSDDatatype.XSDinteger));
+
+    ResultSerializer.Serialized serialized;
+    try (QueryExecution qe =
+        QueryExecutionFactory.create(
+            "SELECT ?o WHERE { <" + EX + "s1> <" + EX + "p> ?o }", model)) {
+      serialized = ResultSerializer.selectToJson(qe.execSelect(), 100);
+    }
+
+    assertEquals(5, serialized.count());
+    assertFalse(serialized.truncated());
+
+    Set<String> descriptors = new HashSet<>();
+    for (JsonObject binding : bindings(serialized.payload())) {
+      JsonObject o = binding.getAsJsonObject("o");
+      String type = o.get("type").getAsString();
+      String value = o.get("value").getAsString();
+      String suffix =
+          o.has("xml:lang")
+              ? ";lang=" + o.get("xml:lang").getAsString()
+              : o.has("datatype") ? ";datatype=" + o.get("datatype").getAsString() : "";
+      descriptors.add(type + ":" + value + suffix);
+    }
+
+    assertEquals(5, descriptors.size());
+    assertTrue(descriptors.contains("uri:" + EX + "o1"));
+    assertTrue(descriptors.contains("literal:plain"));
+    assertTrue(descriptors.contains("literal:hello;lang=en"));
+    assertTrue(
+        descriptors.contains("literal:42;datatype=http://www.w3.org/2001/XMLSchema#integer"));
+    assertTrue(
+        "expected exactly one bnode term",
+        descriptors.stream().anyMatch(d -> d.startsWith("bnode:")));
+  }
+
+  @Test
+  public void selectToJsonOmitsDatatypeForPlainXsdString() {
+    Model model = ModelFactory.createDefaultModel();
+    Resource s = model.createResource(EX + "s1");
+    s.addProperty(
+        model.createProperty(EX + "p"),
+        model.createTypedLiteral("plain-typed", XSDDatatype.XSDstring));
+
+    ResultSerializer.Serialized serialized;
+    try (QueryExecution qe =
+        QueryExecutionFactory.create(
+            "SELECT ?o WHERE { <" + EX + "s1> <" + EX + "p> ?o }", model)) {
+      serialized = ResultSerializer.selectToJson(qe.execSelect(), 100);
+    }
+
+    JsonObject o = bindings(serialized.payload()).get(0).getAsJsonObject("o");
+    assertEquals("literal", o.get("type").getAsString());
+    assertFalse(
+        "xsd:string is the RDF 1.1 default and should not be emitted as an explicit datatype",
+        o.has("datatype"));
+  }
+
+  @Test
+  public void selectToJsonTruncatesAtMaxRows() {
+    Model model = ModelFactory.createDefaultModel();
+    Resource s = model.createResource(EX + "s1");
+    Property p = model.createProperty(EX + "p");
+    for (int i = 0; i < 5; i++) {
+      s.addProperty(p, model.createTypedLiteral(i));
+    }
+
+    ResultSerializer.Serialized serialized;
+    try (QueryExecution qe =
+        QueryExecutionFactory.create(
+            "SELECT ?o WHERE { <" + EX + "s1> <" + EX + "p> ?o }", model)) {
+      serialized = ResultSerializer.selectToJson(qe.execSelect(), 3);
+    }
+
+    assertEquals(3, serialized.count());
+    assertTrue(serialized.truncated());
+    assertEquals(3, bindings(serialized.payload()).size());
+  }
+
+  @Test
+  public void selectToJsonNotTruncatedWhenResultFitsExactlyAtMaxRows() {
+    Model model = ModelFactory.createDefaultModel();
+    Resource s = model.createResource(EX + "s1");
+    s.addProperty(model.createProperty(EX + "p"), model.createTypedLiteral(1));
+
+    ResultSerializer.Serialized serialized;
+    try (QueryExecution qe =
+        QueryExecutionFactory.create(
+            "SELECT ?o WHERE { <" + EX + "s1> <" + EX + "p> ?o }", model)) {
+      serialized = ResultSerializer.selectToJson(qe.execSelect(), 1);
+    }
+
+    assertEquals(1, serialized.count());
+    assertFalse(serialized.truncated());
+  }
+
+  @Test
+  public void askToJsonSerializesTrueAndFalse() {
+    JsonObject trueResult =
+        JsonParser.parseString(ResultSerializer.askToJson(true)).getAsJsonObject();
+    assertTrue(trueResult.get("boolean").getAsBoolean());
+
+    JsonObject falseResult =
+        JsonParser.parseString(ResultSerializer.askToJson(false)).getAsJsonObject();
+    assertFalse(falseResult.get("boolean").getAsBoolean());
+  }
+
+  @Test
+  public void constructToTurtleSerializesTriplesAsTurtle() {
+    List<Triple> triples =
+        List.of(
+            Triple.create(uri("s1"), uri("p"), uri("o1")),
+            Triple.create(uri("s1"), uri("p"), uri("o2")));
+
+    ResultSerializer.Serialized serialized =
+        ResultSerializer.constructToTurtle(triples.iterator(), 100);
+
+    assertEquals(2, serialized.count());
+    assertFalse(serialized.truncated());
+    // Parse the Turtle back to confirm it round-trips rather than asserting exact formatting.
+    Model roundTripped = ModelFactory.createDefaultModel();
+    roundTripped.read(new java.io.StringReader(serialized.payload()), null, "TURTLE");
+    assertEquals(2, roundTripped.size());
+  }
+
+  @Test
+  public void constructToTurtleTruncatesAtMaxTriplesWithoutConsumingWholeIterator() {
+    List<Triple> triples = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      triples.add(Triple.create(uri("s1"), uri("p"), uri("o" + i)));
+    }
+    // A spy iterator that counts how many elements are actually pulled via next(), to confirm
+    // the truncation cap stops before draining the whole (potentially oversized/streaming)
+    // source — checking truncation via a plain hasNext() call does not itself pull an element.
+    CountingIterator<Triple> counting = new CountingIterator<>(triples.iterator());
+
+    ResultSerializer.Serialized serialized = ResultSerializer.constructToTurtle(counting, 2);
+
+    assertEquals(2, serialized.count());
+    assertTrue(serialized.truncated());
+    assertEquals(2, counting.pulled);
+  }
+
+  private static Node uri(String localName) {
+    return NodeFactory.createURI(EX + localName);
+  }
+
+  private static List<JsonObject> bindings(String resultsJson) {
+    JsonObject root = JsonParser.parseString(resultsJson).getAsJsonObject();
+    JsonArray bindings = root.getAsJsonObject("results").getAsJsonArray("bindings");
+    List<JsonObject> out = new ArrayList<>();
+    for (JsonElement e : bindings) {
+      out.add(e.getAsJsonObject());
+    }
+    return out;
+  }
+
+  /** Wraps an iterator to count how many elements {@link #next()} actually returns. */
+  private static final class CountingIterator<T> implements Iterator<T> {
+    private final Iterator<T> delegate;
+    private int pulled;
+
+    CountingIterator(Iterator<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return delegate.hasNext();
+    }
+
+    @Override
+    public T next() {
+      T value = delegate.next();
+      pulled++;
+      return value;
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutorTest.java
@@ -327,14 +327,14 @@ public class ShaclExecutorTest {
 
   private ExecuteResponse executeLocal(String shapes, String... files) {
     ExecuteTarget target =
-        new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files));
+        new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files), null);
     return ShaclExecutor.execute(request(shapes, target), stores, ctx(NEVER_CANCELLED));
   }
 
   private ExecuteResponse executeRemote(String shapes, String shaclServiceUrl) {
     ExecuteTarget target =
         new ExecuteTarget(
-            ExecuteTarget.TYPE_HTTP, fuseki.serverURL() + "ds", null, shaclServiceUrl, null);
+            ExecuteTarget.TYPE_HTTP, fuseki.serverURL() + "ds", null, shaclServiceUrl, null, null);
     return ShaclExecutor.execute(request(shapes, target), stores, ctx(NEVER_CANCELLED));
   }
 

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutorTest.java
@@ -1,0 +1,378 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.server.Operation;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.system.Txn;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises {@link ShaclExecutor} (and, through it, {@link HttpShaclClient}): local jena-shacl
+ * validation over file targets, remote validation against a real in-process Fuseki SHACL operation,
+ * shapes parsing failures, and the timeout/cancellation behavior of the racing variant that
+ * in-process validation relies on.
+ */
+public class ShaclExecutorTest {
+
+  private static final String EX = "http://example.org/";
+
+  private static final String SHAPES_NAME_REQUIRED =
+      """
+      PREFIX sh: <http://www.w3.org/ns/shacl#>
+      PREFIX ex: <http://example.org/>
+      ex:PersonShape a sh:NodeShape ;
+        sh:targetClass ex:Person ;
+        sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+      """;
+
+  private static final String DATA_CONFORMING =
+      """
+      PREFIX ex: <http://example.org/>
+      ex:alice a ex:Person ; ex:name "Alice" .
+      """;
+
+  private static final String DATA_VIOLATING =
+      """
+      PREFIX ex: <http://example.org/>
+      ex:bob a ex:Person .
+      """;
+
+  private static final CancelChecker NEVER_CANCELLED =
+      new CancelChecker() {
+        @Override
+        public void checkCanceled() {}
+
+        @Override
+        public boolean isCanceled() {
+          return false;
+        }
+      };
+
+  private static FusekiServer fuseki;
+  private static String shaclUrl;
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private ExecutorService executionPool;
+  private ScheduledExecutorService watchdogScheduler;
+  private LocalStoreManager stores;
+
+  @BeforeClass
+  public static void startFuseki() {
+    DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
+    Txn.executeWrite(
+        dsg,
+        () ->
+            dsg.getDefaultGraph()
+                .add(
+                    Triple.create(
+                        NodeFactory.createURI(EX + "bob"),
+                        NodeFactory.createURI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                        NodeFactory.createURI(EX + "Person"))));
+    fuseki =
+        FusekiServer.create()
+            .port(0)
+            .add("/ds", dsg)
+            .addEndpoint("/ds", "shacl", Operation.Shacl)
+            .build()
+            .start();
+    // Fuseki's SHACL operation requires the graph selector; "default" = the default graph. The
+    // TS client's deriveShaclUrl appends exactly this when the directive has no query string.
+    shaclUrl = fuseki.serverURL() + "ds/shacl?graph=default";
+  }
+
+  @AfterClass
+  public static void stopFuseki() {
+    fuseki.stop();
+  }
+
+  @Before
+  public void setUp() {
+    executionPool = Executors.newCachedThreadPool();
+    watchdogScheduler = Executors.newSingleThreadScheduledExecutor();
+    stores = new LocalStoreManager();
+  }
+
+  @After
+  public void tearDown() {
+    executionPool.shutdownNow();
+    watchdogScheduler.shutdownNow();
+  }
+
+  // ---- local validation --------------------------------------------------------------------
+
+  @Test
+  public void conformingDataReportsConforms() throws IOException {
+    Path data = dataFile("data.ttl", DATA_CONFORMING);
+
+    ExecuteResponse response = executeLocal(SHAPES_NAME_REQUIRED, data.toString());
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.SHACL.name(), response.queryKind());
+    ShaclSummary summary = response.shaclSummary();
+    assertNotNull(summary);
+    assertTrue(summary.conforms());
+    assertEquals(0, summary.violations());
+    assertTrue("the report itself travels as turtle", response.turtle().contains("conforms"));
+    assertEquals(data.toString(), response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void violationsAreCountedBySeverity() throws IOException {
+    Path data = dataFile("data.ttl", DATA_VIOLATING);
+    String shapes =
+        """
+        PREFIX sh: <http://www.w3.org/ns/shacl#>
+        PREFIX ex: <http://example.org/>
+        ex:NameShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+        ex:AgeShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:path ex:age ; sh:minCount 1 ; sh:severity sh:Warning ] .
+        """;
+
+    ExecuteResponse response = executeLocal(shapes, data.toString());
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    ShaclSummary summary = response.shaclSummary();
+    assertFalse(summary.conforms());
+    assertEquals(1, summary.violations());
+    assertEquals(1, summary.warnings());
+    assertEquals(0, summary.infos());
+    assertEquals(Integer.valueOf(2), response.stats().rowCount());
+    assertTrue(response.turtle().contains("ValidationResult"));
+  }
+
+  @Test
+  public void validationSpansTheUnionOfAllTargetFiles() throws IOException {
+    Path good = dataFile("good.ttl", DATA_CONFORMING);
+    Path bad = dataFile("bad.ttl", DATA_VIOLATING);
+
+    ExecuteResponse response = executeLocal(SHAPES_NAME_REQUIRED, good.toString(), bad.toString());
+
+    ShaclSummary summary = response.shaclSummary();
+    assertFalse("the violating file must be seen through the union", summary.conforms());
+    assertEquals(1, summary.violations());
+  }
+
+  @Test
+  public void invalidTurtleShapesReportParseErrorWithPosition() throws IOException {
+    Path data = dataFile("data.ttl", DATA_CONFORMING);
+
+    ExecuteResponse response = executeLocal("this is not turtle @@@", data.toString());
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.PARSE_ERROR.name(), response.error().code());
+    assertNotNull("riot reports a line for syntax errors", response.error().line());
+  }
+
+  @Test
+  public void wellFormedTurtleButBrokenShapesReportParseError() throws IOException {
+    Path data = dataFile("data.ttl", DATA_CONFORMING);
+    // Valid Turtle, invalid SHACL: a property shape without sh:path.
+    String shapes =
+        """
+        PREFIX sh: <http://www.w3.org/ns/shacl#>
+        PREFIX ex: <http://example.org/>
+        ex:Broken a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:minCount 1 ] .
+        """;
+
+    ExecuteResponse response = executeLocal(shapes, data.toString());
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.PARSE_ERROR.name(), response.error().code());
+    assertTrue(response.error().message().contains("SHACL"));
+  }
+
+  @Test
+  public void missingDataFileReportsFileNotFound() {
+    ExecuteResponse response =
+        executeLocal(SHAPES_NAME_REQUIRED, tmp.getRoot().toPath().resolve("nope.ttl").toString());
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.name(), response.error().code());
+  }
+
+  @Test
+  public void missingTargetReportsNoTarget() {
+    ExecuteResponse response =
+        ShaclExecutor.execute(request(SHAPES_NAME_REQUIRED, null), stores, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  // ---- timeout / cancellation of the racing variant used for in-process validation ----------
+
+  @Test
+  public void timeoutOverloadResolvesToTimeoutWhileWorkIsStillRunning() {
+    ExecuteResponse response =
+        ExecSupport.runCancellable(
+            ctx(NEVER_CANCELLED), () -> {}, ShaclExecutorTest::sleepForever, 100);
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.TIMEOUT.name(), response.error().code());
+  }
+
+  @Test
+  public void cancellationWinsOverBlockedWork() {
+    long start = System.nanoTime();
+    ExecuteResponse response =
+        ExecSupport.runCancellable(
+            ctx(cancelAfter(200)), () -> {}, ShaclExecutorTest::sleepForever, 30_000);
+    long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+    assertEquals(ExecutionStatus.CANCELLED.name(), response.status());
+    assertTrue(
+        "expected cancellation to resolve quickly, took " + elapsedMs + "ms", elapsedMs < 10_000);
+  }
+
+  // ---- remote validation (real Fuseki SHACL operation) --------------------------------------
+
+  @Test
+  public void remoteValidationReportsViolationsFromTheService() {
+    ExecuteResponse response = executeRemote(SHAPES_NAME_REQUIRED, shaclUrl);
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.SHACL.name(), response.queryKind());
+    ShaclSummary summary = response.shaclSummary();
+    assertNotNull(summary);
+    assertFalse("bob has no name, the service must report it", summary.conforms());
+    assertTrue(summary.violations() >= 1);
+    assertTrue(response.turtle().contains("ValidationResult"));
+    assertEquals(shaclUrl, response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void remoteValidationCanConform() {
+    // Shapes that the server's data satisfies: bob is typed, nothing more required.
+    String shapes =
+        """
+        PREFIX sh: <http://www.w3.org/ns/shacl#>
+        PREFIX ex: <http://example.org/>
+        ex:TypedShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:path <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ;
+                        sh:minCount 1 ] .
+        """;
+
+    ExecuteResponse response = executeRemote(shapes, shaclUrl);
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertTrue(response.shaclSummary().conforms());
+  }
+
+  @Test
+  public void remoteErrorsSurfaceAsHttpError() {
+    ExecuteResponse response = executeRemote(SHAPES_NAME_REQUIRED, fuseki.serverURL() + "ds/query");
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.HTTP_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void httpTargetWithoutShaclServiceReportsNoTarget() {
+    ExecuteResponse response = executeRemote(SHAPES_NAME_REQUIRED, null);
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+    assertTrue(response.error().message().contains("SHACL"));
+  }
+
+  // ---- helpers -------------------------------------------------------------------------------
+
+  private ExecuteResponse executeLocal(String shapes, String... files) {
+    ExecuteTarget target =
+        new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files));
+    return ShaclExecutor.execute(request(shapes, target), stores, ctx(NEVER_CANCELLED));
+  }
+
+  private ExecuteResponse executeRemote(String shapes, String shaclServiceUrl) {
+    ExecuteTarget target =
+        new ExecuteTarget(
+            ExecuteTarget.TYPE_HTTP, fuseki.serverURL() + "ds", null, shaclServiceUrl, null);
+    return ShaclExecutor.execute(request(shapes, target), stores, ctx(NEVER_CANCELLED));
+  }
+
+  private static ExecuteRequest request(String shapes, ExecuteTarget target) {
+    return new ExecuteRequest("file:///cell1.shacl", null, "shacl", shapes, target, null);
+  }
+
+  private ExecContext ctx(CancelChecker checker) {
+    return new ExecContext(executionPool, watchdogScheduler, checker);
+  }
+
+  private Path dataFile(String name, String content) throws IOException {
+    Path file = tmp.getRoot().toPath().resolve(name);
+    Files.writeString(file, content);
+    return file;
+  }
+
+  private static ExecuteResponse sleepForever() {
+    try {
+      Thread.sleep(60_000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    return ExecuteResponse.failed(
+        new ExecError(ErrorCode.INTERNAL, "work was not interrupted", null, null, null));
+  }
+
+  /** A {@link CancelChecker} that reports cancelled once {@code delayMs} has elapsed. */
+  private static CancelChecker cancelAfter(long delayMs) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayMs);
+    return new CancelChecker() {
+      @Override
+      public void checkCanceled() {}
+
+      @Override
+      public boolean isCanceled() {
+        return System.nanoTime() >= deadlineNanos;
+      }
+    };
+  }
+}

--- a/cimvocabcheck/sbom/maven/THIRD-PARTY.txt
+++ b/cimvocabcheck/sbom/maven/THIRD-PARTY.txt
@@ -1,5 +1,5 @@
 
-Lists of 38 third-party dependencies.
+Lists of 39 third-party dependencies.
      (Apache-2.0) aalto-xml (com.fasterxml:aalto-xml:1.4.0 - https://github.com/FasterXML/aalto-xml)
      (Apache-2.0) Apache Commons Codec (commons-codec:commons-codec:1.22.0 - https://commons.apache.org/proper/commons-codec/)
      (Apache-2.0) Apache Commons Collections (org.apache.commons:commons-collections4:4.5.0 - https://commons.apache.org/proper/commons-collections/)
@@ -12,6 +12,7 @@ Lists of 38 third-party dependencies.
      (Apache-2.0) Apache Jena - Core (org.apache.jena:jena-core:6.1.0 - https://jena.apache.org/jena-core/)
      (Apache-2.0) Apache Jena - IRI3986 (org.apache.jena:jena-iri3986:6.1.0 - https://jena.apache.org/jena-iri3986/)
      (Apache-2.0) Apache Jena - Language tags (org.apache.jena:jena-langtag:6.1.0 - https://jena.apache.org/jena-langtag/)
+     (Apache-2.0) Apache Jena - SHACL (org.apache.jena:jena-shacl:6.1.0 - https://jena.apache.org/jena-shacl/)
      (Apache-2.0) Apache Log4j API (org.apache.logging.log4j:log4j-api:2.26.1 - https://logging.apache.org/log4j/2.x/)
      (Apache-2.0) Apache Log4j Core (org.apache.logging.log4j:log4j-core:2.26.1 - https://logging.apache.org/log4j/2.x/)
      (Apache-2.0) Apache Thrift (org.apache.thrift:libthrift:0.22.0 - https://thrift.apache.org/)

--- a/cimvocabcheck/sbom/maven/bom.json
+++ b/cimvocabcheck/sbom/maven/bom.json
@@ -2028,6 +2028,80 @@
     },
     {
       "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.jena/jena-shacl@6.1.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.jena",
+      "name" : "jena-shacl",
+      "version" : "6.1.0",
+      "description" : "SHACL engine for Apache Jena",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c778b89c251c4d59c6bb865266a8d9f6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9bf215ed23b30b88347ac5be5310e788c5bc1c11"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d03e61141624b45ea601c4bf10dc65f9b17c9637cbf534425e88edecb74c2f9b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4e6555f12f70228c91c021f3c171186db2518fad8cfb8f18f432bf9e2367a00be71bdf271c75944626c74652378699180f02ce7570748786a89bcacec6ee4286"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "77794195c9fb924148de4f3c071d4ecf78d8122ae1101f82c90a1b39fbd414a4a0830342dcdf5b23c6538fa8770791f7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a4927c736b08530f55ac404d43be0b54ae4eae0402c752bcc937336335ec40bd129f80549eaa9919062c845cd5a8bb0d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "700fe5f3c34fac7366970019430c2ccde2e694e9d153092d73b4d0d942d1275a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5066c8012f6be15f8927ea85f3d3db3dc68f461f95e1acdd3e9c4b0c03dc5d3012b1d15dd50394d8e416e6ee1b82d5f77a291d54e1468838221e0b381b7344cf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.jena/jena-shacl@6.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://jena.apache.org/jena-shacl/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/JENA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?users@jena.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/jena.git/jena-shacl"
+        }
+      ]
+    },
+    {
+      "type" : "library",
       "bom-ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.26.1?type=jar",
       "publisher" : "The Apache Software Foundation",
       "group" : "org.apache.logging.log4j",
@@ -3012,6 +3086,7 @@
       "dependsOn" : [
         "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.22.1?type=jar",
         "pkg:maven/de.soptim.opencgmes/cimvocabcheck-core@0.0.0-SNAPSHOT?type=jar",
+        "pkg:maven/org.apache.jena/jena-shacl@6.1.0?type=jar",
         "pkg:maven/org.apache.logging.log4j/log4j-core@2.26.1?type=jar",
         "pkg:maven/org.apache.logging.log4j/log4j-slf4j2-impl@2.26.1?type=jar",
         "pkg:maven/org.eclipse.lsp4j/org.eclipse.lsp4j@1.0.0?type=jar",
@@ -3108,6 +3183,12 @@
     {
       "ref" : "pkg:maven/org.apache.jena/jena-langtag@6.1.0?type=jar",
       "dependsOn" : []
+    },
+    {
+      "ref" : "pkg:maven/org.apache.jena/jena-shacl@6.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.jena/jena-arq@6.1.0?type=jar"
+      ]
     },
     {
       "ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.26.1?type=jar",

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 # CIM Notebooks
 
 CIM Notebooks are CIMNotebook's own notebook documents for VS Code: markdown files whose
-```` ```sparql ```` and ```` ```shacl ```` code blocks open as notebook cells. Because the
+` ```sparql ` and ` ```shacl ` code blocks open as notebook cells. Because the
 on-disk format **is** plain markdown, notebooks diff and merge cleanly in git, render on any
 git forge, and need no special tooling to read.
 
@@ -30,13 +30,13 @@ reads and writes Zazuko's `.sparqlbook` format for interoperability.
 
 ## File formats
 
-| Format | Opens as notebook | Notes |
-| --- | --- | --- |
-| `*.cimnb.md` | by default | The native format. A regular markdown file — the suffix just tells VS Code to open it as a notebook. |
-| any `*.md` / `*.markdown` | via **Open With… → CIM Notebook (Markdown)** | Turn any markdown document (a README, a runbook) into a notebook without renaming it. |
-| `*.sparqlbook` | via **Open With… → CIM Notebook (SPARQL Book)** | Zazuko SPARQL Notebook interop (JSON). |
+| Format                    | Opens as notebook                               | Notes                                                                                                |
+| ------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `*.cimnb.md`              | by default                                      | The native format. A regular markdown file — the suffix just tells VS Code to open it as a notebook. |
+| any `*.md` / `*.markdown` | via **Open With… → CIM Notebook (Markdown)**    | Turn any markdown document (a README, a runbook) into a notebook without renaming it.                |
+| `*.sparqlbook`            | via **Open With… → CIM Notebook (SPARQL Book)** | Zazuko SPARQL Notebook interop (JSON).                                                               |
 
-To use **Open With…**: right-click the file in the Explorer → *Open With…* → pick the CIM
+To use **Open With…**: right-click the file in the Explorer → _Open With…_ → pick the CIM
 Notebook editor. VS Code remembers the choice per file type if you set it as default.
 
 ## The markdown format
@@ -78,18 +78,24 @@ back) and opens it. The source file is never modified. Zazuko per-cell metadata 
 
 ## Running cells
 
-SPARQL cells have a **Run** button (the *CIM Notebook* kernel). Execution happens inside
+SPARQL cells have a **Run** button (the _CIM Notebook_ kernel). Execution happens inside
 CIMLangServer — the same Java process that validates your queries — using Apache Jena's
 SPARQL 1.1 engine, so there is nothing extra to install.
 
 A cell names its target with the same `# [endpoint=...]` directive used for validation —
-one directive drives both *validate against* and *run against*:
+one directive drives both _validate against_ and _run against_. The target can be a SPARQL
+endpoint or local data files:
 
 ```sparql
 # [endpoint=http://localhost:3030/cgmes/query]
 SELECT ?class (COUNT(?s) AS ?n)
 WHERE { ?s a ?class }
 GROUP BY ?class ORDER BY DESC(?n)
+```
+
+```sparql
+# [endpoint=./model.xml]
+SELECT ?name WHERE { ?s cim:IdentifiedObject.name ?name }
 ```
 
 What you get per query kind:
@@ -115,10 +121,36 @@ assumed to accept updates directly.
 stops waiting and aborts the query where the endpoint supports it). Requests time out
 after 30 seconds by default.
 
+### Querying local files — including CIMXML models
+
+When a directive is not an `http(s)://` URL it is taken as a file path, relative to the
+notebook's own directory. The file is parsed in-process and queried directly — no triple
+store, no import step:
+
+- **CIMXML models** (`*.xml`): parsed by OpenCGMES's IEC 61970-552 parser. The model body
+  and its `md:FullModel` header are both queryable.
+- **RDF files**: anything Jena reads by extension — `.ttl`, `.rdf`, `.owl`, `.nt`, `.nq`,
+  `.trig`, ….
+
+Several directives in one cell query the **union** of the files: named graphs stay
+addressable with `GRAPH`, and a bare `?s ?p ?o` sees everything.
+
+```sparql
+# [endpoint=./model.xml]
+# [endpoint=./boundary.ttl]
+SELECT (COUNT(*) AS ?triples) WHERE { ?s ?p ?o }
+```
+
+Parsed files are cached in the language server and re-parsed automatically when the file
+changes on disk, so _edit model → re-run cell_ just works. Local files are **read-only**:
+a SPARQL Update against a file target is rejected — updates need an HTTP endpoint.
+
+Note the dual meaning of the directive: for _validation_, a `.ttl`/`.rdf`/`.owl` file is
+loaded as the schema, while instance-data files (`.xml` models, `.nt`/`.nq`/`.trig` dumps)
+keep the workspace schema so diagnostics stay meaningful — and either way the file is what
+the cell _runs_ against.
+
 **Current limitations:**
 
-- Only `http(s)://` endpoints can be executed. A directive pointing at a local file is
-  still used for *validation*, but running such a cell reports it as unsupported —
-  querying local RDF and CIMXML files is planned next.
-- SHACL cells are validated statically but cannot be *run* yet.
-- No authentication support yet — the endpoint must be reachable without credentials.
+- SHACL cells are validated statically but cannot be _run_ yet.
+- No authentication support yet — HTTP endpoints must be reachable without credentials.

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -146,6 +146,11 @@ Parsed files are cached in the language server and re-parsed automatically when 
 changes on disk, so _edit model → re-run cell_ just works. Local files are **read-only**:
 a SPARQL Update against a file target is rejected — updates need an HTTP endpoint.
 
+Multiple **file** directives are the only repetition that means something. A cell runs
+against exactly one endpoint, so mixing kinds (a file and a URL, a file and a connection
+name) or repeating a URL or a connection name is reported as an error rather than
+silently resolved to one of them — remove the directives you didn't mean.
+
 Note the dual meaning of the directive: for _validation_, a `.ttl`/`.rdf`/`.owl` file is
 loaded as the schema, while instance-data files (`.xml` models, `.nt`/`.nq`/`.trig` dumps)
 keep the workspace schema so diagnostics stay meaningful — and either way the file is what
@@ -177,6 +182,82 @@ The output is a ✅ conforms / ❌ does-not-conform banner with counts per sever
 run that finds violations is still a _successful_ run — non-conformance is the result,
 not an error.
 
+### Named connections
+
+Endpoints you use often can be declared once in `opencgmes.jsonc` (the same file that
+configures validation) under a `cimnotebook` section, and referenced by name:
+
+```jsonc
+{
+  "cimnotebook": {
+    "connections": [
+      {
+        "name": "local-fuseki",
+        "url": "http://localhost:3030/cgmes/query",
+        "default": true,
+      },
+      {
+        "name": "prod",
+        "url": "https://sparql.example.org/query",
+        "authType": "basic",
+      },
+    ],
+    "queryTimeoutSeconds": 30, // workspace default for cell executions
+    "maxRows": 10000, // workspace default result cap
+  },
+}
+```
+
+```sparql
+# [endpoint=local-fuseki]
+SELECT * WHERE { ?s ?p ?o } LIMIT 10
+```
+
+A connection name has no slashes and no dots — that's how it is told apart from a file
+path. `updateUrl`/`shaclUrl` are optional and derived from `url` when omitted.
+
+Every cell shows its resolved target in the **cell status bar** (`local-fuseki`, a URL,
+`model.xml (+1)`, or a _no endpoint_ warning); clicking it — or running **CIMNotebook:
+Set Cell Endpoint…** — picks a connection, URL, or file and either writes the
+`# [endpoint=…]` directive into the cell (the portable, versioned form) or remembers it
+as the notebook's default without touching the file.
+
+### Where a cell without a directive runs
+
+A cell with no `# [endpoint=...]` line of its own is not stranded — the target is resolved
+in three steps, and the first one that answers wins:
+
+1. **The cell's own directive.**
+2. **The notebook default.** *Set Cell Endpoint…* offers to apply a single connection, URL,
+   or file as the **Notebook default** instead of writing it into the cell. It is remembered
+   in VS Code's **workspace state** — deliberately not in the notebook file and not in
+   `opencgmes.jsonc` — so it is a private, per-workspace convenience: a notebook shared with
+   a colleague carries only its directives. The picker shows the current default in its title
+   and offers **Clear the notebook default** while one is set.
+3. **The default connection.** The `opencgmes.jsonc` connection marked `"default": true`.
+
+Validation follows the same three steps, so a cell is always validated against the endpoint
+it runs against: schema-based diagnostics, completion, hover, and go-to-definition all use
+the schema of the resolved target (a `.ttl`/`.rdf`/`.owl` file or the endpoint's schema
+graphs). A target that carries no schema — a CIMXML model, an `.nt` dump — keeps the
+workspace schema from `opencgmes.jsonc` instead, since instance data would only produce
+false diagnostics.
+
+### Credentials
+
+Connections with `"authType": "basic"` prompt once for username and password on first
+run and offer to keep them in **VS Code secret storage** (the OS keychain). Passwords are
+**never** written to `opencgmes.jsonc`, VS Code settings, or the notebook — they travel
+only inside the execute request to the local language server, which turns them into the
+HTTP `Authorization` header. Manage them with **CIMNotebook: Set Connection
+Credentials…** and **Clear Connection Credentials…**.
+
+:::caution Verbose tracing logs requests
+The `CIMNotebook (trace)` output channel (LSP trace, off by default) logs full request
+payloads — including credentials of an execute request. Leave tracing off when working
+with authenticated endpoints, or clear the channel afterwards.
+:::
+
 **Current limitations:**
 
-- No authentication support yet — HTTP endpoints must be reachable without credentials.
+- Only HTTP basic authentication is supported.

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -78,7 +78,47 @@ back) and opens it. The source file is never modified. Zazuko per-cell metadata 
 
 ## Running cells
 
-Cell execution (running SPARQL queries and SHACL validation against endpoints or local
-files) ships in an upcoming CIMNotebook release; today CIM Notebooks are an authoring and
-validation surface. To *run* `.sparqlbook` notebooks you can meanwhile keep using the Zazuko
-SPARQL Notebook extension side by side — CIMNotebook validates its cells too.
+SPARQL cells have a **Run** button (the *CIM Notebook* kernel). Execution happens inside
+CIMLangServer — the same Java process that validates your queries — using Apache Jena's
+SPARQL 1.1 engine, so there is nothing extra to install.
+
+A cell names its target with the same `# [endpoint=...]` directive used for validation —
+one directive drives both *validate against* and *run against*:
+
+```sparql
+# [endpoint=http://localhost:3030/cgmes/query]
+SELECT ?class (COUNT(?s) AS ?n)
+WHERE { ?s a ?class }
+GROUP BY ?class ORDER BY DESC(?n)
+```
+
+What you get per query kind:
+
+| Query                               | Output                                                                                                                    |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `SELECT`                            | Result table (first 50 rows rendered; the full result travels alongside as `application/sparql-results+json`) |
+| `ASK`                               | ✅ **true** / ❌ **false**                                                                                                |
+| `CONSTRUCT` / `DESCRIBE`            | The result graph as Turtle                                                                                                |
+| `INSERT` / `DELETE` / other updates | A confirmation with the update endpoint used                                                                              |
+
+Each output ends with a small stats line — row count, duration, and the resolved endpoint.
+Results are capped server-side (10 000 rows/triples by default) and the output says so when
+the cap was hit. The raw payload of a result is one click away: the output's **⋯ → Change
+Presentation** menu switches between the rendered view and the plain-text payload (the
+SPARQL Results JSON, or the Turtle of a graph/report).
+
+**Updates** run against the endpoint's update service: for Fuseki-style URLs the client
+derives it from the query URL (`…/query` or `…/sparql` → `…/update`); any other URL is
+assumed to accept updates directly.
+
+**Cancel and timeout.** The notebook Stop button cancels the running request (the server
+stops waiting and aborts the query where the endpoint supports it). Requests time out
+after 30 seconds by default.
+
+**Current limitations:**
+
+- Only `http(s)://` endpoints can be executed. A directive pointing at a local file is
+  still used for *validation*, but running such a cell reports it as unsupported —
+  querying local RDF and CIMXML files is planned next.
+- SHACL cells are validated statically but cannot be *run* yet.
+- No authentication support yet — the endpoint must be reachable without credentials.

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -142,6 +142,22 @@ addressable with `GRAPH`, and a bare `?s ?p ?o` sees everything.
 SELECT (COUNT(*) AS ?triples) WHERE { ?s ?p ?o }
 ```
 
+A directive can also be a **glob pattern** — `*` matches within a directory, `**` crosses
+directories, and `{a,b}` picks alternatives, just like the SPARQL Notebook extension:
+
+```sparql
+# [endpoint=./rdf/*.ttl]
+SELECT (COUNT(*) AS ?triples) WHERE { ?s ?p ?o }
+```
+
+```sparql
+# [endpoint=./rdf/{a,b}.ttl]
+SELECT (COUNT(*) AS ?triples) WHERE { ?s ?p ?o }
+```
+
+A pattern that matches no files fails the run with an error (it won't silently query
+nothing); a file matched by several directives is read once.
+
 Parsed files are cached in the language server and re-parsed automatically when the file
 changes on disk, so _edit model → re-run cell_ just works. Local files are **read-only**:
 a SPARQL Update against a file target is rejected — updates need an HTTP endpoint.
@@ -151,10 +167,12 @@ against exactly one endpoint, so mixing kinds (a file and a URL, a file and a co
 name) or repeating a URL or a connection name is reported as an error rather than
 silently resolved to one of them — remove the directives you didn't mean.
 
-Note the dual meaning of the directive: for _validation_, a `.ttl`/`.rdf`/`.owl` file is
-loaded as the schema, while instance-data files (`.xml` models, `.nt`/`.nq`/`.trig` dumps)
-keep the workspace schema so diagnostics stay meaningful — and either way the file is what
-the cell _runs_ against.
+Note the dual meaning of the directive: for _validation_, the `.ttl`/`.rdf`/`.owl` files
+are loaded as the schema (several files or a pattern's matches form one union schema),
+while instance-data files (`.xml` models, `.nt`/`.nq`/`.trig` dumps) keep the workspace
+schema so diagnostics stay meaningful — and either way the files are what the cell _runs_
+against. So `# [endpoint=./model.xml]` + `# [endpoint=./schema.ttl]` queries both files
+while validating the query against `schema.ttl`.
 
 ### Running SHACL cells
 

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -215,12 +215,18 @@ SELECT * WHERE { ?s ?p ?o } LIMIT 10
 
 A connection name has no slashes and no dots — that's how it is told apart from a file
 path. `updateUrl`/`shaclUrl` are optional and derived from `url` when omitted.
+Connections (and the rest of the config) can also be edited in the **CIMNotebook
+sidebar** — see [Configuration sidebar](/cimnotebook/vscode#configuration-sidebar).
 
 Every cell shows its resolved target in the **cell status bar** (`local-fuseki`, a URL,
 `model.xml (+1)`, or a _no endpoint_ warning); clicking it — or running **CIMNotebook:
-Set Cell Endpoint…** — picks a connection, URL, or file and either writes the
-`# [endpoint=…]` directive into the cell (the portable, versioned form) or remembers it
-as the notebook's default without touching the file.
+Set Cell Endpoint…** — picks a connection, a URL (with a small recent-URLs history above
+the input box), or one or more data files via fuzzy, search-as-you-type matching over the
+workspace (with **Browse…** for files outside it and **Enter path manually…** for a file
+that doesn't exist yet). Picking several files writes one `# [endpoint=...]` directive
+per file — the same union target described above. One constraint inherited from the
+directive syntax: a path containing spaces cannot be referenced (the directive value ends
+at the first whitespace character).
 
 ### Where a cell without a directive runs
 

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -24,7 +24,8 @@ CIM Notebooks are a VS Code feature. The [IntelliJ plugin](/cimnotebook/intellij
 :::info Attribution
 The notebook feature is inspired by the
 [SPARQL Notebook](https://marketplace.visualstudio.com/items?itemName=Zazuko.sparql-notebook)
-extension by Zazuko (MIT-licensed) — CIM Notebooks are an independent implementation.
+extension by Zazuko (MIT-licensed) — CIM Notebooks are an independent implementation that
+reads and writes Zazuko's `.sparqlbook` format for interoperability.
 :::
 
 ## File formats
@@ -33,6 +34,7 @@ extension by Zazuko (MIT-licensed) — CIM Notebooks are an independent implemen
 | --- | --- | --- |
 | `*.cimnb.md` | by default | The native format. A regular markdown file — the suffix just tells VS Code to open it as a notebook. |
 | any `*.md` / `*.markdown` | via **Open With… → CIM Notebook (Markdown)** | Turn any markdown document (a README, a runbook) into a notebook without renaming it. |
+| `*.sparqlbook` | via **Open With… → CIM Notebook (SPARQL Book)** | Zazuko SPARQL Notebook interop (JSON). |
 
 To use **Open With…**: right-click the file in the Explorer → *Open With…* → pick the CIM
 Notebook editor. VS Code remembers the choice per file type if you set it as default.
@@ -66,6 +68,13 @@ Saving a notebook normalizes the file deterministically: cells are separated by 
 blank line, trailing blank lines inside cells are dropped, and the file ends with a single
 newline. Line endings (LF/CRLF) are preserved. Cell **outputs are never written to disk** —
 notebook files stay pure source.
+
+## Converting between formats
+
+The command **CIMNotebook: Convert Notebook (Markdown ⇔ SPARQL Book)** writes the active
+notebook in the other format as a sibling file (`report.sparqlbook` → `report.cimnb.md` and
+back) and opens it. The source file is never modified. Zazuko per-cell metadata survives a
+`.sparqlbook` round trip but is dropped when converting to markdown.
 
 ## Running cells
 

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -78,9 +78,9 @@ back) and opens it. The source file is never modified. Zazuko per-cell metadata 
 
 ## Running cells
 
-SPARQL cells have a **Run** button (the _CIM Notebook_ kernel). Execution happens inside
-CIMLangServer — the same Java process that validates your queries — using Apache Jena's
-SPARQL 1.1 engine, so there is nothing extra to install.
+SPARQL and SHACL cells have a **Run** button (the _CIM Notebook_ kernel). Execution
+happens inside CIMLangServer — the same Java process that validates your queries — using
+Apache Jena's SPARQL 1.1 and SHACL engines, so there is nothing extra to install.
 
 A cell names its target with the same `# [endpoint=...]` directive used for validation —
 one directive drives both _validate against_ and _run against_. The target can be a SPARQL
@@ -106,6 +106,7 @@ What you get per query kind:
 | `ASK`                               | ✅ **true** / ❌ **false**                                                                                                |
 | `CONSTRUCT` / `DESCRIBE`            | The result graph as Turtle                                                                                                |
 | `INSERT` / `DELETE` / other updates | A confirmation with the update endpoint used                                                                              |
+| SHACL cell                          | A conforms / does-not-conform verdict with severity counts, plus the full validation report as Turtle                     |
 
 Each output ends with a small stats line — row count, duration, and the resolved endpoint.
 Results are capped server-side (10 000 rows/triples by default) and the output says so when
@@ -150,7 +151,32 @@ loaded as the schema, while instance-data files (`.xml` models, `.nt`/`.nq`/`.tr
 keep the workspace schema so diagnostics stay meaningful — and either way the file is what
 the cell _runs_ against.
 
+### Running SHACL cells
+
+A SHACL cell's text is the **shapes graph**; running the cell validates the target data
+against those shapes. The same `# [endpoint=...]` directives pick the data:
+
+- **Local files** — the shapes are checked in-process (Apache Jena SHACL) against the
+  union of the referenced files, CIMXML models included:
+
+  ```shacl
+  # [endpoint=./model.xml]
+  ex:SwitchNameShape a sh:NodeShape ;
+    sh:targetClass cim:Switch ;
+    sh:property [ sh:path cim:IdentifiedObject.name ; sh:minCount 1 ] .
+  ```
+
+- **HTTP endpoints** — the shapes are POSTed as Turtle to the endpoint's SHACL service
+  (Fuseki's `shacl` operation and compatibles), which validates its own data. For
+  Fuseki-style URLs the service is derived from the query URL (`…/query` → `…/shacl`);
+  because Fuseki requires a graph selector, `?graph=default` (the default graph) is added
+  automatically — put an explicit `?graph=…` in the directive to validate a named graph.
+
+The output is a ✅ conforms / ❌ does-not-conform banner with counts per severity
+(violations, warnings, infos), followed by the full `sh:ValidationReport` as Turtle. A
+run that finds violations is still a _successful_ run — non-conformance is the result,
+not an error.
+
 **Current limitations:**
 
-- SHACL cells are validated statically but cannot be _run_ yet.
 - No authentication support yet — HTTP endpoints must be reachable without credentials.

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -1,0 +1,75 @@
+---
+title: CIM Notebooks
+sidebar_position: 3
+---
+
+# CIM Notebooks
+
+CIM Notebooks are CIMNotebook's own notebook documents for VS Code: markdown files whose
+```` ```sparql ```` and ```` ```shacl ```` code blocks open as notebook cells. Because the
+on-disk format **is** plain markdown, notebooks diff and merge cleanly in git, render on any
+git forge, and need no special tooling to read.
+
+Every code cell is validated by CIMLangServer exactly like a standalone `.rq` or `.shacl`
+file — diagnostics, hover, completion, and go-to-definition all work inside cells, resolved
+against your configured CGMES schema (see
+[SPARQL Notebooks](/cimnotebook/sparql-notebooks) for how a cell picks its schema with the
+`# [endpoint=...]` directive).
+
+:::note VS Code only
+CIM Notebooks are a VS Code feature. The [IntelliJ plugin](/cimnotebook/intellij) validates
+`.rq`, `.sparql`, `.ttl`, and `.shacl` files but has no notebook support.
+:::
+
+:::info Attribution
+The notebook feature is inspired by the
+[SPARQL Notebook](https://marketplace.visualstudio.com/items?itemName=Zazuko.sparql-notebook)
+extension by Zazuko (MIT-licensed) — CIM Notebooks are an independent implementation.
+:::
+
+## File formats
+
+| Format | Opens as notebook | Notes |
+| --- | --- | --- |
+| `*.cimnb.md` | by default | The native format. A regular markdown file — the suffix just tells VS Code to open it as a notebook. |
+| any `*.md` / `*.markdown` | via **Open With… → CIM Notebook (Markdown)** | Turn any markdown document (a README, a runbook) into a notebook without renaming it. |
+
+To use **Open With…**: right-click the file in the Explorer → *Open With…* → pick the CIM
+Notebook editor. VS Code remembers the choice per file type if you set it as default.
+
+## The markdown format
+
+Only top-level, unindented three-backtick fences labelled `sparql` or `shacl` become code
+cells. Everything else — prose, headings, tables, code blocks in other languages (` ```turtle `,
+` ```json `, …) — stays markdown:
+
+````markdown
+# Switch survey
+
+Count switches per substation:
+
+```sparql
+SELECT ?substation (COUNT(?switch) AS ?n)
+WHERE { ?switch cim:Equipment.EquipmentContainer ?substation }
+GROUP BY ?substation
+```
+
+Shapes for the same data:
+
+```shacl
+ex:SwitchShape a sh:NodeShape ;
+  sh:targetClass cim:Switch .
+```
+````
+
+Saving a notebook normalizes the file deterministically: cells are separated by exactly one
+blank line, trailing blank lines inside cells are dropped, and the file ends with a single
+newline. Line endings (LF/CRLF) are preserved. Cell **outputs are never written to disk** —
+notebook files stay pure source.
+
+## Running cells
+
+Cell execution (running SPARQL queries and SHACL validation against endpoints or local
+files) ships in an upcoming CIMNotebook release; today CIM Notebooks are an authoring and
+validation surface. To *run* `.sparqlbook` notebooks you can meanwhile keep using the Zazuko
+SPARQL Notebook extension side by side — CIMNotebook validates its cells too.

--- a/docs/content/cimnotebook/overview.md
+++ b/docs/content/cimnotebook/overview.md
@@ -69,8 +69,9 @@ Both editors share this feature set:
 
 :::note Per-editor feature parity
 Endpoint-aware hover and go-to-definition are handled by CIMLangServer itself, so both editors get
-them equally. The one remaining gap is **SPARQL Notebook cell validation**, which today is VS Code
-only. Each editor page documents what that editor actually does today.
+them equally. The remaining gap is notebooks: **[CIM Notebooks](/cimnotebook/notebooks)** and
+**SPARQL Notebook cell validation** are today VS Code only. Each editor page documents what that
+editor actually does today.
 :::
 
 ## Schema configuration
@@ -85,6 +86,7 @@ canonically, on the [Configuration](/cimvocabcheck/configuration) page.
 - **[VS Code](/cimnotebook/vscode)** — install from the
   [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=soptim-ag.cimnotebook),
   configure a schema, and validate `.rq`, `.sparql`, `.ttl`, `.shacl` files plus
+  [CIM Notebooks](/cimnotebook/notebooks) and
   [SPARQL Notebook cells](/cimnotebook/sparql-notebooks).
 - **[IntelliJ](/cimnotebook/intellij)** — install from the
   [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/32789-cimnotebook) (LSP4IJ is pulled

--- a/docs/content/cimnotebook/sparql-notebooks.md
+++ b/docs/content/cimnotebook/sparql-notebooks.md
@@ -5,11 +5,12 @@ sidebar_position: 4
 
 # SPARQL Notebooks
 
-In VS Code, CIMNotebook validates SPARQL **cells** inside
+In VS Code, CIMNotebook validates SPARQL **cells** inside notebook documents, not just
+`.rq` / `.sparql` files — both in CIMNotebook's own [CIM Notebooks](/cimnotebook/notebooks)
+and in third-party
 [SPARQL Notebook](https://marketplace.visualstudio.com/items?itemName=Zazuko.sparql-notebook)
-documents, not just `.rq` / `.sparql` files. Each cell is validated independently as you edit it,
-and a cell can name the schema it should be checked against with the SPARQL Notebook endpoint
-directive.
+documents. Each cell is validated independently as you edit it, and a cell can name the schema it
+should be checked against with the endpoint directive described below.
 
 :::note VS Code only
 SPARQL Notebook cell validation is a VS Code feature. The [IntelliJ plugin](/cimnotebook/intellij)

--- a/docs/content/cimnotebook/sparql-notebooks.md
+++ b/docs/content/cimnotebook/sparql-notebooks.md
@@ -38,8 +38,22 @@ SELECT * WHERE { ?s a cim:ACLineSegment }
 The directive names **where the CGMES schema lives** — never live instance data. There are three
 cases:
 
-- **Local file** (`./relative/path.ttl`, `.rdf`, `.owl`) — the file is loaded as the schema for
-  that cell. Relative paths resolve against the notebook's own directory.
+- **Local file(s)** (`./relative/path.ttl`, `.rdf`, `.owl`) — the file is loaded as the schema for
+  that cell. Relative paths resolve against the notebook's own directory. Several directives — or a
+  glob pattern — load the **union** of the files, so one cell can validate against multiple
+  profiles at once:
+
+  ```sparql
+  # [endpoint=./schemas/cgmes-3.0/EquipmentCore.ttl]
+  # [endpoint=./schemas/cgmes-3.0/Topology.ttl]
+  ```
+
+  or, equivalently, with glob (`*`) and alternative (`{a,b}`) patterns:
+
+  ```sparql
+  # [endpoint=./schemas/cgmes-3.0/*.ttl]
+  # [endpoint=./schemas/cgmes-3.0/{EquipmentCore,Topology}.ttl]
+  ```
 - **Remote SPARQL endpoint** (`http(s)://…`) — CIMNotebook loads the schema from the endpoint
   itself, enumerating the named graphs that hold the CGMES profiles and reading them into the schema
   index. The schema is fetched in the background; diagnostics appear once it has loaded.

--- a/docs/content/cimnotebook/vscode.md
+++ b/docs/content/cimnotebook/vscode.md
@@ -103,6 +103,23 @@ status-bar button and **CIMNotebook: Set Cell Endpoint…** pick the target, and
 **CIMNotebook: Set/Clear Connection Credentials…** manage basic-auth secrets. See
 [CIM Notebooks](/cimnotebook/notebooks).
 
+### Configuration sidebar
+
+The **CIMNotebook** icon in the activity bar opens three native, collapsible sections for
+the workspace's [`opencgmes.jsonc`](/cimvocabcheck/configuration): **Connections**,
+**Validation** (strictness, standard-vocabulary check, schemas directory, schema files),
+and **Notebook Execution** (query timeout, max rows). Each row shows its current value —
+click a row to edit it with a QuickPick or input box, use the `+` button in a section's
+title bar (or on **Schema files**) to add an entry, and hover a row for inline edit /
+remove / set-default / credentials actions. Adding a schema file or a connection's data
+file offers fuzzy, search-as-you-type file matching over the workspace, with a
+**Browse…** fallback for files outside it. Every edit patches only the changed value
+through the same comment-preserving path edits as hand-editing, so the sidebar and manual
+changes to the file coexist. Without a config file yet, the sections show a **Create
+Config File** prompt instead. The sections follow the active document's _nearest_ config,
+the same discovery validation uses — the **Connections** section header shows which
+config file that is.
+
 ### SPARQL Notebook support
 
 CIMNotebook validates SPARQL **cells** inside notebook documents — its own CIM Notebooks as well

--- a/docs/content/cimnotebook/vscode.md
+++ b/docs/content/cimnotebook/vscode.md
@@ -95,9 +95,12 @@ term across the workspace. Matching is partial and case-insensitive — `aclines
 ### CIM Notebooks
 
 CIMNotebook opens git-friendly **markdown notebooks** (`*.cimnb.md`, or any `*.md` via
-*Open With…*) whose ```` ```sparql ```` / ```` ```shacl ```` code blocks become notebook cells,
+_Open With…_) whose ` ```sparql ` / ` ```shacl ` code blocks become notebook cells,
 and reads/writes Zazuko's `.sparqlbook` format for interop. The command
-**CIMNotebook: Convert Notebook** switches a notebook between the two formats. See
+**CIMNotebook: Convert Notebook** switches a notebook between the two formats. Cells run
+against SPARQL endpoints, local RDF/CIMXML files, or named connections — the cell's
+status-bar button and **CIMNotebook: Set Cell Endpoint…** pick the target, and
+**CIMNotebook: Set/Clear Connection Credentials…** manage basic-auth secrets. See
 [CIM Notebooks](/cimnotebook/notebooks).
 
 ### SPARQL Notebook support
@@ -115,7 +118,7 @@ These editor-specific settings live in VS Code's settings (`settings.json` or th
 Schema configuration itself lives in [`opencgmes.jsonc`](/cimvocabcheck/configuration), not here.
 
 | Setting                      | Default     | Description                                                                                      |
-| ---------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| ---------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
 | `cimnotebook.serverJar`      | _(bundled)_ | Absolute path to `cimvocabcheck-lsp.jar`. Leave empty to use the JAR bundled with the extension. |
 | `cimnotebook.javaExecutable` | `java`      | Java executable used to launch the language server. Must be Java 21 or later.                    |
 | `cimnotebook.javaArgs`       | `[]`        | Extra JVM arguments passed before `-jar`, e.g. `["-Xmx512m"]`.                                   |

--- a/docs/content/cimnotebook/vscode.md
+++ b/docs/content/cimnotebook/vscode.md
@@ -92,11 +92,20 @@ Press `Ctrl+T` (`Cmd+T` on macOS) and type a CIM class or property name to navig
 term across the workspace. Matching is partial and case-insensitive — `aclineseg` matches
 `ACLineSegment`.
 
+### CIM Notebooks
+
+CIMNotebook opens git-friendly **markdown notebooks** (`*.cimnb.md`, or any `*.md` via
+*Open With…*) whose ```` ```sparql ```` / ```` ```shacl ```` code blocks become notebook cells,
+and reads/writes Zazuko's `.sparqlbook` format for interop. The command
+**CIMNotebook: Convert Notebook** switches a notebook between the two formats. See
+[CIM Notebooks](/cimnotebook/notebooks).
+
 ### SPARQL Notebook support
 
-CIMNotebook validates SPARQL **cells** inside
+CIMNotebook validates SPARQL **cells** inside notebook documents — its own CIM Notebooks as well
+as third-party
 [SPARQL Notebook](https://marketplace.visualstudio.com/items?itemName=Zazuko.sparql-notebook)
-documents, not just `.rq` / `.sparql` files. Each cell is validated independently, and a cell can
+documents — not just `.rq` / `.sparql` files. Each cell is validated independently, and a cell can
 declare its own schema with a `# [endpoint=...]` directive. See
 [SPARQL Notebooks](/cimnotebook/sparql-notebooks) for the full behaviour.
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -38,6 +38,7 @@ const sidebars = {
   cimnotebookSidebar: [
     'cimnotebook/overview',
     'cimnotebook/vscode',
+    'cimnotebook/notebooks',
     'cimnotebook/intellij',
     'cimnotebook/sparql-notebooks',
     'cimnotebook/troubleshooting',


### PR DESCRIPTION
## Summary

Turns CIMNotebook from a thin validation client for the third-party Zazuko *SPARQL
Notebook* extension into a fully native notebook implementation. The primary authoring
format is now git-friendly Markdown (`*.cimnb.md` with standard code fences), and cells
execute through our own Java LSP server (Jena 6.1.0) — no third-party extension required.

Clean-room design inspired by `zazuko/vscode-sparql-notebook` and it's fork by `arne-bdt`.

## What's included

- **Native markdown notebook format** (GH-45): `*.cimnb.md` serializer/deserializer so notebooks diff and review cleanly in PRs.
- **Zazuko interop** (GH-46): `.sparqlbook` files still open, plus a bidirectional conversion command between the two formats.
- **Execution engine in the LSP server** (GH-47): new `cimvocabcheck.notebook.execute` command runs SELECT/ASK/CONSTRUCT/DESCRIBE/UPDATE against HTTP SPARQL endpoints, with timeouts and cancellation.
- **VS Code notebook kernel** (GH-48): native controller with rich outputs (markdown result tables, raw `application/sparql-results+json` payloads) and cell cancellation.
- **Local execution targets** (GH-49): run cells directly against local RDF files and CIMXML models via an in-process store, no endpoint needed.
- **SHACL cells** (GH-50): `shacl` code fences validate data either in-process (jena-shacl) or against a remote Fuseki SHACL endpoint.
- **Connection management** (GH-51): named connections in the `"cimnotebook"` section of `opencgmes.jsonc`, credentials kept exclusively in VS Code SecretStorage (never in config or markdown), per-cell endpoint status bar with quick-pick switching.
- **Configuration sidebar** (GH-44): activity-bar webview for editing connections and schemas with comment-preserving JSONC edits.
- **Multi-file and glob endpoint directives** (GH-18): `# [endpoint=./rdf/*.ttl]`, brace patterns, and multiple file directives per cell; validation builds a union schema from all schema files.

Schema-aware validation (completion, hover, diagnostics) follows the same endpoint
resolution chain as execution: cell directive → notebook default → default connection
from config — fixing the original GH-44 bug where notebook-default cells validated
syntax-only.

Docs: new `docs/content/cimnotebook/notebooks.md` reference page plus updates to the
overview, VS Code, and SPARQL-notebooks pages.

## Testing

- New JUnit suites for the LSP notebook package (execution, serialization, SHACL,
  config loading, globbing, cancellation) — SHACL tests run against a real in-process
  Fuseki instance.
- TS unit tests for formats, output rendering, endpoint resolution, and the JSONC
  config model.
- `mvn verify` and the VS Code lint/format/compile/test pipeline pass locally.

Closes #44. Also closes #45, #46, #47, #48, #49, #50, #51, and #18.