### PR TITLE
feat(cimnotebook): Zazuko .sparqlbook interop and format conversion (GH-46)

### DIFF
--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -33,7 +33,8 @@
         "workspaceContains:**/*.shacl",
         "onNotebook:sparql-notebook",
         "onNotebook:cimnotebook",
-        "onNotebook:cimnotebook-markdown"
+        "onNotebook:cimnotebook-markdown",
+        "onNotebook:cimnotebook-sparqlbook"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -100,6 +101,16 @@
                         "filenamePattern": "*.markdown"
                     }
                 ]
+            },
+            {
+                "type": "cimnotebook-sparqlbook",
+                "displayName": "CIM Notebook (SPARQL Book)",
+                "priority": "option",
+                "selector": [
+                    {
+                        "filenamePattern": "*.sparqlbook"
+                    }
+                ]
             }
         ],
         "jsonValidation": [
@@ -126,6 +137,11 @@
                 "command": "cimnotebook.createConfig",
                 "title": "Create Config File (opencgmes.jsonc)",
                 "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.notebook.convert",
+                "title": "Convert Notebook (Markdown ⇔ SPARQL Book)",
+                "category": "CIMNotebook"
             }
         ],
         "menus": {
@@ -143,6 +159,10 @@
                 },
                 {
                     "command": "cimnotebook.createConfig"
+                },
+                {
+                    "command": "cimnotebook.notebook.convert",
+                    "when": "activeNotebookType =~ /^cimnotebook/"
                 }
             ]
         },

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -27,6 +27,7 @@ import {
 } from "vscode-languageclient/node";
 
 import { registerNotebookSerializers } from "./notebook/serializers";
+import { registerConvertCommand } from "./notebook/convert";
 
 const CHANNEL = "CIMNotebook";
 
@@ -57,9 +58,10 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand("cimnotebook.createConfig", createConfig),
     );
 
-    // Native CIM Notebooks (markdown format; cells are validated through the
-    // vscode-notebook-cell entries of the LSP documentSelector below).
+    // Native CIM Notebooks (markdown + .sparqlbook formats; cells are validated through
+    // the vscode-notebook-cell entries of the LSP documentSelector below).
     registerNotebookSerializers(context);
+    registerConvertCommand(context);
 
     try {
         doActivate(context);

--- a/cimnotebook/vscode/src/notebook/cells.ts
+++ b/cimnotebook/vscode/src/notebook/cells.ts
@@ -17,9 +17,9 @@
  */
 
 /**
- * Editor-independent notebook cell model used by the markdown serializer. Deliberately
- * free of any `vscode` import so the format logic can be unit-tested with plain
- * `node --test`.
+ * Editor-independent notebook cell model shared by the markdown and .sparqlbook
+ * serializers. Deliberately free of any `vscode` import so the format logic can be
+ * unit-tested with plain `node --test`.
  */
 
 /** Cell languages that CIMNotebook treats as executable code cells. */
@@ -30,7 +30,7 @@ export interface RawCell {
     /** Language id for code cells (usually "sparql" or "shacl"); absent for markdown. */
     language?: string;
     value: string;
-    /** Opaque per-cell metadata, passed through untouched by the serializers. */
+    /** Opaque per-cell metadata (only round-tripped by the .sparqlbook format). */
     metadata?: Record<string, unknown>;
 }
 

--- a/cimnotebook/vscode/src/notebook/convert.ts
+++ b/cimnotebook/vscode/src/notebook/convert.ts
@@ -1,0 +1,124 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * "CIMNotebook: Convert Notebook" — writes the active notebook in the other format
+ * (markdown `*.cimnb.md` ⇔ Zazuko `*.sparqlbook`) as a sibling file and opens it.
+ * Converting never touches the source file.
+ */
+
+import * as vscode from "vscode";
+
+import { serializeMarkdownNotebook } from "./markdown";
+import { serializeSparqlBook } from "./sparqlbook";
+import {
+    notebookDocumentToRaw,
+    NOTEBOOK_TYPE_DEFAULT,
+    NOTEBOOK_TYPE_SPARQLBOOK,
+    NOTEBOOK_TYPES,
+} from "./serializers";
+
+export const CONVERT_COMMAND = "cimnotebook.notebook.convert";
+
+export function registerConvertCommand(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(CONVERT_COMMAND, convertActiveNotebook),
+    );
+}
+
+interface TargetFormat {
+    label: string;
+    description: string;
+    serialize: (notebook: ReturnType<typeof notebookDocumentToRaw>) => string;
+    targetUri: (source: vscode.Uri) => vscode.Uri;
+    openAsType: string;
+}
+
+const TO_MARKDOWN: TargetFormat = {
+    label: "Markdown notebook (*.cimnb.md)",
+    description: "Git-friendly markdown with ```sparql / ```shacl cells",
+    serialize: serializeMarkdownNotebook,
+    targetUri: (source) =>
+        siblingUri(source, [".cimnb.md", ".sparqlbook", ".md", ".markdown"], ".cimnb.md"),
+    openAsType: NOTEBOOK_TYPE_DEFAULT,
+};
+
+const TO_SPARQLBOOK: TargetFormat = {
+    label: "SPARQL Book (*.sparqlbook)",
+    description: "JSON format of the Zazuko SPARQL Notebook extension",
+    serialize: serializeSparqlBook,
+    targetUri: (source) => siblingUri(source, [".cimnb.md", ".md", ".markdown"], ".sparqlbook"),
+    openAsType: NOTEBOOK_TYPE_SPARQLBOOK,
+};
+
+async function convertActiveNotebook(): Promise<void> {
+    const notebook = vscode.window.activeNotebookEditor?.notebook;
+    if (!notebook || !(NOTEBOOK_TYPES as readonly string[]).includes(notebook.notebookType)) {
+        vscode.window.showWarningMessage("CIMNotebook: open a CIM Notebook to convert it.");
+        return;
+    }
+
+    const source = notebook.uri;
+    const target = await vscode.window.showQuickPick(
+        (source.path.endsWith(".sparqlbook") ? [TO_MARKDOWN] : [TO_SPARQLBOOK, TO_MARKDOWN]).map(
+            (format) => ({ ...format, detail: format.targetUri(source).path }),
+        ),
+        { title: "Convert notebook to" },
+    );
+    if (!target) {
+        return;
+    }
+
+    const targetUri = target.targetUri(source);
+    if (targetUri.toString() === source.toString()) {
+        vscode.window.showInformationMessage("CIMNotebook: notebook is already in that format.");
+        return;
+    }
+    if (await fileExists(targetUri)) {
+        const choice = await vscode.window.showWarningMessage(
+            `CIMNotebook: ${vscode.workspace.asRelativePath(targetUri)} already exists.`,
+            "Overwrite",
+        );
+        if (choice !== "Overwrite") {
+            return;
+        }
+    }
+
+    const content = target.serialize(notebookDocumentToRaw(notebook));
+    await vscode.workspace.fs.writeFile(targetUri, Buffer.from(content, "utf8"));
+    await vscode.commands.executeCommand("vscode.openWith", targetUri, target.openAsType);
+}
+
+/** Strips the first matching suffix (longest first) and appends the target suffix. */
+function siblingUri(source: vscode.Uri, strip: string[], suffix: string): vscode.Uri {
+    const name = source.path.slice(source.path.lastIndexOf("/") + 1);
+    const match = strip
+        .filter((s) => name.toLowerCase().endsWith(s))
+        .sort((a, b) => b.length - a.length)[0];
+    const base = match ? name.slice(0, name.length - match.length) : name;
+    return source.with({ path: source.path.slice(0, -name.length) + base + suffix });
+}
+
+async function fileExists(uri: vscode.Uri): Promise<boolean> {
+    try {
+        await vscode.workspace.fs.stat(uri);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/cimnotebook/vscode/src/notebook/serializers.ts
+++ b/cimnotebook/vscode/src/notebook/serializers.ts
@@ -17,11 +17,12 @@
  */
 
 /**
- * VS Code adapters around the pure notebook format modules. The contributed
+ * VS Code adapters around the pure notebook format modules. The three contributed
  * notebook types (see package.json `contributes.notebooks`) share these serializers:
  *
  * - `cimnotebook`            — `*.cimnb.md`, opens as a notebook by default
  * - `cimnotebook-markdown`   — any `*.md`/`*.markdown` via "Open With…"
+ * - `cimnotebook-sparqlbook` — `*.sparqlbook` (Zazuko interop) via "Open With…"
  *
  * Outputs are always transient: notebook files on disk stay pure source.
  */
@@ -31,24 +32,47 @@ import { TextDecoder, TextEncoder } from "util";
 
 import { RawCell, RawNotebook } from "./cells";
 import { parseMarkdownNotebook, serializeMarkdownNotebook } from "./markdown";
+import { parseSparqlBook, serializeSparqlBook } from "./sparqlbook";
 
 export const NOTEBOOK_TYPE_DEFAULT = "cimnotebook";
 export const NOTEBOOK_TYPE_MARKDOWN = "cimnotebook-markdown";
+export const NOTEBOOK_TYPE_SPARQLBOOK = "cimnotebook-sparqlbook";
 
 /** All notebook types owned by this extension. */
-export const NOTEBOOK_TYPES = [NOTEBOOK_TYPE_DEFAULT, NOTEBOOK_TYPE_MARKDOWN] as const;
+export const NOTEBOOK_TYPES = [
+    NOTEBOOK_TYPE_DEFAULT,
+    NOTEBOOK_TYPE_MARKDOWN,
+    NOTEBOOK_TYPE_SPARQLBOOK,
+] as const;
 
 /** Notebook-level metadata key carrying the source file's line ending. */
 const METADATA_EOL = "cimnotebookEol";
 
 export function registerNotebookSerializers(context: vscode.ExtensionContext): void {
     const markdown = new FormatSerializer(parseMarkdownNotebook, serializeMarkdownNotebook);
+    const sparqlbook = new FormatSerializer(parseSparqlBook, serializeSparqlBook);
     const options: vscode.NotebookDocumentContentOptions = { transientOutputs: true };
 
     context.subscriptions.push(
         vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_DEFAULT, markdown, options),
         vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_MARKDOWN, markdown, options),
+        vscode.workspace.registerNotebookSerializer(NOTEBOOK_TYPE_SPARQLBOOK, sparqlbook, options),
     );
+}
+
+/** Snapshot of an open notebook document as raw cells, for the convert command. */
+export function notebookDocumentToRaw(notebook: vscode.NotebookDocument): RawNotebook {
+    return {
+        cells: notebook.getCells().map((cell) => {
+            const data = new vscode.NotebookCellData(
+                cell.kind,
+                cell.document.getText(),
+                cell.document.languageId,
+            );
+            return cellDataToRaw(data, cell.metadata as Record<string, unknown>);
+        }),
+        eol: readEol(notebook.metadata),
+    };
 }
 
 class FormatSerializer implements vscode.NotebookSerializer {

--- a/cimnotebook/vscode/src/notebook/sparqlbook.test.ts
+++ b/cimnotebook/vscode/src/notebook/sparqlbook.test.ts
@@ -1,0 +1,91 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseSparqlBook, serializeSparqlBook } from "./sparqlbook";
+
+describe("parseSparqlBook", () => {
+    it("maps kind ordinals to markdown/code cells", () => {
+        const text = JSON.stringify([
+            { kind: 1, language: "markdown", value: "# Title" },
+            { kind: 2, language: "sparql", value: "ASK {}" },
+        ]);
+        const { cells } = parseSparqlBook(text);
+        assert.deepEqual(cells, [
+            { kind: "markdown", value: "# Title", metadata: undefined },
+            { kind: "code", language: "sparql", value: "ASK {}", metadata: undefined },
+        ]);
+    });
+
+    it("passes per-cell metadata through (Zazuko external-file cells)", () => {
+        const text = JSON.stringify([
+            { kind: 2, language: "sparql", value: "SELECT 1", metadata: { file: "./q.sparql" } },
+        ]);
+        const { cells } = parseSparqlBook(text);
+        assert.deepEqual(cells[0].metadata, { file: "./q.sparql" });
+    });
+
+    it("accepts an empty file as an empty notebook", () => {
+        assert.deepEqual(parseSparqlBook("").cells, []);
+        assert.deepEqual(parseSparqlBook("[]").cells, []);
+    });
+
+    it("rejects non-array JSON with a clear message", () => {
+        assert.throws(() => parseSparqlBook("{}"), /expected a JSON array/);
+        assert.throws(() => parseSparqlBook("not json"), /JSON parse failed/);
+    });
+
+    it("defaults missing language on code cells to sparql", () => {
+        const { cells } = parseSparqlBook(JSON.stringify([{ kind: 2, value: "ASK {}" }]));
+        assert.equal(cells[0].language, "sparql");
+    });
+});
+
+describe("serializeSparqlBook", () => {
+    it("writes the Zazuko JSON layout, pretty-printed", () => {
+        const text = serializeSparqlBook({
+            eol: "\n",
+            cells: [
+                { kind: "markdown", value: "# Title" },
+                { kind: "code", language: "shacl", value: "ex:S a sh:NodeShape ." },
+            ],
+        });
+        const parsed = JSON.parse(text);
+        assert.deepEqual(parsed, [
+            { kind: 1, language: "markdown", value: "# Title" },
+            { kind: 2, language: "shacl", value: "ex:S a sh:NodeShape ." },
+        ]);
+        assert.ok(text.includes("\n  "), "must be pretty-printed for reviewable diffs");
+        assert.ok(text.endsWith("\n"));
+    });
+
+    it("round-trips cells and metadata", () => {
+        const original = JSON.stringify(
+            [
+                { kind: 1, language: "markdown", value: "intro" },
+                { kind: 2, language: "sparql", value: "SELECT 1", metadata: { file: "a.rq" } },
+            ],
+            null,
+            2,
+        );
+        const roundTripped = serializeSparqlBook(parseSparqlBook(original));
+        assert.deepEqual(JSON.parse(roundTripped), JSON.parse(original));
+    });
+});

--- a/cimnotebook/vscode/src/notebook/sparqlbook.ts
+++ b/cimnotebook/vscode/src/notebook/sparqlbook.ts
@@ -1,0 +1,81 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `.sparqlbook` interop format: the JSON layout used by the Zazuko "SPARQL Notebook"
+ * extension — a pretty-printed array of `{ kind, language, value, metadata }` where
+ * `kind` is the VS Code NotebookCellKind ordinal (1 = markup, 2 = code). Per-cell
+ * metadata is passed through untouched so foreign notebooks survive a round trip.
+ */
+
+import { RawCell, RawNotebook } from "./cells";
+
+/** NotebookCellKind ordinals used on disk (mirror vscode.NotebookCellKind). */
+const KIND_MARKUP = 1;
+const KIND_CODE = 2;
+
+interface SparqlBookCell {
+    kind: number;
+    language: string;
+    value: string;
+    metadata?: Record<string, unknown>;
+}
+
+export function parseSparqlBook(text: string): RawNotebook {
+    let raw: unknown;
+    try {
+        raw = JSON.parse(text.length > 0 ? text : "[]");
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Not a valid .sparqlbook file (JSON parse failed: ${msg})`, {
+            cause: err,
+        });
+    }
+    if (!Array.isArray(raw)) {
+        throw new Error("Not a valid .sparqlbook file (expected a JSON array of cells)");
+    }
+
+    const cells: RawCell[] = raw.map((entry, index) => {
+        if (typeof entry !== "object" || entry === null) {
+            throw new Error(`Not a valid .sparqlbook file (cell ${index} is not an object)`);
+        }
+        const cell = entry as Partial<SparqlBookCell>;
+        const value = typeof cell.value === "string" ? cell.value : "";
+        if (cell.kind === KIND_MARKUP) {
+            return { kind: "markdown", value, metadata: cell.metadata };
+        }
+        return {
+            kind: "code",
+            language: typeof cell.language === "string" ? cell.language : "sparql",
+            value,
+            metadata: cell.metadata,
+        };
+    });
+
+    return { cells, eol: "\n" };
+}
+
+export function serializeSparqlBook(notebook: RawNotebook): string {
+    const cells: SparqlBookCell[] = notebook.cells.map((cell) => ({
+        kind: cell.kind === "markdown" ? KIND_MARKUP : KIND_CODE,
+        language: cell.kind === "markdown" ? "markdown" : (cell.language ?? "sparql"),
+        value: cell.value,
+        ...(cell.metadata !== undefined ? { metadata: cell.metadata } : {}),
+    }));
+    return JSON.stringify(cells, null, 2) + "\n";
+}

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -24,7 +24,8 @@ CIM Notebooks are a VS Code feature. The [IntelliJ plugin](/cimnotebook/intellij
 :::info Attribution
 The notebook feature is inspired by the
 [SPARQL Notebook](https://marketplace.visualstudio.com/items?itemName=Zazuko.sparql-notebook)
-extension by Zazuko (MIT-licensed) — CIM Notebooks are an independent implementation.
+extension by Zazuko (MIT-licensed) — CIM Notebooks are an independent implementation that
+reads and writes Zazuko's `.sparqlbook` format for interoperability.
 :::
 
 ## File formats
@@ -33,6 +34,7 @@ extension by Zazuko (MIT-licensed) — CIM Notebooks are an independent implemen
 | --- | --- | --- |
 | `*.cimnb.md` | by default | The native format. A regular markdown file — the suffix just tells VS Code to open it as a notebook. |
 | any `*.md` / `*.markdown` | via **Open With… → CIM Notebook (Markdown)** | Turn any markdown document (a README, a runbook) into a notebook without renaming it. |
+| `*.sparqlbook` | via **Open With… → CIM Notebook (SPARQL Book)** | Zazuko SPARQL Notebook interop (JSON). |
 
 To use **Open With…**: right-click the file in the Explorer → *Open With…* → pick the CIM
 Notebook editor. VS Code remembers the choice per file type if you set it as default.
@@ -66,6 +68,13 @@ Saving a notebook normalizes the file deterministically: cells are separated by 
 blank line, trailing blank lines inside cells are dropped, and the file ends with a single
 newline. Line endings (LF/CRLF) are preserved. Cell **outputs are never written to disk** —
 notebook files stay pure source.
+
+## Converting between formats
+
+The command **CIMNotebook: Convert Notebook (Markdown ⇔ SPARQL Book)** writes the active
+notebook in the other format as a sibling file (`report.sparqlbook` → `report.cimnb.md` and
+back) and opens it. The source file is never modified. Zazuko per-cell metadata survives a
+`.sparqlbook` round trip but is dropped when converting to markdown.
 
 ## Running cells
 


### PR DESCRIPTION
Reads and writes the JSON layout of the Zazuko "SPARQL Notebook" extension, contributed as a third notebook type (*.sparqlbook via "Open With…"). Per-cell metadata is passed through untouched, so a foreign notebook survives a round trip.

"CIMNotebook: Convert Notebook (Markdown ⇔ SPARQL Book)" writes the active notebook in the other format as a sibling file and opens it; the source file is never modified. Zazuko per-cell metadata survives a .sparqlbook round trip but is dropped when converting to markdown, which has nowhere to put it.

Closes #46