### PR TITLE
feat(cimvocabcheck): notebook cell execution engine and HTTP endpoints (GH-47)

### DIFF
--- a/cimvocabcheck/lsp/pom.xml
+++ b/cimvocabcheck/lsp/pom.xml
@@ -54,6 +54,10 @@
         <ver.slf4j>2.0.18</ver.slf4j>
         <ver.log4j2>2.26.1</ver.log4j2>
         <ver.junit4>4.13.2</ver.junit4>
+        <!-- Test-only: in-process Fuseki server for notebook execution tests. Jena itself is
+             already on the classpath transitively via cimvocabcheck-core (${ver.jena} there);
+             kept in sync manually since this module has no direct compile-scope Jena dependency. -->
+        <ver.jena>6.1.0</ver.jena>
 
         <ver.plugin.compiler>3.15.0</ver.plugin.compiler>
         <ver.plugin.surefire>3.5.6</ver.plugin.surefire>
@@ -125,6 +129,14 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${ver.junit4}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- In-process HTTP endpoint for notebook execution tests -->
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-fuseki-main</artifactId>
+            <version>${ver.jena}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlLanguageServer.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlLanguageServer.java
@@ -19,6 +19,7 @@
 package de.soptim.opencgmes.cimvocabcheck.lsp;
 
 import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookCommandHandler;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
@@ -66,6 +67,7 @@ public final class SparqlLanguageServer implements LanguageServer, LanguageClien
   private final SchemaManager schemaManager;
   private final SparqlTextDocumentService textDocumentService;
   private final SparqlWorkspaceService workspaceService;
+  private final NotebookCommandHandler notebookCommandHandler;
 
   private LanguageClient client;
 
@@ -73,7 +75,8 @@ public final class SparqlLanguageServer implements LanguageServer, LanguageClien
   public SparqlLanguageServer() {
     schemaManager = new SchemaManager();
     textDocumentService = new SparqlTextDocumentService(schemaManager);
-    workspaceService = new SparqlWorkspaceService(schemaManager);
+    notebookCommandHandler = new NotebookCommandHandler();
+    workspaceService = new SparqlWorkspaceService(schemaManager, notebookCommandHandler);
     // After each successful schema load, revalidate all open documents.
     schemaManager.addOnLoadedCallback(textDocumentService::revalidateAll);
   }
@@ -143,6 +146,7 @@ public final class SparqlLanguageServer implements LanguageServer, LanguageClien
   public CompletableFuture<Object> shutdown() {
     schemaManager.shutdown();
     textDocumentService.shutdown();
+    notebookCommandHandler.shutdown();
     return CompletableFuture.completedFuture(null);
   }
 

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlWorkspaceService.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlWorkspaceService.java
@@ -24,6 +24,7 @@ import de.soptim.opencgmes.cimvocabcheck.core.ConfigTemplate;
 import de.soptim.opencgmes.cimvocabcheck.core.SparqlValidationApi;
 import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
 import de.soptim.opencgmes.cimvocabcheck.core.explain.QueryExplanation;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookCommandHandler;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
@@ -58,9 +59,12 @@ final class SparqlWorkspaceService implements WorkspaceService {
   static final String CMD_CREATE_CONFIG = "cimvocabcheck.createConfig";
 
   private final SchemaManager schemaManager;
+  private final NotebookCommandHandler notebookCommandHandler;
 
-  SparqlWorkspaceService(SchemaManager schemaManager) {
+  SparqlWorkspaceService(
+      SchemaManager schemaManager, NotebookCommandHandler notebookCommandHandler) {
     this.schemaManager = schemaManager;
+    this.notebookCommandHandler = notebookCommandHandler;
   }
 
   @Override
@@ -91,6 +95,9 @@ final class SparqlWorkspaceService implements WorkspaceService {
   public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
     if (CMD_CREATE_CONFIG.equals(params.getCommand())) {
       return CompletableFuture.completedFuture(ConfigTemplate.defaultJson());
+    }
+    if (NotebookCommandHandler.CMD_EXECUTE.equals(params.getCommand())) {
+      return notebookCommandHandler.executeCommand(params.getArguments());
     }
     if (!CMD_EXPLAIN_QUERY.equals(params.getCommand())) {
       LOG.warn("Unknown command: {}", params.getCommand());

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CancellationWatchdog.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CancellationWatchdog.java
@@ -1,0 +1,73 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Polls a {@link CancelChecker} on a background scheduler and runs a callback the first time it
+ * reports cancellation.
+ *
+ * <p>Used by {@link HttpQueryExecutor} to react to a client-sent {@code $/cancelRequest}, since
+ * Jena's blocking HTTP execution calls have no cancellation hook of their own — polling {@link
+ * CancelChecker#isCanceled()} (a non-throwing check) is simpler here than reacting to {@link
+ * CancelChecker#checkCanceled()}'s thrown exception on every poll.
+ */
+final class CancellationWatchdog {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CancellationWatchdog.class);
+  private static final long POLL_INTERVAL_MS = 250;
+
+  private CancellationWatchdog() {}
+
+  /**
+   * Starts polling {@code cancelChecker} every {@value #POLL_INTERVAL_MS}ms on {@code scheduler}.
+   * The first poll that observes cancellation runs {@code onCancel} exactly once. The caller must
+   * cancel the returned task (typically in a {@code finally} block) once the guarded operation
+   * finishes, whether normally or exceptionally.
+   */
+  static ScheduledFuture<?> watch(
+      ScheduledExecutorService scheduler, CancelChecker cancelChecker, Runnable onCancel) {
+    AtomicBoolean triggered = new AtomicBoolean(false);
+    return scheduler.scheduleWithFixedDelay(
+        () -> {
+          if (cancelChecker.isCanceled() && triggered.compareAndSet(false, true)) {
+            try {
+              onCancel.run();
+            } catch (RuntimeException e) {
+              // The guarded operation may already have finished on its own (e.g. the abort()
+              // callback racing a just-completed execution) — this is a best-effort signal, not
+              // a hard requirement, so a failure here is logged and swallowed rather than
+              // propagated to the scheduler (which would otherwise silently stop future polls).
+              LOG.debug(
+                  "Cancellation callback failed (likely already finished): {}", e.getMessage());
+            }
+          }
+        },
+        POLL_INTERVAL_MS,
+        POLL_INTERVAL_MS,
+        TimeUnit.MILLISECONDS);
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
@@ -1,0 +1,57 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Machine-readable failure reason reported in {@link ExecError#code()}.
+ *
+ * <p>Local-file targets (and their file-specific failure modes) are added once local-file execution
+ * is implemented; every code needed for HTTP-endpoint execution is declared here.
+ */
+enum ErrorCode {
+  /** The command argument could not be parsed as an {@link ExecuteRequest} at all. */
+  INVALID_REQUEST,
+
+  /** No endpoint is configured for the cell (missing/blank {@code target}). */
+  NO_TARGET,
+
+  /** The cell's text is neither a valid SPARQL query nor a valid SPARQL Update request. */
+  PARSE_ERROR,
+
+  /**
+   * The cell parsed as a SPARQL Update, but its target has no update endpoint configured (see
+   * {@link ExecuteTarget#updateUrl()}).
+   */
+  UPDATE_NOT_ALLOWED,
+
+  /** The endpoint answered with an HTTP error, or the connection otherwise failed. */
+  HTTP_ERROR,
+
+  /** The endpoint rejected the request as unauthorized/forbidden (HTTP 401/403). */
+  AUTH_FAILED,
+
+  /** The request did not complete within the configured timeout. */
+  TIMEOUT,
+
+  /** The client cancelled the execution before it completed. */
+  CANCELLED,
+
+  /** An unexpected internal error occurred while handling the request. */
+  INTERNAL
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecError.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecError.java
@@ -1,0 +1,37 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Failure details reported when {@link ExecuteResponse#status()} is not {@code SUCCESS}.
+ *
+ * @param code machine-readable failure reason: the {@link ErrorCode} name. Carried as a string
+ *     because lsp4j's message Gson serializes enum fields as ordinals, which no client should have
+ *     to decode (pinned by {@code NotebookCommandHandlerTest}).
+ * @param message human-readable message, suitable for display in the cell's error output.
+ * @param detail additional detail (e.g. a parser error's underlying cause); {@code null} if none.
+ * @param line 1-based source line of a parse error; {@code null} if not applicable/unknown.
+ * @param column 1-based source column of a parse error; {@code null} if not applicable/unknown.
+ */
+record ExecError(String code, String message, String detail, Integer line, Integer column) {
+
+  ExecError(ErrorCode code, String message, String detail, Integer line, Integer column) {
+    this(code.name(), message, detail, line, column);
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecStats.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecStats.java
@@ -1,0 +1,30 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Execution metadata reported alongside a successful {@link ExecuteResponse}.
+ *
+ * @param durationMs wall-clock execution time in milliseconds.
+ * @param rowCount number of result rows (SELECT) or triples (CONSTRUCT/DESCRIBE) returned; {@code
+ *     null} for ASK and UPDATE.
+ * @param truncated whether the result was cut off at the {@code maxRows} limit.
+ * @param resolvedTarget the endpoint URL actually queried/updated.
+ */
+record ExecStats(long durationMs, Integer rowCount, boolean truncated, String resolvedTarget) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteOptions.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteOptions.java
@@ -1,0 +1,29 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Per-execution overrides for the server-side defaults (see {@link
+ * HttpQueryExecutor#DEFAULT_TIMEOUT_MS} / {@link HttpQueryExecutor#DEFAULT_MAX_ROWS}).
+ *
+ * @param timeoutMs request timeout in milliseconds, or {@code null} to use the default.
+ * @param maxRows maximum number of solutions/triples to include in the result before truncating, or
+ *     {@code null} to use the default.
+ */
+record ExecuteOptions(Integer timeoutMs, Integer maxRows) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteRequest.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteRequest.java
@@ -1,0 +1,33 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Argument of the {@code cimvocabcheck.notebook.execute} workspace command, sent by the VS Code
+ * notebook controller for each cell execution.
+ *
+ * @param cellUri URI of the executing cell; used only for logging/diagnostics.
+ * @param languageId the cell's language id (e.g. {@code sparql}).
+ * @param text the cell's source text.
+ * @param target the endpoint to execute against, resolved client-side; {@code null} when the cell
+ *     (and its notebook) has no {@code # [endpoint=...]} directive.
+ * @param options per-execution overrides; {@code null} to use all defaults.
+ */
+record ExecuteRequest(
+    String cellUri, String languageId, String text, ExecuteTarget target, ExecuteOptions options) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteResponse.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteResponse.java
@@ -1,0 +1,81 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Result of the {@code cimvocabcheck.notebook.execute} workspace command.
+ *
+ * <p>{@code resultsJson} (SELECT/ASK) and {@code turtle} (CONSTRUCT/DESCRIBE) are opaque,
+ * pre-serialized payload strings — the client renders them without re-interpreting their structure
+ * beyond the {@code queryKind} tag. At most one of the two is set; both are {@code null} for a
+ * successful UPDATE and for any non-{@code SUCCESS} status.
+ *
+ * @param status the outcome of the execution: an {@link ExecutionStatus} name. Status and kind are
+ *     carried as strings because lsp4j's message Gson serializes enum fields as ordinals, which no
+ *     client should have to decode (pinned by {@code NotebookCommandHandlerTest}).
+ * @param queryKind the detected kind of the cell's text: a {@link QueryKind} name; {@code null}
+ *     unless {@code status} is {@code SUCCESS}.
+ * @param resultsJson SPARQL 1.1 Query Results JSON for a SELECT or ASK, {@code null} otherwise.
+ * @param turtle Turtle serialization of the result graph for a CONSTRUCT or DESCRIBE, {@code null}
+ *     otherwise.
+ * @param stats execution metadata; {@code null} unless {@code status} is {@code SUCCESS}.
+ * @param error failure details; {@code null} unless {@code status} is not {@code SUCCESS}.
+ */
+record ExecuteResponse(
+    String status,
+    String queryKind,
+    String resultsJson,
+    String turtle,
+    ExecStats stats,
+    ExecError error) {
+
+  /** A successful SELECT or ASK execution. */
+  static ExecuteResponse successJson(QueryKind kind, String resultsJson, ExecStats stats) {
+    return new ExecuteResponse(
+        ExecutionStatus.SUCCESS.name(), kind.name(), resultsJson, null, stats, null);
+  }
+
+  /** A successful CONSTRUCT or DESCRIBE execution. */
+  static ExecuteResponse successTurtle(QueryKind kind, String turtle, ExecStats stats) {
+    return new ExecuteResponse(
+        ExecutionStatus.SUCCESS.name(), kind.name(), null, turtle, stats, null);
+  }
+
+  /** A successful UPDATE execution (no result payload). */
+  static ExecuteResponse successUpdate(ExecStats stats) {
+    return new ExecuteResponse(
+        ExecutionStatus.SUCCESS.name(), QueryKind.UPDATE.name(), null, null, stats, null);
+  }
+
+  /** A failed execution. */
+  static ExecuteResponse failed(ExecError error) {
+    return new ExecuteResponse(ExecutionStatus.ERROR.name(), null, null, null, null, error);
+  }
+
+  /** An execution that was cancelled before it produced a result. */
+  static ExecuteResponse cancelled() {
+    return new ExecuteResponse(
+        ExecutionStatus.CANCELLED.name(),
+        null,
+        null,
+        null,
+        null,
+        new ExecError(ErrorCode.CANCELLED, "Execution was cancelled.", null, null, null));
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
@@ -1,0 +1,36 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * The endpoint a cell is executed against, resolved client-side from the cell's {@code #
+ * [endpoint=...]} directive (see {@code EndpointDirective} in the parent package).
+ *
+ * @param type {@code "http"} for a remote SPARQL endpoint; other target types (local file, SHACL)
+ *     are added in later milestones.
+ * @param url the SPARQL query endpoint URL.
+ * @param updateUrl the SPARQL Update endpoint URL. {@code null}/blank means this target has no
+ *     configured update endpoint, so a cell that parses as a SPARQL Update is rejected with {@link
+ *     ErrorCode#UPDATE_NOT_ALLOWED} rather than silently reusing {@link #url()}.
+ */
+record ExecuteTarget(String type, String url, String updateUrl) {
+
+  /** The only target {@link #type()} understood in this milestone. */
+  static final String TYPE_HTTP = "http";
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecutionStatus.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecutionStatus.java
@@ -1,0 +1,26 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/** Outcome of a single {@code cimvocabcheck.notebook.execute} call. */
+enum ExecutionStatus {
+  SUCCESS,
+  ERROR,
+  CANCELLED
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
@@ -1,0 +1,289 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.net.http.HttpTimeoutException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.jena.atlas.web.HttpException;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
+import org.apache.jena.sparql.exec.http.UpdateExecutionHTTP;
+import org.apache.jena.update.UpdateExecution;
+import org.apache.jena.update.UpdateRequest;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a parsed SPARQL query or update against an HTTP endpoint, applying the request timeout,
+ * result truncation, and client-cancellation wiring.
+ *
+ * <p><b>Cancellation.</b> Jena's {@code QueryExecution.abort()} reliably interrupts an in-flight
+ * HTTP query — verified empirically against Jena 6.1.0 — but the symmetric {@code
+ * UpdateExecution.abort()} does not: an in-flight {@code UpdateExecutionHTTP.execute()} call keeps
+ * blocking until the request's own timeout elapses regardless of {@code abort()} being called from
+ * another thread. Rather than rely on that asymmetric, version-specific behavior, the blocking Jena
+ * call always runs on a background task ({@link #runCancellable}) raced against a {@link
+ * CancellationWatchdog}-driven signal: whichever finishes first — the real result, or the
+ * cancellation signal — determines the response. {@code abort()} is still called as a best-effort
+ * courtesy (it does help for queries, and costs nothing when it does not), but correctness of the
+ * client-visible CANCELLED outcome never depends on it. One consequence: a cancelled UPDATE's HTTP
+ * request may continue running against the endpoint in the background until it completes or times
+ * out; the notebook simply stops waiting for it.
+ */
+final class HttpQueryExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpQueryExecutor.class);
+
+  /** Default request timeout, matching {@code SchemaManager}'s remote-fetch timeout. */
+  static final int DEFAULT_TIMEOUT_MS = 30_000;
+
+  /** Default cap on returned rows/triples before the result is marked truncated. */
+  static final int DEFAULT_MAX_ROWS = 10_000;
+
+  private HttpQueryExecutor() {}
+
+  /**
+   * Resources a single execution needs for cancellation wiring, bundled to keep call sites short.
+   */
+  record ExecContext(
+      ExecutorService executionPool,
+      ScheduledExecutorService watchdogScheduler,
+      CancelChecker cancelChecker) {}
+
+  /**
+   * Executes a SELECT/ASK/CONSTRUCT/DESCRIBE query, returning a populated {@link ExecuteResponse}.
+   */
+  static ExecuteResponse executeQuery(
+      Query query, QueryKind kind, ExecuteTarget target, ExecuteOptions options, ExecContext ctx) {
+    ExecError targetError = checkTarget(target);
+    if (targetError != null) {
+      return ExecuteResponse.failed(targetError);
+    }
+
+    String url = target.url();
+    int maxRows = maxRows(options);
+    QueryExecution qe =
+        QueryExecutionHTTP.service(url)
+            .query(query)
+            .timeout(timeoutMs(options), TimeUnit.MILLISECONDS)
+            .build();
+    return runCancellable(
+        ctx,
+        qe::abort,
+        () -> {
+          try (qe) {
+            return runQuery(qe, kind, url, maxRows);
+          }
+        });
+  }
+
+  /** Executes a SPARQL Update request, returning a populated {@link ExecuteResponse}. */
+  static ExecuteResponse executeUpdate(
+      UpdateRequest update, ExecuteTarget target, ExecuteOptions options, ExecContext ctx) {
+    ExecError targetError = checkTarget(target);
+    if (targetError != null) {
+      return ExecuteResponse.failed(targetError);
+    }
+    String updateUrl = target.updateUrl();
+    if (isBlank(updateUrl)) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.UPDATE_NOT_ALLOWED,
+              "No update endpoint configured for this target.",
+              null,
+              null,
+              null));
+    }
+
+    UpdateExecution ue =
+        UpdateExecutionHTTP.service(updateUrl)
+            .update(update)
+            .timeout(timeoutMs(options), TimeUnit.MILLISECONDS)
+            .build();
+    return runCancellable(ctx, ue::abort, () -> runUpdate(ue, updateUrl));
+  }
+
+  // ---- query/update execution (runs on ctx.executionPool()) -------------------------------
+
+  private static ExecuteResponse runQuery(
+      QueryExecution qe, QueryKind kind, String url, int maxRows) {
+    long start = System.currentTimeMillis();
+    try {
+      return switch (kind) {
+        case SELECT -> {
+          ResultSerializer.Serialized s = ResultSerializer.selectToJson(qe.execSelect(), maxRows);
+          yield ExecuteResponse.successJson(
+              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
+        }
+        case ASK -> {
+          String json = ResultSerializer.askToJson(qe.execAsk());
+          yield ExecuteResponse.successJson(kind, json, stats(start, null, false, url));
+        }
+        case CONSTRUCT -> {
+          ResultSerializer.Serialized s =
+              ResultSerializer.constructToTurtle(qe.execConstructTriples(), maxRows);
+          yield ExecuteResponse.successTurtle(
+              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
+        }
+        case DESCRIBE -> {
+          ResultSerializer.Serialized s =
+              ResultSerializer.constructToTurtle(qe.execDescribeTriples(), maxRows);
+          yield ExecuteResponse.successTurtle(
+              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
+        }
+        case UPDATE ->
+            throw new IllegalStateException("UPDATE must be routed through executeUpdate(...)");
+      };
+    } catch (QueryExceptionHTTP e) {
+      return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
+    } catch (CancellationException e) {
+      // Expected fallout of runCancellable's best-effort qe.abort(): the cancelFuture race has
+      // already been won by the time this unwinds, so the returned value is discarded, but avoid
+      // logging a normal user-initiated cancellation as an unexpected internal error.
+      LOG.debug("{} query aborted after cancellation", kind);
+      return ExecuteResponse.cancelled();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error executing {} query: {}", kind, e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  private static ExecuteResponse runUpdate(UpdateExecution ue, String updateUrl) {
+    long start = System.currentTimeMillis();
+    try {
+      ue.execute();
+      return ExecuteResponse.successUpdate(stats(start, null, false, updateUrl));
+    } catch (HttpException e) {
+      return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
+    } catch (CancellationException e) {
+      // See the matching catch in runQuery: expected fallout of a best-effort abort() racing
+      // against (and losing to) cancelFuture, not a genuine internal error.
+      LOG.debug("Update aborted after cancellation");
+      return ExecuteResponse.cancelled();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error executing update: {}", e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  // ---- cancellation racing -----------------------------------------------------------------
+
+  /**
+   * Runs {@code work} on {@code ctx.executionPool()} and races it against cancellation of {@code
+   * ctx.cancelChecker()}, returning whichever resolves first. {@code bestEffortAbort} is invoked
+   * (on the watchdog thread) the moment cancellation is observed, as a courtesy to unblock {@code
+   * work} sooner where the underlying Jena execution supports it — see the class-level note on why
+   * this is not relied upon for correctness.
+   */
+  private static ExecuteResponse runCancellable(
+      ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work) {
+    CompletableFuture<ExecuteResponse> workFuture =
+        CompletableFuture.supplyAsync(work, ctx.executionPool());
+    CompletableFuture<ExecuteResponse> cancelFuture = new CompletableFuture<>();
+
+    ScheduledFuture<?> watchdogTask =
+        CancellationWatchdog.watch(
+            ctx.watchdogScheduler(),
+            ctx.cancelChecker(),
+            () -> {
+              // Complete cancelFuture before aborting: aborting can itself unblock the blocked
+              // Jena call on ctx.executionPool(), which would otherwise race workFuture's own
+              // completion against cancelFuture below. Signalling cancellation first guarantees
+              // workFuture cannot win that race as a side effect of the abort it triggers.
+              cancelFuture.complete(ExecuteResponse.cancelled());
+              bestEffortAbort.run();
+            });
+    try {
+      return workFuture.applyToEither(cancelFuture, Function.identity()).join();
+    } finally {
+      watchdogTask.cancel(true);
+    }
+  }
+
+  // ---- error classification ----------------------------------------------------------------
+
+  private static ExecError classify(int statusCode, String message, Throwable causeChain) {
+    if (hasCause(causeChain, HttpTimeoutException.class)) {
+      return new ExecError(ErrorCode.TIMEOUT, "Request timed out.", message, null, null);
+    }
+    if (statusCode == 401 || statusCode == 403) {
+      return new ExecError(
+          ErrorCode.AUTH_FAILED,
+          "Authentication failed (HTTP " + statusCode + ").",
+          message,
+          null,
+          null);
+    }
+    return new ExecError(ErrorCode.HTTP_ERROR, message, null, null, null);
+  }
+
+  private static boolean hasCause(Throwable t, Class<? extends Throwable> type) {
+    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      if (type.isInstance(cur)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // ---- small helpers ------------------------------------------------------------------------
+
+  private static ExecError checkTarget(ExecuteTarget target) {
+    if (target == null || isBlank(target.url())) {
+      return new ExecError(
+          ErrorCode.NO_TARGET,
+          "No endpoint configured. Add a `# [endpoint=<url>]` directive to the cell.",
+          null,
+          null,
+          null);
+    }
+    return null;
+  }
+
+  private static ExecStats stats(
+      long startMs, Integer rowCount, boolean truncated, String resolvedTarget) {
+    return new ExecStats(System.currentTimeMillis() - startMs, rowCount, truncated, resolvedTarget);
+  }
+
+  private static long timeoutMs(ExecuteOptions options) {
+    return options != null && options.timeoutMs() != null
+        ? options.timeoutMs()
+        : DEFAULT_TIMEOUT_MS;
+  }
+
+  private static int maxRows(ExecuteOptions options) {
+    return options != null && options.maxRows() != null ? options.maxRows() : DEFAULT_MAX_ROWS;
+  }
+
+  private static boolean isBlank(String s) {
+    return s == null || s.isBlank();
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -1,0 +1,153 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles the {@value #CMD_EXECUTE} workspace command: runs a notebook cell's SPARQL query or
+ * update against the endpoint resolved by the client, and returns an {@link ExecuteResponse}.
+ *
+ * <p>Wired into {@code SparqlWorkspaceService#executeCommand} by {@code SparqlLanguageServer},
+ * which also forwards {@link #shutdown()} from its own shutdown sequence.
+ */
+public final class NotebookCommandHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookCommandHandler.class);
+  private static final Gson GSON = new Gson();
+
+  /** Command id for cell execution (see {@link #executeCommand}). */
+  public static final String CMD_EXECUTE = "cimvocabcheck.notebook.execute";
+
+  /**
+   * Pool the blocking Jena HTTP call runs on. Must stay unbounded (cached, not fixed): {@link
+   * HttpQueryExecutor#executeQuery} submits its own nested task to this same pool and joins on it
+   * from the calling thread, so a fixed-size pool could deadlock once all threads are blocked
+   * waiting on a nested task that has no thread left to run on.
+   */
+  private final ExecutorService executionPool =
+      Executors.newCachedThreadPool(threadFactory("cimvocabcheck-notebook-exec"));
+
+  private final ScheduledExecutorService watchdogScheduler =
+      Executors.newSingleThreadScheduledExecutor(threadFactory("cimvocabcheck-notebook-watchdog"));
+
+  /**
+   * Handles one {@value #CMD_EXECUTE} invocation. {@code arguments} must have a single element that
+   * Gson-deserializes to an {@link ExecuteRequest}; over JSON-RPC this arrives as a {@link
+   * JsonElement}, while a direct in-process call may pass a JSON {@link String}.
+   */
+  public CompletableFuture<Object> executeCommand(List<Object> arguments) {
+    ExecuteRequest request;
+    try {
+      request = parseRequest(arguments);
+    } catch (RuntimeException e) {
+      return CompletableFuture.failedFuture(
+          new ResponseErrorException(
+              new ResponseError(
+                  ResponseErrorCode.InvalidParams,
+                  "Malformed " + CMD_EXECUTE + " argument: " + e.getMessage(),
+                  null)));
+    }
+    return CompletableFutures.computeAsync(
+        executionPool, cancelChecker -> doExecute(request, cancelChecker));
+  }
+
+  /** Releases the thread pools. Safe to call once during server shutdown. */
+  public void shutdown() {
+    executionPool.shutdown();
+    watchdogScheduler.shutdown();
+    try {
+      if (!executionPool.awaitTermination(2, TimeUnit.SECONDS)) {
+        executionPool.shutdownNow();
+      }
+      if (!watchdogScheduler.awaitTermination(2, TimeUnit.SECONDS)) {
+        watchdogScheduler.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      executionPool.shutdownNow();
+      watchdogScheduler.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private Object doExecute(ExecuteRequest request, CancelChecker cancelChecker) {
+    LOG.debug("Executing {} cell {}", request.languageId(), request.cellUri());
+    try {
+      var ctx = new HttpQueryExecutor.ExecContext(executionPool, watchdogScheduler, cancelChecker);
+      return switch (QueryKindDetector.detect(request.text())) {
+        case QueryKindDetector.AsQuery(var kind, var query) ->
+            HttpQueryExecutor.executeQuery(query, kind, request.target(), request.options(), ctx);
+        case QueryKindDetector.AsUpdate(var update) ->
+            HttpQueryExecutor.executeUpdate(update, request.target(), request.options(), ctx);
+        case QueryKindDetector.ParseFailure(var message, var line, var column) ->
+            ExecuteResponse.failed(
+                new ExecError(ErrorCode.PARSE_ERROR, message, null, line, column));
+      };
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error handling {}: {}", CMD_EXECUTE, e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  /**
+   * Extracts and deserializes the command's single argument. Over JSON-RPC, lsp4j delivers
+   * arguments as Gson {@link JsonElement}s; a direct in-process call may pass a JSON {@link String}
+   * instead — mirrors the dual-case handling in {@code SparqlWorkspaceService}.
+   */
+  private static ExecuteRequest parseRequest(List<Object> arguments) {
+    if (arguments == null || arguments.isEmpty() || arguments.get(0) == null) {
+      throw new IllegalArgumentException("missing required argument");
+    }
+    Object first = arguments.get(0);
+    ExecuteRequest request =
+        first instanceof JsonElement el
+            ? GSON.fromJson(el, ExecuteRequest.class)
+            : GSON.fromJson(first.toString(), ExecuteRequest.class);
+    if (request == null || request.text() == null) {
+      throw new IllegalArgumentException("missing required field 'text'");
+    }
+    return request;
+  }
+
+  private static ThreadFactory threadFactory(String namePrefix) {
+    AtomicInteger threadNum = new AtomicInteger(1);
+    return r -> {
+      Thread t = new Thread(r, namePrefix + "-" + threadNum.getAndIncrement());
+      t.setDaemon(true);
+      return t;
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKind.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKind.java
@@ -1,0 +1,28 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/** The kind of SPARQL operation a cell's text was classified as by {@link QueryKindDetector}. */
+enum QueryKind {
+  SELECT,
+  ASK,
+  CONSTRUCT,
+  DESCRIBE,
+  UPDATE
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKindDetector.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKindDetector.java
@@ -1,0 +1,87 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import de.soptim.opencgmes.cimvocabcheck.core.InvalidQueryException;
+import de.soptim.opencgmes.cimvocabcheck.core.analysis.SparqlQueryAnalyzer;
+import org.apache.jena.query.Query;
+import org.apache.jena.update.UpdateRequest;
+
+/**
+ * Classifies a cell's text as a SPARQL query (with its {@link QueryKind}) or a SPARQL Update
+ * request, by attempting both parses in turn.
+ *
+ * <p>Reuses {@link SparqlQueryAnalyzer#parse} / {@link SparqlQueryAnalyzer#parseUpdate} directly
+ * rather than a separate parsing path, so notebook execution shares the same base-IRI policy
+ * ({@link SparqlQueryAnalyzer#RELATIVE_IRI_BASE}) as validation.
+ */
+final class QueryKindDetector {
+
+  private QueryKindDetector() {}
+
+  /** Outcome of classifying a cell's text. */
+  sealed interface Result {}
+
+  /** The text parsed as a SPARQL query of the given {@link QueryKind}. */
+  record AsQuery(QueryKind kind, Query query) implements Result {}
+
+  /** The text parsed as a SPARQL Update request. */
+  record AsUpdate(UpdateRequest update) implements Result {}
+
+  /** The text is neither a valid query nor a valid update. */
+  record ParseFailure(String message, Integer line, Integer column) implements Result {}
+
+  /**
+   * Attempts to parse {@code text} as a SPARQL query first, then as a SPARQL Update request. If
+   * both fail, the <em>query</em> parser's error is reported — matching the fallback precedent in
+   * {@code SparqlValidationApi#validateAutoDetectRaw}.
+   */
+  static Result detect(String text) {
+    SparqlQueryAnalyzer analyzer = new SparqlQueryAnalyzer();
+    InvalidQueryException queryError;
+    try {
+      Query query = analyzer.parse(text);
+      return new AsQuery(kindOf(query), query);
+    } catch (InvalidQueryException e) {
+      queryError = e;
+    }
+    try {
+      return new AsUpdate(analyzer.parseUpdate(text));
+    } catch (InvalidQueryException ignored) {
+      // Neither parse succeeded — report the query error, per SparqlValidationApi precedent.
+      return new ParseFailure(queryError.getMessage(), queryError.line(), queryError.column());
+    }
+  }
+
+  private static QueryKind kindOf(Query query) {
+    if (query.isSelectType()) {
+      return QueryKind.SELECT;
+    }
+    if (query.isAskType()) {
+      return QueryKind.ASK;
+    }
+    if (query.isConstructType()) {
+      return QueryKind.CONSTRUCT;
+    }
+    if (query.isDescribeType()) {
+      return QueryKind.DESCRIBE;
+    }
+    throw new IllegalStateException("Unknown query type: " + query);
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ResultSerializer.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ResultSerializer.java
@@ -1,0 +1,139 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.io.StringWriter;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+
+/**
+ * Serializes Jena query results to the wire formats used by {@link ExecuteResponse}: SPARQL 1.1
+ * Query Results JSON for SELECT/ASK, Turtle for CONSTRUCT/DESCRIBE.
+ *
+ * <p>SELECT and CONSTRUCT/DESCRIBE results are truncated at a caller-supplied row/triple limit.
+ * Jena's {@code ResultSetFormatter} has no such limit and no boolean/ASK overload, so results are
+ * hand-built here; CONSTRUCT/DESCRIBE consume the streaming {@code execConstructTriples()} / {@code
+ * execDescribeTriples()} iterators (not the materializing {@code execConstruct()} / {@code
+ * execDescribe()}) so an oversized result is never fully loaded into memory.
+ */
+final class ResultSerializer {
+
+  /** A literal's datatype is omitted from the JSON output when it is this (RDF 1.1 default). */
+  private static final String XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+  private ResultSerializer() {}
+
+  /** A serialized result payload together with truncation bookkeeping for {@link ExecStats}. */
+  record Serialized(String payload, int count, boolean truncated) {}
+
+  /** Serializes a SELECT result to SPARQL 1.1 Query Results JSON, truncated at {@code maxRows}. */
+  static Serialized selectToJson(ResultSet rs, int maxRows) {
+    List<String> varNames = rs.getResultVars();
+
+    JsonObject head = new JsonObject();
+    JsonArray vars = new JsonArray();
+    varNames.forEach(vars::add);
+    head.add("vars", vars);
+
+    JsonArray bindings = new JsonArray();
+    int count = 0;
+    while (rs.hasNext() && count < maxRows) {
+      QuerySolution sol = rs.next();
+      JsonObject binding = new JsonObject();
+      for (String var : varNames) {
+        RDFNode node = sol.get(var);
+        if (node != null) {
+          binding.add(var, termToJson(node));
+        }
+      }
+      bindings.add(binding);
+      count++;
+    }
+
+    JsonObject results = new JsonObject();
+    results.add("bindings", bindings);
+
+    JsonObject root = new JsonObject();
+    root.add("head", head);
+    root.add("results", results);
+    return new Serialized(root.toString(), count, rs.hasNext());
+  }
+
+  /** Serializes an ASK result to SPARQL 1.1 Query Results JSON. */
+  static String askToJson(boolean result) {
+    JsonObject root = new JsonObject();
+    root.add("head", new JsonObject());
+    root.addProperty("boolean", result);
+    return root.toString();
+  }
+
+  /**
+   * Serializes a CONSTRUCT/DESCRIBE triple stream to Turtle, truncated at {@code maxTriples}. Pulls
+   * at most {@code maxTriples} elements from {@code triples} via {@code next()}; the truncation
+   * check afterward is a plain {@code hasNext()} peek, so an oversized or streaming result is never
+   * fully materialized just to detect truncation.
+   */
+  static Serialized constructToTurtle(Iterator<Triple> triples, int maxTriples) {
+    Model model = ModelFactory.createDefaultModel();
+    int count = 0;
+    while (triples.hasNext() && count < maxTriples) {
+      model.getGraph().add(triples.next());
+      count++;
+    }
+    boolean truncated = triples.hasNext();
+
+    StringWriter sw = new StringWriter();
+    RDFDataMgr.write(sw, model, RDFFormat.TURTLE_PRETTY);
+    return new Serialized(sw.toString(), count, truncated);
+  }
+
+  private static JsonObject termToJson(RDFNode node) {
+    JsonObject obj = new JsonObject();
+    if (node.isURIResource()) {
+      obj.addProperty("type", "uri");
+      obj.addProperty("value", node.asResource().getURI());
+    } else if (node.isAnon()) {
+      obj.addProperty("type", "bnode");
+      obj.addProperty("value", node.asResource().getId().getLabelString());
+    } else {
+      Literal literal = node.asLiteral();
+      obj.addProperty("type", "literal");
+      obj.addProperty("value", literal.getLexicalForm());
+      String lang = literal.getLanguage();
+      String datatype = literal.getDatatypeURI();
+      if (lang != null && !lang.isEmpty()) {
+        obj.addProperty("xml:lang", lang);
+      } else if (datatype != null && !XSD_STRING.equals(datatype)) {
+        obj.addProperty("datatype", datatype);
+      }
+    }
+    return obj;
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CancellationWatchdogTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/CancellationWatchdogTest.java
@@ -1,0 +1,141 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CancellationWatchdogTest {
+
+  private ScheduledExecutorService scheduler;
+
+  @Before
+  public void setUp() {
+    scheduler = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  @After
+  public void tearDown() {
+    scheduler.shutdownNow();
+  }
+
+  @Test
+  public void firesOnCancelWhenCancelCheckerReportsCancelled() throws InterruptedException {
+    CountDownLatch fired = new CountDownLatch(1);
+    FlagCancelChecker checker = new FlagCancelChecker();
+    checker.cancel();
+
+    ScheduledFuture<?> task = CancellationWatchdog.watch(scheduler, checker, fired::countDown);
+    try {
+      assertTrue(
+          "onCancel should fire shortly after cancellation", fired.await(2, TimeUnit.SECONDS));
+    } finally {
+      task.cancel(true);
+    }
+  }
+
+  @Test
+  public void neverFiresWhenNeverCancelled() throws InterruptedException {
+    CountDownLatch fired = new CountDownLatch(1);
+    FlagCancelChecker checker = new FlagCancelChecker();
+
+    ScheduledFuture<?> task = CancellationWatchdog.watch(scheduler, checker, fired::countDown);
+    try {
+      assertFalse(
+          "onCancel must not fire while never cancelled", fired.await(600, TimeUnit.MILLISECONDS));
+    } finally {
+      task.cancel(true);
+    }
+  }
+
+  @Test
+  public void firesOnCancelExactlyOnceAcrossMultiplePolls() throws InterruptedException {
+    AtomicInteger fireCount = new AtomicInteger();
+    FlagCancelChecker checker = new FlagCancelChecker();
+    checker.cancel();
+
+    ScheduledFuture<?> task =
+        CancellationWatchdog.watch(scheduler, checker, fireCount::incrementAndGet);
+    try {
+      // Let several poll intervals elapse; the guard must keep the callback to a single firing.
+      Thread.sleep(900);
+      assertEquals(1, fireCount.get());
+    } finally {
+      task.cancel(true);
+    }
+  }
+
+  @Test
+  public void exceptionFromOnCancelIsSwallowed() throws InterruptedException {
+    FlagCancelChecker checker = new FlagCancelChecker();
+    checker.cancel();
+    CountDownLatch invoked = new CountDownLatch(1);
+
+    ScheduledFuture<?> task =
+        CancellationWatchdog.watch(
+            scheduler,
+            checker,
+            () -> {
+              invoked.countDown();
+              throw new IllegalStateException("boom — guarded operation already finished");
+            });
+    try {
+      // The callback running (and throwing) must not propagate out of the scheduler or prevent
+      // the scheduled task itself from remaining alive/cancellable.
+      assertTrue(invoked.await(2, TimeUnit.SECONDS));
+      assertFalse(task.isDone());
+    } finally {
+      task.cancel(true);
+    }
+  }
+
+  /** A simple settable {@link CancelChecker} test double. */
+  private static final class FlagCancelChecker implements CancelChecker {
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    void cancel() {
+      cancelled.set(true);
+    }
+
+    @Override
+    public void checkCanceled() {
+      if (cancelled.get()) {
+        throw new RuntimeException("cancelled");
+      }
+    }
+
+    @Override
+    public boolean isCanceled() {
+      return cancelled.get();
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
@@ -1,0 +1,521 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class HttpQueryExecutorTest {
+
+  private static final String EX = "http://example.org/";
+  private static final AtomicInteger SUBJECT_COUNTER = new AtomicInteger();
+
+  private static final CancelChecker NEVER_CANCELLED =
+      new CancelChecker() {
+        @Override
+        public void checkCanceled() {}
+
+        @Override
+        public boolean isCanceled() {
+          return false;
+        }
+      };
+
+  private static FusekiServer fuseki;
+  private static String queryUrl;
+  private static String updateUrl;
+
+  private ExecutorService executionPool;
+  private ScheduledExecutorService watchdogScheduler;
+
+  @BeforeClass
+  public static void startFuseki() {
+    fuseki =
+        FusekiServer.create()
+            .port(0)
+            .add("/ds", DatasetGraphFactory.createTxnMem())
+            .build()
+            .start();
+    queryUrl = fuseki.serverURL() + "ds";
+    updateUrl = fuseki.serverURL() + "ds/update";
+  }
+
+  @AfterClass
+  public static void stopFuseki() {
+    fuseki.stop();
+  }
+
+  @Before
+  public void setUp() {
+    executionPool = Executors.newCachedThreadPool();
+    watchdogScheduler = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  @After
+  public void tearDown() {
+    executionPool.shutdownNow();
+    watchdogScheduler.shutdownNow();
+  }
+
+  // ---- happy paths (against the shared in-process Fuseki dataset) --------------------------
+
+  @Test
+  public void executeUpdateInsertsDataVisibleToASubsequentQuery() {
+    String subject = uniqueSubject();
+    var update = UpdateFactory.create("INSERT DATA { <" + subject + "> <" + EX + "p> \"v\" }");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(
+            update, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.UPDATE.name(), response.queryKind());
+    assertNull(response.error());
+    assertNotNull(response.stats());
+    assertEquals(updateUrl, response.stats().resolvedTarget());
+
+    Query ask = QueryFactory.create("ASK { <" + subject + "> <" + EX + "p> \"v\" }");
+    ExecuteResponse askResponse =
+        HttpQueryExecutor.executeQuery(
+            ask, QueryKind.ASK, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+    assertEquals(ExecutionStatus.SUCCESS.name(), askResponse.status());
+    assertTrue(asBoolean(askResponse));
+  }
+
+  @Test
+  public void executeQueryAskReturnsFalseWhenNoMatch() {
+    Query ask = QueryFactory.create("ASK { <" + EX + "does-not-exist> <" + EX + "p> ?o }");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            ask, QueryKind.ASK, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertFalse(asBoolean(response));
+  }
+
+  @Test
+  public void executeQuerySelectReturnsAllRowsUnderTheLimit() {
+    String subject = uniqueSubject();
+    insertTriples(subject, 3);
+    Query select = QueryFactory.create("SELECT ?o WHERE { <" + subject + "> <" + EX + "p> ?o }");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            select, QueryKind.SELECT, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.SELECT.name(), response.queryKind());
+    assertNotNull(response.resultsJson());
+    assertNull(response.turtle());
+    assertFalse(response.stats().truncated());
+    assertEquals(3, response.stats().rowCount().intValue());
+    assertEquals(
+        3,
+        JsonParser.parseString(response.resultsJson())
+            .getAsJsonObject()
+            .getAsJsonObject("results")
+            .getAsJsonArray("bindings")
+            .size());
+  }
+
+  @Test
+  public void executeQuerySelectTruncatesAtConfiguredMaxRows() {
+    String subject = uniqueSubject();
+    insertTriples(subject, 5);
+    Query select = QueryFactory.create("SELECT ?o WHERE { <" + subject + "> <" + EX + "p> ?o }");
+    var options = new ExecuteOptions(null, 2);
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            select, QueryKind.SELECT, target(queryUrl, updateUrl), options, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertTrue(response.stats().truncated());
+    assertEquals(2, response.stats().rowCount().intValue());
+  }
+
+  @Test
+  public void executeQueryConstructReturnsParseableTurtle() {
+    String subject = uniqueSubject();
+    insertTriples(subject, 2);
+    Query construct =
+        QueryFactory.create(
+            "CONSTRUCT { <"
+                + subject
+                + "> <"
+                + EX
+                + "p> ?o } WHERE { <"
+                + subject
+                + "> <"
+                + EX
+                + "p> ?o }");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            construct,
+            QueryKind.CONSTRUCT,
+            target(queryUrl, updateUrl),
+            null,
+            ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.CONSTRUCT.name(), response.queryKind());
+    assertNull(response.resultsJson());
+    assertNotNull(response.turtle());
+    assertEquals(2, parseTurtle(response.turtle()).size());
+  }
+
+  @Test
+  public void executeQueryDescribeReturnsParseableTurtle() {
+    String subject = uniqueSubject();
+    insertTriples(subject, 1);
+    Query describe = QueryFactory.create("DESCRIBE <" + subject + ">");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            describe, QueryKind.DESCRIBE, target(queryUrl, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertNotNull(response.turtle());
+    assertEquals(1, parseTurtle(response.turtle()).size());
+  }
+
+  // ---- target/validation errors --------------------------------------------------------------
+
+  @Test
+  public void executeQueryFailsWithNoTargetWhenTargetIsNull() {
+    Query ask = QueryFactory.create("ASK {}");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(ask, QueryKind.ASK, null, null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  @Test
+  public void executeQueryFailsWithNoTargetWhenUrlIsBlank() {
+    Query ask = QueryFactory.create("ASK {}");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            ask, QueryKind.ASK, target("   ", null), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  @Test
+  public void executeUpdateFailsWithUpdateNotAllowedWhenUpdateUrlIsBlank() {
+    var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(update, target(queryUrl, null), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.UPDATE_NOT_ALLOWED.name(), response.error().code());
+  }
+
+  @Test
+  public void executeUpdateFailsWithNoTargetWhenTargetIsNull() {
+    var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(update, null, null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  @Test
+  public void executeUpdateFailsWithNoTargetWhenQueryUrlIsBlankEvenIfUpdateUrlIsSet() {
+    // The query url is the base "is anything configured at all" check and applies uniformly to
+    // both executeQuery and executeUpdate; a blank query url is NO_TARGET even when updateUrl is
+    // present. In practice the client always derives both urls from the same directive, so this
+    // combination should not arise, but the precedence is worth pinning down explicitly.
+    var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(
+            update, target(null, updateUrl), null, ctx(NEVER_CANCELLED));
+
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  // ---- transport-level failures (against a throwaway JDK HttpServer) ------------------------
+
+  @Test
+  public void executeQueryReportsAuthFailedOn401() throws IOException {
+    HttpServer server = respondingWith(401, "unauthorized");
+    try {
+      Query ask = QueryFactory.create("ASK {}");
+      ExecuteResponse response =
+          HttpQueryExecutor.executeQuery(
+              ask, QueryKind.ASK, target(baseUrl(server), null), null, ctx(NEVER_CANCELLED));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.AUTH_FAILED.name(), response.error().code());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void executeQueryReportsHttpErrorOnServerError() throws IOException {
+    HttpServer server = respondingWith(500, "boom");
+    try {
+      Query ask = QueryFactory.create("ASK {}");
+      ExecuteResponse response =
+          HttpQueryExecutor.executeQuery(
+              ask, QueryKind.ASK, target(baseUrl(server), null), null, ctx(NEVER_CANCELLED));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.HTTP_ERROR.name(), response.error().code());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void executeQueryReportsHttpErrorOnConnectionRefused() throws IOException {
+    int freePort;
+    try (ServerSocket probe = new ServerSocket(0)) {
+      freePort = probe.getLocalPort();
+    }
+    Query ask = QueryFactory.create("ASK {}");
+
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            ask,
+            QueryKind.ASK,
+            target("http://localhost:" + freePort + "/nope", null),
+            null,
+            ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.HTTP_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void executeQueryReportsTimeoutWhenEndpointIsSlow() throws IOException {
+    HttpServer server = sleepingFor(2_000);
+    try {
+      Query ask = QueryFactory.create("ASK {}");
+      var options = new ExecuteOptions(200, null);
+
+      ExecuteResponse response =
+          HttpQueryExecutor.executeQuery(
+              ask, QueryKind.ASK, target(baseUrl(server), null), options, ctx(NEVER_CANCELLED));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.TIMEOUT.name(), response.error().code());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void executeUpdateReportsTimeoutWhenEndpointIsSlow() throws IOException {
+    HttpServer server = sleepingFor(2_000);
+    try {
+      var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+      var options = new ExecuteOptions(200, null);
+
+      ExecuteResponse response =
+          HttpQueryExecutor.executeUpdate(
+              update, target(queryUrl, baseUrl(server)), options, ctx(NEVER_CANCELLED));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.TIMEOUT.name(), response.error().code());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  // ---- cancellation ---------------------------------------------------------------------------
+
+  @Test
+  public void executeQueryReturnsCancelledBeforeTheSlowEndpointResponds() throws IOException {
+    HttpServer server = sleepingFor(5_000);
+    try {
+      Query ask = QueryFactory.create("ASK {}");
+      var options = new ExecuteOptions(20_000, null);
+
+      long start = System.nanoTime();
+      ExecuteResponse response =
+          HttpQueryExecutor.executeQuery(
+              ask, QueryKind.ASK, target(baseUrl(server), null), options, ctx(cancelAfter(300)));
+      long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+      assertEquals(ExecutionStatus.CANCELLED.name(), response.status());
+      assertEquals(ErrorCode.CANCELLED.name(), response.error().code());
+      assertTrue(
+          "expected to return well before the 5s server delay, took " + elapsedMs + "ms",
+          elapsedMs < 4_000);
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void executeUpdateReturnsCancelledEvenThoughAbortCannotUnblockIt() throws IOException {
+    // Regression test for the abort()-asymmetry documented on HttpQueryExecutor: unlike queries,
+    // UpdateExecution.abort() does not unblock a blocked execute() call, so this only passes
+    // because the race against the watchdog signal — not abort() — decides the outcome.
+    HttpServer server = sleepingFor(5_000);
+    try {
+      var update = UpdateFactory.create("INSERT DATA { <" + EX + "x> <" + EX + "p> 1 }");
+      var options = new ExecuteOptions(20_000, null);
+
+      long start = System.nanoTime();
+      ExecuteResponse response =
+          HttpQueryExecutor.executeUpdate(
+              update, target(queryUrl, baseUrl(server)), options, ctx(cancelAfter(300)));
+      long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+      assertEquals(ExecutionStatus.CANCELLED.name(), response.status());
+      assertTrue(
+          "expected to return well before the 5s server delay, took " + elapsedMs + "ms",
+          elapsedMs < 4_000);
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------------
+
+  private HttpQueryExecutor.ExecContext ctx(CancelChecker checker) {
+    return new HttpQueryExecutor.ExecContext(executionPool, watchdogScheduler, checker);
+  }
+
+  private static ExecuteTarget target(String url, String updateUrl) {
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl);
+  }
+
+  private static String uniqueSubject() {
+    return EX + "s" + SUBJECT_COUNTER.incrementAndGet();
+  }
+
+  private void insertTriples(String subject, int count) {
+    StringBuilder sb = new StringBuilder("INSERT DATA { ");
+    for (int i = 0; i < count; i++) {
+      sb.append('<').append(subject).append("> <").append(EX).append("p> ").append(i).append(" . ");
+    }
+    sb.append('}');
+    ExecuteResponse response =
+        HttpQueryExecutor.executeUpdate(
+            UpdateFactory.create(sb.toString()),
+            target(queryUrl, updateUrl),
+            null,
+            ctx(NEVER_CANCELLED));
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+  }
+
+  private static boolean asBoolean(ExecuteResponse response) {
+    return JsonParser.parseString(response.resultsJson())
+        .getAsJsonObject()
+        .get("boolean")
+        .getAsBoolean();
+  }
+
+  private static Model parseTurtle(String turtle) {
+    Model model = ModelFactory.createDefaultModel();
+    model.read(new java.io.StringReader(turtle), null, "TURTLE");
+    return model;
+  }
+
+  /** A {@link CancelChecker} that reports cancelled once {@code delayMs} has elapsed. */
+  private static CancelChecker cancelAfter(long delayMs) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayMs);
+    return new CancelChecker() {
+      @Override
+      public void checkCanceled() {}
+
+      @Override
+      public boolean isCanceled() {
+        return System.nanoTime() >= deadlineNanos;
+      }
+    };
+  }
+
+  private static String baseUrl(HttpServer server) {
+    return "http://localhost:" + server.getAddress().getPort() + "/endpoint";
+  }
+
+  private static HttpServer respondingWith(int status, String body) throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    server.createContext(
+        "/endpoint",
+        exchange -> {
+          try {
+            exchange.sendResponseHeaders(status, bytes.length);
+            exchange.getResponseBody().write(bytes);
+          } finally {
+            exchange.close();
+          }
+        });
+    server.setExecutor(Executors.newCachedThreadPool());
+    server.start();
+    return server;
+  }
+
+  private static HttpServer sleepingFor(long millis) throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext(
+        "/endpoint",
+        exchange -> {
+          try {
+            Thread.sleep(millis);
+            byte[] bytes = "{\"head\":{},\"boolean\":true}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/sparql-results+json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            exchange.close();
+          }
+        });
+    server.setExecutor(Executors.newCachedThreadPool());
+    server.start();
+    return server;
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -1,0 +1,268 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Exercises {@link NotebookCommandHandler#executeCommand} end to end, covering argument parsing
+ * (both the {@code JsonElement} and in-process {@code String} argument shapes handled by {@link
+ * NotebookCommandHandler}) and dispatch into {@link HttpQueryExecutor}. Query-execution behavior
+ * itself (timeouts, cancellation, HTTP error classification, etc.) is covered by {@link
+ * HttpQueryExecutorTest}; this class only needs enough of a real endpoint to prove that a
+ * successfully parsed request actually reaches it.
+ */
+public class NotebookCommandHandlerTest {
+
+  private static FusekiServer fuseki;
+  private static String queryUrl;
+  private static String updateUrl;
+
+  private NotebookCommandHandler handler;
+
+  @BeforeClass
+  public static void startFuseki() {
+    fuseki =
+        FusekiServer.create()
+            .port(0)
+            .add("/ds", DatasetGraphFactory.createTxnMem())
+            .build()
+            .start();
+    queryUrl = fuseki.serverURL() + "ds";
+    updateUrl = fuseki.serverURL() + "ds/update";
+  }
+
+  @AfterClass
+  public static void stopFuseki() {
+    fuseki.stop();
+  }
+
+  @Before
+  public void setUp() {
+    handler = new NotebookCommandHandler();
+  }
+
+  @After
+  public void tearDown() {
+    handler.shutdown();
+  }
+
+  // ---- malformed arguments (never reach HttpQueryExecutor) -----------------------------------
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenArgumentsIsNull() {
+    assertInvalidParams(handler.executeCommand(null));
+  }
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenArgumentsIsEmpty() {
+    assertInvalidParams(handler.executeCommand(List.of()));
+  }
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenFirstArgumentIsNull() {
+    List<Object> args = new ArrayList<>();
+    args.add(null);
+    assertInvalidParams(handler.executeCommand(args));
+  }
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenArgumentIsNotValidJson() {
+    assertInvalidParams(handler.executeCommand(List.of("not json at all")));
+  }
+
+  @Test
+  public void executeCommandFailsWithInvalidParamsWhenTextFieldIsMissing() {
+    JsonObject arg = new JsonObject();
+    arg.addProperty("cellUri", "file:///cell1.sparql");
+    assertInvalidParams(handler.executeCommand(List.of(arg)));
+  }
+
+  // ---- successful dispatch ---------------------------------------------------------------------
+
+  @Test
+  public void executeCommandDispatchesJsonElementArgumentAndExecutesAskQuery() throws Exception {
+    JsonObject arg = requestJson("ASK {}", queryUrl, updateUrl);
+
+    ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.ASK.name(), response.queryKind());
+  }
+
+  @Test
+  public void executeCommandDispatchesStringArgumentAndExecutesAskQuery() throws Exception {
+    // Mirrors a direct in-process call (as opposed to a JsonElement arriving over JSON-RPC): the
+    // same request serialized to a plain JSON string.
+    JsonObject arg = requestJson("ASK {}", queryUrl, updateUrl);
+
+    ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg.toString())));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.ASK.name(), response.queryKind());
+  }
+
+  // ---- requests that parse as arguments but fail during execution --------------------------
+
+  @Test
+  public void executeCommandReturnsParseErrorResponseWhenTextIsNotValidSparql() throws Exception {
+    JsonObject arg = requestJson("this is not sparql at all", null, null);
+
+    ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.PARSE_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void executeCommandReturnsNoTargetResponseWhenTargetIsMissing() throws Exception {
+    JsonObject arg = requestJson("ASK {}", null, null);
+
+    ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  // ---- wire shape ----------------------------------------------------------------------------
+
+  /**
+   * Pins the JSON the VS Code client actually parses: lsp4j encodes the {@link ExecuteResponse}
+   * returned from {@code workspace/executeCommand} with its message Gson, so record component names
+   * become the JSON keys and enums serialize as their names. The TypeScript mirror of this contract
+   * lives in {@code cimnotebook/vscode/src/notebook/endpoint.ts}.
+   */
+  @Test
+  public void executeResponseSerializesToTheWireShapeTheClientParses() throws Exception {
+    Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
+
+    JsonObject success =
+        wireGson
+            .toJsonTree(
+                getResponse(
+                    handler.executeCommand(
+                        List.of(
+                            requestJson(
+                                "SELECT ?s WHERE { VALUES ?s { <http://example.org/x> } }",
+                                queryUrl,
+                                updateUrl)))))
+            .getAsJsonObject();
+    assertEquals("SUCCESS", success.get("status").getAsString());
+    assertEquals("SELECT", success.get("queryKind").getAsString());
+    assertFalse("gson must omit the null error field", success.has("error"));
+    JsonObject stats = success.getAsJsonObject("stats");
+    assertTrue(stats.get("durationMs").getAsLong() >= 0);
+    assertEquals(queryUrl, stats.get("resolvedTarget").getAsString());
+    JsonObject results =
+        JsonParser.parseString(success.get("resultsJson").getAsString()).getAsJsonObject();
+    JsonObject binding =
+        results
+            .getAsJsonObject("results")
+            .getAsJsonArray("bindings")
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonObject("s");
+    assertEquals("uri", binding.get("type").getAsString());
+    assertEquals("http://example.org/x", binding.get("value").getAsString());
+
+    JsonObject failure =
+        wireGson
+            .toJsonTree(
+                getResponse(handler.executeCommand(List.of(requestJson("not sparql", null, null)))))
+            .getAsJsonObject();
+    assertEquals("ERROR", failure.get("status").getAsString());
+    JsonObject error = failure.getAsJsonObject("error");
+    assertEquals("PARSE_ERROR", error.get("code").getAsString());
+    assertFalse(error.get("message").getAsString().isEmpty());
+    if (error.has("line")) {
+      assertTrue(error.get("line").getAsInt() >= 1);
+    }
+  }
+
+  // ---- shutdown ----------------------------------------------------------------------------
+
+  @Test
+  public void shutdownIsIdempotent() {
+    handler.shutdown();
+    handler.shutdown();
+    // tearDown() below calls shutdown() a third time; ExecutorService#shutdown() is documented to
+    // have no additional effect once already shut down, so repeated calls must not throw.
+  }
+
+  // ---- helpers ------------------------------------------------------------------------------
+
+  private static JsonObject requestJson(String text, String url, String updateUrl) {
+    JsonObject arg = new JsonObject();
+    arg.addProperty("cellUri", "file:///cell1.sparql");
+    arg.addProperty("languageId", "sparql");
+    arg.addProperty("text", text);
+    if (url != null) {
+      JsonObject target = new JsonObject();
+      target.addProperty("type", ExecuteTarget.TYPE_HTTP);
+      target.addProperty("url", url);
+      if (updateUrl != null) {
+        target.addProperty("updateUrl", updateUrl);
+      }
+      arg.add("target", target);
+    }
+    return arg;
+  }
+
+  private static ExecuteResponse getResponse(CompletableFuture<Object> future) throws Exception {
+    return (ExecuteResponse) future.get();
+  }
+
+  private static void assertInvalidParams(CompletableFuture<Object> future) {
+    try {
+      future.get();
+      fail("expected the future to fail with InvalidParams");
+    } catch (ExecutionException e) {
+      assertTrue(
+          "expected a ResponseErrorException, got " + e.getCause(),
+          e.getCause() instanceof ResponseErrorException);
+      ResponseErrorException rex = (ResponseErrorException) e.getCause();
+      assertEquals(ResponseErrorCode.InvalidParams.getValue(), rex.getResponseError().getCode());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      fail("interrupted while waiting for the future");
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKindDetectorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/QueryKindDetectorTest.java
@@ -1,0 +1,104 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class QueryKindDetectorTest {
+
+  @Test
+  public void detectsSelect() {
+    var result = QueryKindDetector.detect("SELECT * WHERE { ?s ?p ?o }");
+    assertTrue(result instanceof QueryKindDetector.AsQuery);
+    var asQuery = (QueryKindDetector.AsQuery) result;
+    assertEquals(QueryKind.SELECT, asQuery.kind());
+  }
+
+  @Test
+  public void detectsAsk() {
+    var result = QueryKindDetector.detect("ASK { ?s ?p ?o }");
+    assertTrue(result instanceof QueryKindDetector.AsQuery);
+    assertEquals(QueryKind.ASK, ((QueryKindDetector.AsQuery) result).kind());
+  }
+
+  @Test
+  public void detectsConstruct() {
+    var result = QueryKindDetector.detect("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+    assertTrue(result instanceof QueryKindDetector.AsQuery);
+    assertEquals(QueryKind.CONSTRUCT, ((QueryKindDetector.AsQuery) result).kind());
+  }
+
+  @Test
+  public void detectsDescribe() {
+    var result = QueryKindDetector.detect("DESCRIBE <http://example.org/s>");
+    assertTrue(result instanceof QueryKindDetector.AsQuery);
+    assertEquals(QueryKind.DESCRIBE, ((QueryKindDetector.AsQuery) result).kind());
+  }
+
+  @Test
+  public void detectsInsertDataUpdate() {
+    var result =
+        QueryKindDetector.detect("INSERT DATA { <http://example.org/s> <http://example.org/p> 1 }");
+    assertTrue(result instanceof QueryKindDetector.AsUpdate);
+    assertNotNull(((QueryKindDetector.AsUpdate) result).update());
+  }
+
+  @Test
+  public void detectsDeleteWhereUpdate() {
+    var result = QueryKindDetector.detect("DELETE WHERE { ?s ?p ?o }");
+    assertTrue(result instanceof QueryKindDetector.AsUpdate);
+  }
+
+  @Test
+  public void reportsParseFailureWithPositionWhenTheParserProvidesOne() {
+    // An "expected token" parse error (as opposed to a lexical error, see below) carries a
+    // real 1-based line/column from Jena's parser.
+    var result = QueryKindDetector.detect("SELECT * WHERE { ?s ?p");
+    assertTrue(result instanceof QueryKindDetector.ParseFailure);
+    var failure = (QueryKindDetector.ParseFailure) result;
+    assertNotNull(failure.message());
+    assertEquals(Integer.valueOf(1), failure.line());
+    assertNotNull(failure.column());
+  }
+
+  @Test
+  public void reportsParseFailureWithoutPositionForLexicalErrors() {
+    // Jena reports some failures (e.g. a lexical error on completely non-SPARQL text) with
+    // line/column 0, which SparqlQueryAnalyzer normalizes to null rather than a misleading "0".
+    var result = QueryKindDetector.detect("this is not sparql at all");
+    assertTrue(result instanceof QueryKindDetector.ParseFailure);
+    var failure = (QueryKindDetector.ParseFailure) result;
+    assertNotNull(failure.message());
+    assertNull(failure.line());
+    assertNull(failure.column());
+  }
+
+  @Test
+  public void emptyTextParsesAsAnEmptySparqlUpdate() {
+    // A SPARQL Update request may contain zero operations, so blank/whitespace-only cell text
+    // is a valid (no-op) update rather than a parse failure.
+    var result = QueryKindDetector.detect("");
+    assertTrue(result instanceof QueryKindDetector.AsUpdate);
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ResultSerializerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ResultSerializerTest.java
@@ -1,0 +1,236 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.junit.Test;
+
+public class ResultSerializerTest {
+
+  private static final String EX = "http://example.org/";
+
+  @Test
+  public void selectToJsonSerializesEachTermKind() {
+    Model model = ModelFactory.createDefaultModel();
+    Resource s = model.createResource(EX + "s1");
+    Property p = model.createProperty(EX + "p");
+    s.addProperty(p, model.createResource(EX + "o1"));
+    s.addProperty(p, model.createResource());
+    s.addProperty(p, "plain");
+    s.addProperty(p, model.createLiteral("hello", "en"));
+    s.addProperty(p, model.createTypedLiteral("42", XSDDatatype.XSDinteger));
+
+    ResultSerializer.Serialized serialized;
+    try (QueryExecution qe =
+        QueryExecutionFactory.create(
+            "SELECT ?o WHERE { <" + EX + "s1> <" + EX + "p> ?o }", model)) {
+      serialized = ResultSerializer.selectToJson(qe.execSelect(), 100);
+    }
+
+    assertEquals(5, serialized.count());
+    assertFalse(serialized.truncated());
+
+    Set<String> descriptors = new HashSet<>();
+    for (JsonObject binding : bindings(serialized.payload())) {
+      JsonObject o = binding.getAsJsonObject("o");
+      String type = o.get("type").getAsString();
+      String value = o.get("value").getAsString();
+      String suffix =
+          o.has("xml:lang")
+              ? ";lang=" + o.get("xml:lang").getAsString()
+              : o.has("datatype") ? ";datatype=" + o.get("datatype").getAsString() : "";
+      descriptors.add(type + ":" + value + suffix);
+    }
+
+    assertEquals(5, descriptors.size());
+    assertTrue(descriptors.contains("uri:" + EX + "o1"));
+    assertTrue(descriptors.contains("literal:plain"));
+    assertTrue(descriptors.contains("literal:hello;lang=en"));
+    assertTrue(
+        descriptors.contains("literal:42;datatype=http://www.w3.org/2001/XMLSchema#integer"));
+    assertTrue(
+        "expected exactly one bnode term",
+        descriptors.stream().anyMatch(d -> d.startsWith("bnode:")));
+  }
+
+  @Test
+  public void selectToJsonOmitsDatatypeForPlainXsdString() {
+    Model model = ModelFactory.createDefaultModel();
+    Resource s = model.createResource(EX + "s1");
+    s.addProperty(
+        model.createProperty(EX + "p"),
+        model.createTypedLiteral("plain-typed", XSDDatatype.XSDstring));
+
+    ResultSerializer.Serialized serialized;
+    try (QueryExecution qe =
+        QueryExecutionFactory.create(
+            "SELECT ?o WHERE { <" + EX + "s1> <" + EX + "p> ?o }", model)) {
+      serialized = ResultSerializer.selectToJson(qe.execSelect(), 100);
+    }
+
+    JsonObject o = bindings(serialized.payload()).get(0).getAsJsonObject("o");
+    assertEquals("literal", o.get("type").getAsString());
+    assertFalse(
+        "xsd:string is the RDF 1.1 default and should not be emitted as an explicit datatype",
+        o.has("datatype"));
+  }
+
+  @Test
+  public void selectToJsonTruncatesAtMaxRows() {
+    Model model = ModelFactory.createDefaultModel();
+    Resource s = model.createResource(EX + "s1");
+    Property p = model.createProperty(EX + "p");
+    for (int i = 0; i < 5; i++) {
+      s.addProperty(p, model.createTypedLiteral(i));
+    }
+
+    ResultSerializer.Serialized serialized;
+    try (QueryExecution qe =
+        QueryExecutionFactory.create(
+            "SELECT ?o WHERE { <" + EX + "s1> <" + EX + "p> ?o }", model)) {
+      serialized = ResultSerializer.selectToJson(qe.execSelect(), 3);
+    }
+
+    assertEquals(3, serialized.count());
+    assertTrue(serialized.truncated());
+    assertEquals(3, bindings(serialized.payload()).size());
+  }
+
+  @Test
+  public void selectToJsonNotTruncatedWhenResultFitsExactlyAtMaxRows() {
+    Model model = ModelFactory.createDefaultModel();
+    Resource s = model.createResource(EX + "s1");
+    s.addProperty(model.createProperty(EX + "p"), model.createTypedLiteral(1));
+
+    ResultSerializer.Serialized serialized;
+    try (QueryExecution qe =
+        QueryExecutionFactory.create(
+            "SELECT ?o WHERE { <" + EX + "s1> <" + EX + "p> ?o }", model)) {
+      serialized = ResultSerializer.selectToJson(qe.execSelect(), 1);
+    }
+
+    assertEquals(1, serialized.count());
+    assertFalse(serialized.truncated());
+  }
+
+  @Test
+  public void askToJsonSerializesTrueAndFalse() {
+    JsonObject trueResult =
+        JsonParser.parseString(ResultSerializer.askToJson(true)).getAsJsonObject();
+    assertTrue(trueResult.get("boolean").getAsBoolean());
+
+    JsonObject falseResult =
+        JsonParser.parseString(ResultSerializer.askToJson(false)).getAsJsonObject();
+    assertFalse(falseResult.get("boolean").getAsBoolean());
+  }
+
+  @Test
+  public void constructToTurtleSerializesTriplesAsTurtle() {
+    List<Triple> triples =
+        List.of(
+            Triple.create(uri("s1"), uri("p"), uri("o1")),
+            Triple.create(uri("s1"), uri("p"), uri("o2")));
+
+    ResultSerializer.Serialized serialized =
+        ResultSerializer.constructToTurtle(triples.iterator(), 100);
+
+    assertEquals(2, serialized.count());
+    assertFalse(serialized.truncated());
+    // Parse the Turtle back to confirm it round-trips rather than asserting exact formatting.
+    Model roundTripped = ModelFactory.createDefaultModel();
+    roundTripped.read(new java.io.StringReader(serialized.payload()), null, "TURTLE");
+    assertEquals(2, roundTripped.size());
+  }
+
+  @Test
+  public void constructToTurtleTruncatesAtMaxTriplesWithoutConsumingWholeIterator() {
+    List<Triple> triples = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      triples.add(Triple.create(uri("s1"), uri("p"), uri("o" + i)));
+    }
+    // A spy iterator that counts how many elements are actually pulled via next(), to confirm
+    // the truncation cap stops before draining the whole (potentially oversized/streaming)
+    // source — checking truncation via a plain hasNext() call does not itself pull an element.
+    CountingIterator<Triple> counting = new CountingIterator<>(triples.iterator());
+
+    ResultSerializer.Serialized serialized = ResultSerializer.constructToTurtle(counting, 2);
+
+    assertEquals(2, serialized.count());
+    assertTrue(serialized.truncated());
+    assertEquals(2, counting.pulled);
+  }
+
+  private static Node uri(String localName) {
+    return NodeFactory.createURI(EX + localName);
+  }
+
+  private static List<JsonObject> bindings(String resultsJson) {
+    JsonObject root = JsonParser.parseString(resultsJson).getAsJsonObject();
+    JsonArray bindings = root.getAsJsonObject("results").getAsJsonArray("bindings");
+    List<JsonObject> out = new ArrayList<>();
+    for (JsonElement e : bindings) {
+      out.add(e.getAsJsonObject());
+    }
+    return out;
+  }
+
+  /** Wraps an iterator to count how many elements {@link #next()} actually returns. */
+  private static final class CountingIterator<T> implements Iterator<T> {
+    private final Iterator<T> delegate;
+    private int pulled;
+
+    CountingIterator(Iterator<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return delegate.hasNext();
+    }
+
+    @Override
+    public T next() {
+      T value = delegate.next();
+      pulled++;
+      return value;
+    }
+  }
+}


### PR DESCRIPTION
Adds the LSP-side execution backend behind the workspace command cimvocabcheck.notebook.execute: a cell's text is classified as a SPARQL query or update (reusing SparqlQueryAnalyzer, so execution shares the validator's base-IRI policy), run against an HTTP endpoint with Jena, and returned as an ExecuteResponse — SPARQL 1.1 Query Results JSON for SELECT/ASK, Turtle for CONSTRUCT/DESCRIBE.

Requests carry a timeout and a row cap; results report truncation. The blocking Jena call is raced against the client's $/cancelRequest rather than relying on Jena's abort(), whose support is asymmetric (QueryExecution.abort() interrupts an in-flight HTTP query, UpdateExecution.abort() does not). Enum fields cross the wire as names, not ordinals — lsp4j's Gson would otherwise serialize them as integers.

Closes #47