### PR TITLE
feat(cimnotebook): native markdown notebook format (GH-45)

### DIFF
--- a/cimnotebook/vscode/.gitignore
+++ b/cimnotebook/vscode/.gitignore
@@ -2,3 +2,4 @@ out/
 node_modules/
 *.vsix
 server/sparql-validate-lsp.jar
+out-test/

--- a/cimnotebook/vscode/.prettierignore
+++ b/cimnotebook/vscode/.prettierignore
@@ -8,3 +8,4 @@ syntaxes/
 schemas/
 *.png
 *.svg
+out-test/

--- a/cimnotebook/vscode/.vscodeignore
+++ b/cimnotebook/vscode/.vscodeignore
@@ -7,3 +7,5 @@ esbuild.js
 .vscode/**
 **/*.ts
 **/*.map
+out-test/
+tsconfig.test.json

--- a/cimnotebook/vscode/eslint.config.mjs
+++ b/cimnotebook/vscode/eslint.config.mjs
@@ -25,7 +25,7 @@ import soptim from "./eslint-rules/index.mjs";
 
 export default tseslint.config(
     {
-        ignores: ["out/**", "dist/**", "node_modules/**", "server/**", "*.vsix"],
+        ignores: ["out/**", "out-test/**", "dist/**", "node_modules/**", "server/**", "*.vsix"],
     },
 
     // TypeScript extension sources: full recommended rule set + license header.

--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -31,7 +31,9 @@
         "onLanguage:turtle",
         "workspaceContains:**/*.ttl",
         "workspaceContains:**/*.shacl",
-        "onNotebook:sparql-notebook"
+        "onNotebook:sparql-notebook",
+        "onNotebook:cimnotebook",
+        "onNotebook:cimnotebook-markdown"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -74,6 +76,30 @@
                 "embeddedLanguages": {
                     "meta.embedded.block.sparql": "sparql"
                 }
+            }
+        ],
+        "notebooks": [
+            {
+                "type": "cimnotebook",
+                "displayName": "CIM Notebook",
+                "selector": [
+                    {
+                        "filenamePattern": "*.cimnb.md"
+                    }
+                ]
+            },
+            {
+                "type": "cimnotebook-markdown",
+                "displayName": "CIM Notebook (Markdown)",
+                "priority": "option",
+                "selector": [
+                    {
+                        "filenamePattern": "*.md"
+                    },
+                    {
+                        "filenamePattern": "*.markdown"
+                    }
+                ]
             }
         ],
         "jsonValidation": [
@@ -180,6 +206,7 @@
         "vscode:prepublish": "node esbuild.js --production",
         "bundle": "node esbuild.js",
         "compile": "tsc --noEmit",
+        "test": "tsc -p tsconfig.test.json && node --test \"out-test/**/*.test.js\"",
         "watch": "node esbuild.js --watch",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -26,6 +26,8 @@ import {
     TransportKind,
 } from "vscode-languageclient/node";
 
+import { registerNotebookSerializers } from "./notebook/serializers";
+
 const CHANNEL = "CIMNotebook";
 
 let client: LanguageClient | undefined;
@@ -54,6 +56,10 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand("cimnotebook.createConfig", createConfig),
     );
+
+    // Native CIM Notebooks (markdown format; cells are validated through the
+    // vscode-notebook-cell entries of the LSP documentSelector below).
+    registerNotebookSerializers(context);
 
     try {
         doActivate(context);

--- a/cimnotebook/vscode/src/notebook/cells.ts
+++ b/cimnotebook/vscode/src/notebook/cells.ts
@@ -1,0 +1,42 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Editor-independent notebook cell model used by the markdown serializer. Deliberately
+ * free of any `vscode` import so the format logic can be unit-tested with plain
+ * `node --test`.
+ */
+
+/** Cell languages that CIMNotebook treats as executable code cells. */
+export const CODE_CELL_LANGUAGES = ["sparql", "shacl"] as const;
+
+export interface RawCell {
+    kind: "markdown" | "code";
+    /** Language id for code cells (usually "sparql" or "shacl"); absent for markdown. */
+    language?: string;
+    value: string;
+    /** Opaque per-cell metadata, passed through untouched by the serializers. */
+    metadata?: Record<string, unknown>;
+}
+
+/** A parsed notebook: its cells plus document-level facts needed for faithful saving. */
+export interface RawNotebook {
+    cells: RawCell[];
+    /** Line ending of the source file, preserved on serialization. */
+    eol: "\n" | "\r\n";
+}

--- a/cimnotebook/vscode/src/notebook/markdown.test.ts
+++ b/cimnotebook/vscode/src/notebook/markdown.test.ts
@@ -1,0 +1,223 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseMarkdownNotebook, serializeMarkdownNotebook } from "./markdown";
+
+/** Asserts that serialize(parse(text)) is a fixed point after one normalization pass. */
+function assertRoundTripStable(text: string): string {
+    const once = serializeMarkdownNotebook(parseMarkdownNotebook(text));
+    const twice = serializeMarkdownNotebook(parseMarkdownNotebook(once));
+    assert.equal(twice, once, "serialize(parse(x)) must be idempotent");
+    return once;
+}
+
+describe("parseMarkdownNotebook", () => {
+    it("turns sparql and shacl fences into code cells, keeps prose as markdown", () => {
+        const text = [
+            "# Title",
+            "",
+            "Some prose.",
+            "",
+            "```sparql",
+            "SELECT * WHERE { ?s ?p ?o }",
+            "```",
+            "",
+            "More prose.",
+            "",
+            "```shacl",
+            "ex:Shape a sh:NodeShape .",
+            "```",
+            "",
+        ].join("\n");
+
+        const { cells } = parseMarkdownNotebook(text);
+        assert.deepEqual(
+            cells.map((c) => [c.kind, c.language]),
+            [
+                ["markdown", undefined],
+                ["code", "sparql"],
+                ["markdown", undefined],
+                ["code", "shacl"],
+            ],
+        );
+        assert.equal(cells[0].value, "# Title\n\nSome prose.");
+        assert.equal(cells[1].value, "SELECT * WHERE { ?s ?p ?o }");
+        assert.equal(cells[3].value, "ex:Shape a sh:NodeShape .");
+    });
+
+    it("keeps other fence languages as markdown, verbatim", () => {
+        const text = "```turtle\nex:a ex:b ex:c .\n```\n";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+        assert.equal(cells[0].value, "```turtle\nex:a ex:b ex:c .\n```");
+    });
+
+    it("treats the info string case-insensitively", () => {
+        const { cells } = parseMarkdownNotebook("```SPARQL\nASK {}\n```\n");
+        assert.equal(cells[0].kind, "code");
+        assert.equal(cells[0].language, "sparql");
+    });
+
+    it("does not open code cells inside longer fences", () => {
+        const text = ["````markdown", "```sparql", "SELECT 1", "```", "````", ""].join("\n");
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+    });
+
+    it("does not open code cells inside tilde fences", () => {
+        const text = "~~~\n```sparql\nSELECT 1\n```\n~~~\n";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+    });
+
+    it("keeps indented sparql fences as markdown", () => {
+        const text = "  ```sparql\n  SELECT 1\n  ```\n";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+    });
+
+    it("keeps an unclosed sparql fence at EOF as markdown", () => {
+        const text = "prose\n\n```sparql\nSELECT * WHERE { ?s ?p ?o }";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.deepEqual(
+            cells.map((c) => c.kind),
+            ["markdown", "markdown"],
+        );
+        assert.equal(cells[1].value, "```sparql\nSELECT * WHERE { ?s ?p ?o }");
+        assertRoundTripStable(text);
+    });
+
+    it("supports empty code cells", () => {
+        const { cells } = parseMarkdownNotebook("```sparql\n```\n");
+        assert.deepEqual(cells, [{ kind: "code", language: "sparql", value: "" }]);
+    });
+
+    it("allows closing fences longer than three backticks", () => {
+        const { cells } = parseMarkdownNotebook("```sparql\nASK {}\n`````\nafter\n");
+        assert.equal(cells[0].kind, "code");
+        assert.equal(cells[0].value, "ASK {}");
+        assert.equal(cells[1].value, "after");
+    });
+
+    it("ignores fence-like inline code (backtick info strings)", () => {
+        const text = "``` ```code``` ```\n";
+        const { cells } = parseMarkdownNotebook(text);
+        assert.equal(cells.length, 1);
+        assert.equal(cells[0].kind, "markdown");
+    });
+
+    it("detects CRLF line endings", () => {
+        const { eol, cells } = parseMarkdownNotebook("# Hi\r\n\r\n```sparql\r\nASK {}\r\n```\r\n");
+        assert.equal(eol, "\r\n");
+        assert.equal(cells[1].value, "ASK {}");
+    });
+
+    it("returns no cells for empty input", () => {
+        assert.deepEqual(parseMarkdownNotebook("").cells, []);
+        assert.deepEqual(parseMarkdownNotebook("\n\n\n").cells, []);
+    });
+});
+
+describe("serializeMarkdownNotebook", () => {
+    it("separates cells with exactly one blank line and ends with a newline", () => {
+        const text = serializeMarkdownNotebook({
+            eol: "\n",
+            cells: [
+                { kind: "markdown", value: "# Title" },
+                { kind: "code", language: "sparql", value: "ASK {}" },
+            ],
+        });
+        assert.equal(text, "# Title\n\n```sparql\nASK {}\n```\n");
+    });
+
+    it("restores CRLF line endings", () => {
+        const text = serializeMarkdownNotebook({
+            eol: "\r\n",
+            cells: [{ kind: "code", language: "sparql", value: "ASK {}" }],
+        });
+        assert.equal(text, "```sparql\r\nASK {}\r\n```\r\n");
+    });
+
+    it("defaults code cells without a language to sparql", () => {
+        const text = serializeMarkdownNotebook({
+            eol: "\n",
+            cells: [{ kind: "code", value: "ASK {}" }],
+        });
+        assert.ok(text.startsWith("```sparql\n"));
+    });
+
+    it("drops empty markdown cells", () => {
+        const text = serializeMarkdownNotebook({
+            eol: "\n",
+            cells: [
+                { kind: "markdown", value: "   \n  " },
+                { kind: "code", language: "sparql", value: "ASK {}" },
+            ],
+        });
+        assert.equal(text, "```sparql\nASK {}\n```\n");
+    });
+});
+
+describe("round trip", () => {
+    it("is byte-stable for an already-normalized document", () => {
+        const text = [
+            "# CGMES exploration",
+            "",
+            "Query the model:",
+            "",
+            "```sparql",
+            "# [endpoint=http://localhost:3030/ds/query]",
+            "SELECT * WHERE { ?s ?p ?o } LIMIT 10",
+            "```",
+            "",
+            "```shacl",
+            "ex:Shape a sh:NodeShape ;",
+            "  sh:targetClass cim:Switch .",
+            "```",
+            "",
+        ].join("\n");
+        assert.equal(serializeMarkdownNotebook(parseMarkdownNotebook(text)), text);
+    });
+
+    it("is idempotent for messy input (extra blank lines, trailing spaces)", () => {
+        const messy = "# Title\n\n\n\nprose   \n\n\n```sparql\n\nASK {}\n\n```\n\n\n";
+        const normalized = assertRoundTripStable(messy);
+        const { cells } = parseMarkdownNotebook(normalized);
+        assert.deepEqual(
+            cells.map((c) => c.kind),
+            ["markdown", "code"],
+        );
+    });
+
+    it("is idempotent for CRLF documents and preserves CRLF", () => {
+        const crlf = "# Hi\r\n\r\n```sparql\r\nASK {}\r\n```\r\n";
+        assert.equal(serializeMarkdownNotebook(parseMarkdownNotebook(crlf)), crlf);
+    });
+
+    it("is idempotent for documents that are all markdown", () => {
+        const text = "# Only prose\n\nNothing to run here.\n";
+        assert.equal(serializeMarkdownNotebook(parseMarkdownNotebook(text)), text);
+    });
+});

--- a/cimnotebook/vscode/src/notebook/markdown.ts
+++ b/cimnotebook/vscode/src/notebook/markdown.ts
@@ -1,0 +1,145 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Markdown notebook format: a plain markdown document whose top-level ```sparql and
+ * ```shacl fenced code blocks are executable cells; everything else stays markdown.
+ *
+ * Design rules (git-friendliness first):
+ * - Only unindented, exactly-three-backtick fences with the info string `sparql` or
+ *   `shacl` become code cells. Longer/indented/`~~~` fences and other languages stay
+ *   markdown verbatim, but are still tracked so fence markers inside them never open
+ *   a code cell. When in doubt, content stays markdown.
+ * - Serialization is normalizing but idempotent: cells are separated by exactly one
+ *   blank line, trailing whitespace-only lines are dropped, and the file ends with a
+ *   single newline. `serialize(parse(x))` reaches a fixed point after one pass.
+ * - The source file's line ending (LF/CRLF) is detected on parse and restored on
+ *   serialization, so saving never rewrites every line of a CRLF file.
+ */
+
+import { CODE_CELL_LANGUAGES, RawCell, RawNotebook } from "./cells";
+
+/** Opening fence: 3+ backticks or tildes, up to 3 leading spaces (CommonMark). */
+const FENCE_OPEN = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+/** Closing fence for a code cell: 3+ backticks on their own line, no indentation. */
+const CODE_CELL_CLOSE = /^`{3,}\s*$/;
+
+export function parseMarkdownNotebook(text: string): RawNotebook {
+    const eol: RawNotebook["eol"] = text.includes("\r\n") ? "\r\n" : "\n";
+    const lines = text.split(/\r?\n/);
+
+    const cells: RawCell[] = [];
+    let markdown: string[] = [];
+    let code: string[] = [];
+
+    type State =
+        | { name: "outside" }
+        | { name: "codeCell"; language: string }
+        | { name: "otherFence"; marker: string; length: number };
+    let state: State = { name: "outside" };
+
+    const flushMarkdown = (): void => {
+        const value = trimBlankEdges(markdown).join("\n");
+        if (value.length > 0) {
+            cells.push({ kind: "markdown", value });
+        }
+        markdown = [];
+    };
+
+    for (const line of lines) {
+        if (state.name === "codeCell") {
+            if (CODE_CELL_CLOSE.test(line)) {
+                cells.push({ kind: "code", language: state.language, value: code.join("\n") });
+                code = [];
+                state = { name: "outside" };
+            } else {
+                code.push(line);
+            }
+            continue;
+        }
+
+        if (state.name === "otherFence") {
+            markdown.push(line);
+            // CommonMark closer: same marker char, at least as long, nothing else on the line.
+            const close = new RegExp(`^ {0,3}\\${state.marker}{${state.length},}\\s*$`);
+            if (close.test(line)) {
+                state = { name: "outside" };
+            }
+            continue;
+        }
+
+        const fence = FENCE_OPEN.exec(line);
+        if (fence) {
+            const [, indent, marker, rest] = fence;
+            const info = rest.trim().toLowerCase();
+            const isCodeCellFence =
+                indent.length === 0 &&
+                marker === "```" &&
+                (CODE_CELL_LANGUAGES as readonly string[]).includes(info);
+            if (isCodeCellFence) {
+                flushMarkdown();
+                state = { name: "codeCell", language: info };
+            } else if (marker[0] === "`" && rest.includes("`")) {
+                // Not a valid fence opener (info strings of backtick fences must not
+                // contain backticks, e.g. inline code like ```` ```code``` ````).
+                markdown.push(line);
+            } else {
+                markdown.push(line);
+                state = { name: "otherFence", marker: marker[0], length: marker.length };
+            }
+            continue;
+        }
+
+        markdown.push(line);
+    }
+
+    if (state.name === "codeCell") {
+        // Unclosed cell fence at EOF: keep the original text as markdown so a later
+        // save cannot silently invent a closing fence the author never wrote.
+        markdown = ["```" + state.language, ...code];
+    }
+    flushMarkdown();
+
+    return { cells, eol };
+}
+
+export function serializeMarkdownNotebook(notebook: RawNotebook): string {
+    const blocks = notebook.cells.map((cell) => {
+        if (cell.kind === "code") {
+            const language = cell.language ?? "sparql";
+            const body = trimBlankEdges(cell.value.split("\n")).join("\n");
+            return body.length > 0
+                ? "```" + language + "\n" + body + "\n```"
+                : "```" + language + "\n```";
+        }
+        return trimBlankEdges(cell.value.split("\n")).join("\n");
+    });
+
+    const text = blocks.filter((block) => block.length > 0).join("\n\n");
+    const result = text.length > 0 ? text + "\n" : "";
+    return notebook.eol === "\r\n" ? result.replace(/\n/g, "\r\n") : result;
+}
+
+/** Drops leading/trailing lines that are empty or whitespace-only. */
+function trimBlankEdges(lines: string[]): string[] {
+    let start = 0;
+    let end = lines.length;
+    while (start < end && lines[start].trim().length === 0) start++;
+    while (end > start && lines[end - 1].trim().length === 0) end--;
+    return lines.slice(start, end);
+}

--- a/cimnotebook/vscode/src/notebook/serializers.ts
+++ b/cimnotebook/vscode/src/notebook/serializers.ts
@@ -1,0 +1,103 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * VS Code adapters around the pure notebook format modules. The contributed
+ * notebook types (see package.json `contributes.notebooks`) share these serializers:
+ *
+ * - `cimnotebook`            — `*.cimnb.md`, opens as a notebook by default
+ * - `cimnotebook-markdown`   — any `*.md`/`*.markdown` via "Open With…"
+ *
+ * Outputs are always transient: notebook files on disk stay pure source.
+ */
+
+import * as vscode from "vscode";
+import { TextDecoder, TextEncoder } from "util";
+
+import { RawCell, RawNotebook } from "./cells";
+import { parseMarkdownNotebook, serializeMarkdownNotebook } from "./markdown";
+
+export const NOTEBOOK_TYPE_DEFAULT = "cimnotebook";
+export const NOTEBOOK_TYPE_MARKDOWN = "cimnotebook-markdown";
+
+/** All notebook types owned by this extension. */
+export const NOTEBOOK_TYPES = [NOTEBOOK_TYPE_DEFAULT, NOTEBOOK_TYPE_MARKDOWN] as const;
+
+/** Notebook-level metadata key carrying the source file's line ending. */
+const METADATA_EOL = "cimnotebookEol";
+
+export function registerNotebookSerializers(context: vscode.ExtensionContext): void {
+    const markdown = new FormatSerializer(parseMarkdownNotebook, serializeMarkdownNotebook);
+    const options: vscode.NotebookDocumentContentOptions = { transientOutputs: true };
+
+    context.subscriptions.push(
+        vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_DEFAULT, markdown, options),
+        vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_MARKDOWN, markdown, options),
+    );
+}
+
+class FormatSerializer implements vscode.NotebookSerializer {
+    constructor(
+        private readonly parse: (text: string) => RawNotebook,
+        private readonly serialize: (notebook: RawNotebook) => string,
+    ) {}
+
+    deserializeNotebook(content: Uint8Array): vscode.NotebookData {
+        const raw = this.parse(new TextDecoder().decode(content));
+        const data = new vscode.NotebookData(raw.cells.map(rawToCellData));
+        data.metadata = { [METADATA_EOL]: raw.eol };
+        return data;
+    }
+
+    serializeNotebook(data: vscode.NotebookData): Uint8Array {
+        const raw: RawNotebook = {
+            cells: data.cells.map((cell) => cellDataToRaw(cell, cell.metadata)),
+            eol: readEol(data.metadata),
+        };
+        return new TextEncoder().encode(this.serialize(raw));
+    }
+}
+
+function rawToCellData(cell: RawCell): vscode.NotebookCellData {
+    const data = new vscode.NotebookCellData(
+        cell.kind === "markdown" ? vscode.NotebookCellKind.Markup : vscode.NotebookCellKind.Code,
+        cell.value,
+        cell.kind === "markdown" ? "markdown" : (cell.language ?? "sparql"),
+    );
+    if (cell.metadata !== undefined) {
+        data.metadata = cell.metadata;
+    }
+    return data;
+}
+
+function cellDataToRaw(
+    cell: vscode.NotebookCellData,
+    metadata: Record<string, unknown> | undefined,
+): RawCell {
+    const isMarkdown = cell.kind === vscode.NotebookCellKind.Markup;
+    return {
+        kind: isMarkdown ? "markdown" : "code",
+        ...(isMarkdown ? {} : { language: cell.languageId }),
+        value: cell.value,
+        ...(metadata !== undefined && Object.keys(metadata).length > 0 ? { metadata } : {}),
+    };
+}
+
+function readEol(metadata: { [key: string]: unknown } | undefined): RawNotebook["eol"] {
+    return metadata?.[METADATA_EOL] === "\r\n" ? "\r\n" : "\n";
+}

--- a/cimnotebook/vscode/tsconfig.json
+++ b/cimnotebook/vscode/tsconfig.json
@@ -4,7 +4,7 @@
         "moduleResolution": "Node16",
         "target": "ES2021",
         "outDir": "out",
-        "lib": ["ES2021"],
+        "lib": ["ES2021", "ES2022.Error"],
         "sourceMap": true,
         "rootDir": "src",
         "strict": true,

--- a/cimnotebook/vscode/tsconfig.test.json
+++ b/cimnotebook/vscode/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "out-test",
+        "noEmit": false,
+        "sourceMap": false,
+        // Only "node": the format modules under test must stay importable without a
+        // running VS Code host — an accidental `import "vscode"` fails this build.
+        "types": ["node"]
+    },
+    "include": [
+        "src/notebook/cells.ts",
+        "src/notebook/markdown.ts",
+        "src/notebook/sparqlbook.ts",
+        "src/notebook/*.test.ts"
+    ]
+}

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -1,0 +1,75 @@
+---
+title: CIM Notebooks
+sidebar_position: 3
+---
+
+# CIM Notebooks
+
+CIM Notebooks are CIMNotebook's own notebook documents for VS Code: markdown files whose
+```` ```sparql ```` and ```` ```shacl ```` code blocks open as notebook cells. Because the
+on-disk format **is** plain markdown, notebooks diff and merge cleanly in git, render on any
+git forge, and need no special tooling to read.
+
+Every code cell is validated by CIMLangServer exactly like a standalone `.rq` or `.shacl`
+file — diagnostics, hover, completion, and go-to-definition all work inside cells, resolved
+against your configured CGMES schema (see
+[SPARQL Notebooks](/cimnotebook/sparql-notebooks) for how a cell picks its schema with the
+`# [endpoint=...]` directive).
+
+:::note VS Code only
+CIM Notebooks are a VS Code feature. The [IntelliJ plugin](/cimnotebook/intellij) validates
+`.rq`, `.sparql`, `.ttl`, and `.shacl` files but has no notebook support.
+:::
+
+:::info Attribution
+The notebook feature is inspired by the
+[SPARQL Notebook](https://marketplace.visualstudio.com/items?itemName=Zazuko.sparql-notebook)
+extension by Zazuko (MIT-licensed) — CIM Notebooks are an independent implementation.
+:::
+
+## File formats
+
+| Format | Opens as notebook | Notes |
+| --- | --- | --- |
+| `*.cimnb.md` | by default | The native format. A regular markdown file — the suffix just tells VS Code to open it as a notebook. |
+| any `*.md` / `*.markdown` | via **Open With… → CIM Notebook (Markdown)** | Turn any markdown document (a README, a runbook) into a notebook without renaming it. |
+
+To use **Open With…**: right-click the file in the Explorer → *Open With…* → pick the CIM
+Notebook editor. VS Code remembers the choice per file type if you set it as default.
+
+## The markdown format
+
+Only top-level, unindented three-backtick fences labelled `sparql` or `shacl` become code
+cells. Everything else — prose, headings, tables, code blocks in other languages (` ```turtle `,
+` ```json `, …) — stays markdown:
+
+````markdown
+# Switch survey
+
+Count switches per substation:
+
+```sparql
+SELECT ?substation (COUNT(?switch) AS ?n)
+WHERE { ?switch cim:Equipment.EquipmentContainer ?substation }
+GROUP BY ?substation
+```
+
+Shapes for the same data:
+
+```shacl
+ex:SwitchShape a sh:NodeShape ;
+  sh:targetClass cim:Switch .
+```
+````
+
+Saving a notebook normalizes the file deterministically: cells are separated by exactly one
+blank line, trailing blank lines inside cells are dropped, and the file ends with a single
+newline. Line endings (LF/CRLF) are preserved. Cell **outputs are never written to disk** —
+notebook files stay pure source.
+
+## Running cells
+
+Cell execution (running SPARQL queries and SHACL validation against endpoints or local
+files) ships in an upcoming CIMNotebook release; today CIM Notebooks are an authoring and
+validation surface. To *run* `.sparqlbook` notebooks you can meanwhile keep using the Zazuko
+SPARQL Notebook extension side by side — CIMNotebook validates its cells too.

--- a/docs/content/cimnotebook/overview.md
+++ b/docs/content/cimnotebook/overview.md
@@ -69,8 +69,9 @@ Both editors share this feature set:
 
 :::note Per-editor feature parity
 Endpoint-aware hover and go-to-definition are handled by CIMLangServer itself, so both editors get
-them equally. The one remaining gap is **SPARQL Notebook cell validation**, which today is VS Code
-only. Each editor page documents what that editor actually does today.
+them equally. The remaining gap is notebooks: **[CIM Notebooks](/cimnotebook/notebooks)** and
+**SPARQL Notebook cell validation** are today VS Code only. Each editor page documents what that
+editor actually does today.
 :::
 
 ## Schema configuration
@@ -85,6 +86,7 @@ canonically, on the [Configuration](/cimvocabcheck/configuration) page.
 - **[VS Code](/cimnotebook/vscode)** — install from the
   [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=soptim-ag.cimnotebook),
   configure a schema, and validate `.rq`, `.sparql`, `.ttl`, `.shacl` files plus
+  [CIM Notebooks](/cimnotebook/notebooks) and
   [SPARQL Notebook cells](/cimnotebook/sparql-notebooks).
 - **[IntelliJ](/cimnotebook/intellij)** — install from the
   [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/32789-cimnotebook) (LSP4IJ is pulled

--- a/docs/content/cimnotebook/sparql-notebooks.md
+++ b/docs/content/cimnotebook/sparql-notebooks.md
@@ -5,11 +5,12 @@ sidebar_position: 4
 
 # SPARQL Notebooks
 
-In VS Code, CIMNotebook validates SPARQL **cells** inside
+In VS Code, CIMNotebook validates SPARQL **cells** inside notebook documents, not just
+`.rq` / `.sparql` files — both in CIMNotebook's own [CIM Notebooks](/cimnotebook/notebooks)
+and in third-party
 [SPARQL Notebook](https://marketplace.visualstudio.com/items?itemName=Zazuko.sparql-notebook)
-documents, not just `.rq` / `.sparql` files. Each cell is validated independently as you edit it,
-and a cell can name the schema it should be checked against with the SPARQL Notebook endpoint
-directive.
+documents. Each cell is validated independently as you edit it, and a cell can name the schema it
+should be checked against with the endpoint directive described below.
 
 :::note VS Code only
 SPARQL Notebook cell validation is a VS Code feature. The [IntelliJ plugin](/cimnotebook/intellij)

--- a/docs/content/cimnotebook/vscode.md
+++ b/docs/content/cimnotebook/vscode.md
@@ -92,11 +92,20 @@ Press `Ctrl+T` (`Cmd+T` on macOS) and type a CIM class or property name to navig
 term across the workspace. Matching is partial and case-insensitive — `aclineseg` matches
 `ACLineSegment`.
 
+### CIM Notebooks
+
+CIMNotebook opens git-friendly **markdown notebooks** (`*.cimnb.md`, or any `*.md` via
+*Open With…*) whose ```` ```sparql ```` / ```` ```shacl ```` code blocks become notebook cells,
+and reads/writes Zazuko's `.sparqlbook` format for interop. The command
+**CIMNotebook: Convert Notebook** switches a notebook between the two formats. See
+[CIM Notebooks](/cimnotebook/notebooks).
+
 ### SPARQL Notebook support
 
-CIMNotebook validates SPARQL **cells** inside
+CIMNotebook validates SPARQL **cells** inside notebook documents — its own CIM Notebooks as well
+as third-party
 [SPARQL Notebook](https://marketplace.visualstudio.com/items?itemName=Zazuko.sparql-notebook)
-documents, not just `.rq` / `.sparql` files. Each cell is validated independently, and a cell can
+documents — not just `.rq` / `.sparql` files. Each cell is validated independently, and a cell can
 declare its own schema with a `# [endpoint=...]` directive. See
 [SPARQL Notebooks](/cimnotebook/sparql-notebooks) for the full behaviour.
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -38,6 +38,7 @@ const sidebars = {
   cimnotebookSidebar: [
     'cimnotebook/overview',
     'cimnotebook/vscode',
+    'cimnotebook/notebooks',
     'cimnotebook/intellij',
     'cimnotebook/sparql-notebooks',
     'cimnotebook/troubleshooting',


### PR DESCRIPTION
Adds the base notebook infrastructure and the git-friendly markdown format. A CIM Notebook is a plain markdown document whose top-level, unindented ```sparql / ```shacl fences are executable cells; everything else stays markdown. Two notebook types are contributed: *.cimnb.md opens as a notebook by default, any *.md/*.markdown via "Open With…".

Parsing and serialization are a pure, vscode-free module (cells.ts, markdown.ts) so they can be unit-tested with plain `node --test`. Serialization is normalizing but idempotent — one blank line between cells, no trailing blank lines, a single closing newline — and the source file's LF/CRLF line ending is detected on parse and restored on save, so a notebook round-trips without rewriting every line. Outputs are transient: notebook files on disk stay pure source.

Closes #45