### PR TITLE
feat(cimnotebook): notebook kernel — execution, outputs, cancellation (GH-48)

### DIFF
--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -27,6 +27,7 @@ import {
 } from "vscode-languageclient/node";
 
 import { registerNotebookSerializers } from "./notebook/serializers";
+import { registerNotebookControllers } from "./notebook/controller";
 import { registerConvertCommand } from "./notebook/convert";
 
 const CHANNEL = "CIMNotebook";
@@ -59,8 +60,10 @@ export function activate(context: vscode.ExtensionContext): void {
     );
 
     // Native CIM Notebooks (markdown + .sparqlbook formats; cells are validated through
-    // the vscode-notebook-cell entries of the LSP documentSelector below).
+    // the vscode-notebook-cell entries of the LSP documentSelector below and executed
+    // via the server's cimvocabcheck.notebook.execute command).
     registerNotebookSerializers(context);
+    registerNotebookControllers(context, () => client);
     registerConvertCommand(context);
 
     try {

--- a/cimnotebook/vscode/src/notebook/controller.ts
+++ b/cimnotebook/vscode/src/notebook/controller.ts
@@ -1,0 +1,58 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Notebook controllers (kernels) for the three CIM Notebook types. VS Code binds a
+ * controller to exactly one notebook type, so each type gets its own controller instance;
+ * they share one {@link CellExecutor}. Cancellation uses the per-cell execution token
+ * (no `interruptHandler`), which the executor forwards to the language-server request.
+ */
+
+import * as vscode from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+import { CellExecutor } from "./executor";
+import { NOTEBOOK_TYPES } from "./serializers";
+
+export function registerNotebookControllers(
+    context: vscode.ExtensionContext,
+    getClient: () => LanguageClient | undefined,
+): void {
+    const executor = new CellExecutor(getClient);
+    let executionOrder = 0;
+
+    for (const notebookType of NOTEBOOK_TYPES) {
+        const controller = vscode.notebooks.createNotebookController(
+            `${notebookType}.controller`,
+            notebookType,
+            "CIM Notebook",
+        );
+        // SPARQL only until SHACL execution lands; the LSP still validates shacl cells.
+        controller.supportedLanguages = ["sparql"];
+        controller.supportsExecutionOrder = true;
+        controller.description = "Runs SPARQL cells via CIMLangServer";
+        controller.executeHandler = async (cells) => {
+            for (const cell of cells) {
+                const execution = controller.createNotebookCellExecution(cell);
+                execution.executionOrder = ++executionOrder;
+                await executor.execute(cell, execution);
+            }
+        };
+        context.subscriptions.push(controller);
+    }
+}

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -1,0 +1,91 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { deriveUpdateUrl, parseEndpointDirectives, resolveTarget } from "./endpoint";
+
+describe("parseEndpointDirectives", () => {
+    it("finds every directive, in order, with flexible spacing", () => {
+        const text = [
+            "# [endpoint=http://localhost:3030/ds/query]",
+            "#[endpoint=./local.ttl]",
+            "  #  [ endpoint = http://other/sparql ]",
+            "SELECT * WHERE { ?s ?p ?o }",
+        ].join("\n");
+        assert.deepEqual(parseEndpointDirectives(text), [
+            "http://localhost:3030/ds/query",
+            "./local.ttl",
+            "http://other/sparql",
+        ]);
+    });
+
+    it("ignores non-directive comments and directive-like text mid-line", () => {
+        assert.deepEqual(
+            parseEndpointDirectives("# endpoint=http://x\nSELECT 1 # [endpoint=http://y]"),
+            [],
+        );
+    });
+});
+
+describe("resolveTarget", () => {
+    it("returns none without a directive", () => {
+        assert.deepEqual(resolveTarget("SELECT * WHERE { ?s ?p ?o }"), { type: "none" });
+    });
+
+    it("picks the first http(s) directive and derives the update sibling", () => {
+        const target = resolveTarget("# [endpoint=https://host/ds/query]\nASK {}");
+        assert.deepEqual(target, {
+            type: "http",
+            url: "https://host/ds/query",
+            updateUrl: "https://host/ds/update",
+        });
+    });
+
+    it("reports non-URL directives as unsupported (files come later)", () => {
+        assert.deepEqual(resolveTarget("# [endpoint=./data.ttl]\nASK {}"), {
+            type: "unsupported",
+            directive: "./data.ttl",
+        });
+    });
+
+    it("skips file directives when an http one is also present", () => {
+        const target = resolveTarget(
+            "# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}",
+        );
+        assert.equal(target.type, "http");
+    });
+});
+
+describe("deriveUpdateUrl", () => {
+    it("maps Fuseki-style query/sparql services to the update sibling", () => {
+        assert.equal(deriveUpdateUrl("http://h:3030/ds/query"), "http://h:3030/ds/update");
+        assert.equal(deriveUpdateUrl("http://h/ds/sparql"), "http://h/ds/update");
+        assert.equal(deriveUpdateUrl("http://h/ds/QUERY"), "http://h/ds/update");
+    });
+
+    it("drops the query string when deriving the sibling", () => {
+        assert.equal(deriveUpdateUrl("http://h/ds/query?graph=urn:x"), "http://h/ds/update");
+    });
+
+    it("keeps other URLs unchanged (updates POST to the same endpoint)", () => {
+        assert.equal(deriveUpdateUrl("http://h/ds"), "http://h/ds");
+        assert.equal(deriveUpdateUrl("http://h/api/sparql-proxy"), "http://h/api/sparql-proxy");
+    });
+});

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -1,0 +1,113 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resolves a cell's execution target from its `# [endpoint=...]` directives — the same
+ * magic-comment syntax the language server reads to pick the validation schema, so one
+ * directive drives both "validate against" and "run against".
+ *
+ * Pure module (no `vscode` import); the LSP wire types for the
+ * `cimvocabcheck.notebook.execute` command live here too, mirroring the server's records
+ * in `cimvocabcheck/lsp/.../notebook/`.
+ */
+
+/** Same pattern as the server's `EndpointDirective` (value has no spaces or `]`). */
+const DIRECTIVE = /^\s*#\s*\[\s*endpoint\s*=\s*([^\]\s]+)\s*\]/gm;
+
+/** Returns every `# [endpoint=...]` value in the cell text, in order. */
+export function parseEndpointDirectives(text: string): string[] {
+    return [...text.matchAll(DIRECTIVE)].map((m) => m[1].trim());
+}
+
+export type ResolvedTarget =
+    | { type: "http"; url: string; updateUrl: string }
+    | { type: "unsupported"; directive: string }
+    | { type: "none" };
+
+/**
+ * Resolves the target for a cell: the first `http(s)://` directive wins. Non-URL
+ * directives (file paths, names) are recognised but not yet executable — they resolve to
+ * `unsupported` so the cell can show a precise message instead of a parse error.
+ */
+export function resolveTarget(cellText: string): ResolvedTarget {
+    const directives = parseEndpointDirectives(cellText);
+    if (directives.length === 0) {
+        return { type: "none" };
+    }
+    const url = directives.find((d) => /^https?:\/\//i.test(d));
+    if (url === undefined) {
+        return { type: "unsupported", directive: directives[0] };
+    }
+    return { type: "http", url, updateUrl: deriveUpdateUrl(url) };
+}
+
+/**
+ * Best-effort update endpoint for a query endpoint URL: Fuseki-style `…/query` or
+ * `…/sparql` services get their `…/update` sibling (dropping any query string); anything
+ * else is assumed to accept updates on the same URL. The server stays strict — it only
+ * executes updates against an explicit `updateUrl` — so this derivation is the client's
+ * deliberate choice, not a hidden server fallback.
+ */
+export function deriveUpdateUrl(url: string): string {
+    const sibling = /^(.*\/)(?:query|sparql)(?:\?.*)?$/i.exec(url);
+    return sibling ? sibling[1] + "update" : url;
+}
+
+// ---- Wire types for cimvocabcheck.notebook.execute (mirror the server's records) ----
+
+export const EXECUTE_COMMAND = "cimvocabcheck.notebook.execute";
+
+export interface ExecuteTarget {
+    type: "http";
+    url: string;
+    updateUrl?: string;
+}
+
+export interface ExecuteRequest {
+    cellUri: string;
+    languageId: string;
+    text: string;
+    target: ExecuteTarget;
+    options?: { timeoutMs?: number; maxRows?: number };
+}
+
+export type QueryKind = "SELECT" | "ASK" | "CONSTRUCT" | "DESCRIBE" | "UPDATE";
+
+export interface ExecError {
+    code: string;
+    message: string;
+    detail?: string | null;
+    line?: number | null;
+    column?: number | null;
+}
+
+export interface ExecStats {
+    durationMs: number;
+    rowCount?: number | null;
+    truncated: boolean;
+    resolvedTarget?: string | null;
+}
+
+export interface ExecuteResponse {
+    status: "SUCCESS" | "ERROR" | "CANCELLED";
+    queryKind?: QueryKind | null;
+    resultsJson?: string | null;
+    turtle?: string | null;
+    stats?: ExecStats | null;
+    error?: ExecError | null;
+}

--- a/cimnotebook/vscode/src/notebook/executor.ts
+++ b/cimnotebook/vscode/src/notebook/executor.ts
@@ -1,0 +1,173 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Executes one notebook cell through the language server's
+ * `cimvocabcheck.notebook.execute` workspace command and turns the response into cell
+ * outputs. Which MIME types those outputs carry — and, crucially, which one VS Code then
+ * picks to render — is decided in {@link outputItemsFor}.
+ */
+
+import * as vscode from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+import {
+    EXECUTE_COMMAND,
+    ExecError,
+    ExecuteRequest,
+    ExecuteResponse,
+    resolveTarget,
+} from "./endpoint";
+import { errorSummary, MIME_MARKDOWN, outputItemsFor } from "./outputs";
+
+export class CellExecutor {
+    constructor(private readonly getClient: () => LanguageClient | undefined) {}
+
+    async execute(
+        cell: vscode.NotebookCell,
+        execution: vscode.NotebookCellExecution,
+    ): Promise<void> {
+        execution.start(Date.now());
+        try {
+            const ok = await this.run(cell, execution);
+            execution.end(ok, Date.now());
+        } catch (err) {
+            if (execution.token.isCancellationRequested) {
+                // The request was torn down by the Stop button; no error to report.
+                await replaceMarkdown(execution, "*Execution cancelled.*");
+                execution.end(false, Date.now());
+                return;
+            }
+            const message = err instanceof Error ? err.message : String(err);
+            await execution.replaceOutput(
+                new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.error(new Error(message)),
+                ]),
+            );
+            execution.end(false, Date.now());
+        }
+    }
+
+    private async run(
+        cell: vscode.NotebookCell,
+        execution: vscode.NotebookCellExecution,
+    ): Promise<boolean> {
+        const client = this.getClient();
+        if (!client) {
+            await replaceMarkdown(
+                execution,
+                "**Language server is not running.** Reload the window or check the CIMNotebook output channel.",
+            );
+            return false;
+        }
+
+        const text = cell.document.getText();
+        const target = resolveTarget(text);
+        if (target.type === "none") {
+            await replaceMarkdown(
+                execution,
+                "**No endpoint configured.** Add a directive to the cell, e.g.\n\n" +
+                    "```\n# [endpoint=http://localhost:3030/dataset/query]\n```",
+            );
+            return false;
+        }
+        if (target.type === "unsupported") {
+            await replaceMarkdown(
+                execution,
+                `**Unsupported endpoint \`${target.directive}\`.** Only \`http(s)://\` URLs can ` +
+                    "be executed in this version; local files are used for validation only.",
+            );
+            return false;
+        }
+
+        const request: ExecuteRequest = {
+            cellUri: cell.document.uri.toString(),
+            languageId: cell.document.languageId,
+            text,
+            target: { type: "http", url: target.url, updateUrl: target.updateUrl },
+        };
+        const response = await client.sendRequest<ExecuteResponse>(
+            "workspace/executeCommand",
+            { command: EXECUTE_COMMAND, arguments: [request] },
+            execution.token,
+        );
+        return renderResponse(response, execution);
+    }
+}
+
+async function renderResponse(
+    response: ExecuteResponse | null | undefined,
+    execution: vscode.NotebookCellExecution,
+): Promise<boolean> {
+    if (!response) {
+        await replaceMarkdown(execution, "**No response from the language server.**");
+        return false;
+    }
+
+    if (response.status === "CANCELLED") {
+        await replaceMarkdown(execution, "*Execution cancelled.*");
+        return false;
+    }
+
+    if (response.status === "ERROR" || response.error) {
+        const error = response.error ?? { code: "INTERNAL", message: "Unknown error" };
+        await execution.replaceOutput(
+            new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.error(toError(error))]),
+        );
+        return false;
+    }
+
+    const items = outputItemsFor(response);
+    if (items.length === 0) {
+        await replaceMarkdown(
+            execution,
+            `**Unexpected result kind \`${response.queryKind ?? "?"}\`.**`,
+        );
+        return false;
+    }
+    await execution.replaceOutput(
+        new vscode.NotebookCellOutput(
+            items.map((item) => vscode.NotebookCellOutputItem.text(item.text, item.mime)),
+        ),
+    );
+    return true;
+}
+
+/**
+ * The error VS Code renders in its red output box. The server's `detail` (an endpoint's
+ * response body, a Jena message) goes into `stack`, which the renderer prints below the
+ * message — an accompanying markdown item would never be seen, since the items of one
+ * output are alternatives and the error MIME type outranks markdown.
+ */
+function toError(error: ExecError): Error {
+    const err = new Error(errorSummary(error));
+    err.name = "CIMNotebook";
+    err.stack = error.detail?.trimEnd() ?? "";
+    return err;
+}
+
+function markdownItem(markdown: string): vscode.NotebookCellOutputItem {
+    return vscode.NotebookCellOutputItem.text(markdown, MIME_MARKDOWN);
+}
+
+async function replaceMarkdown(
+    execution: vscode.NotebookCellExecution,
+    markdown: string,
+): Promise<void> {
+    await execution.replaceOutput(new vscode.NotebookCellOutput([markdownItem(markdown)]));
+}

--- a/cimnotebook/vscode/src/notebook/outputs.test.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.test.ts
@@ -1,0 +1,183 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    askResultToMarkdown,
+    DISPLAY_ROW_CAP,
+    errorSummary,
+    MIME_MARKDOWN,
+    outputItemsFor,
+    selectResultsToMarkdown,
+    turtleToMarkdown,
+    updateResultToMarkdown,
+} from "./outputs";
+
+function selectJson(bindings: Record<string, unknown>[], vars = ["s"]): string {
+    return JSON.stringify({ head: { vars }, results: { bindings } });
+}
+
+describe("selectResultsToMarkdown", () => {
+    it("renders a header and one row per binding", () => {
+        const md = selectResultsToMarkdown(
+            selectJson(
+                [
+                    { s: { type: "uri", value: "http://x/a" } },
+                    { s: { type: "literal", value: "plain" } },
+                ],
+                ["s"],
+            ),
+        );
+        assert.ok(md.startsWith("| s |\n| --- |\n| http://x/a |\n| plain |"));
+    });
+
+    it("renders lang and typed literals in Turtle-ish form, bnodes with _:", () => {
+        const md = selectResultsToMarkdown(
+            selectJson(
+                [
+                    {
+                        a: { type: "literal", value: "hi", "xml:lang": "en" },
+                        b: {
+                            type: "literal",
+                            value: "4",
+                            datatype: "http://www.w3.org/2001/XMLSchema#int",
+                        },
+                        c: { type: "bnode", value: "b0" },
+                    },
+                ],
+                ["a", "b", "c"],
+            ),
+        );
+        assert.ok(md.includes('"hi"@en'));
+        assert.ok(md.includes('"4"^^<http://www.w3.org/2001/XMLSchema#int>'));
+        assert.ok(md.includes("_:b0"));
+    });
+
+    it("leaves unbound variables empty and escapes pipes/newlines", () => {
+        const md = selectResultsToMarkdown(
+            selectJson([{ a: { type: "literal", value: "x|y\nz" } }], ["a", "b"]),
+        );
+        assert.ok(md.includes("| x\\|y<br>z |  |"));
+    });
+
+    it("caps the table at DISPLAY_ROW_CAP rows with a note", () => {
+        const rows = Array.from({ length: DISPLAY_ROW_CAP + 5 }, (_, i) => ({
+            s: { type: "literal", value: `row${i}` },
+        }));
+        const md = selectResultsToMarkdown(selectJson(rows));
+        assert.ok(md.includes(`first ${DISPLAY_ROW_CAP} of ${DISPLAY_ROW_CAP + 5} fetched rows`));
+        assert.ok(!md.includes(`row${DISPLAY_ROW_CAP}`));
+    });
+
+    it("shows an empty-result message and the stats footer", () => {
+        const md = selectResultsToMarkdown(selectJson([]), {
+            durationMs: 12,
+            rowCount: 0,
+            truncated: false,
+            resolvedTarget: "http://h/ds/query",
+        });
+        assert.ok(md.startsWith("*No results.*"));
+        assert.ok(md.includes("0 results · 12 ms · http://h/ds/query"));
+    });
+
+    it("marks server-side truncation in the footer", () => {
+        const md = selectResultsToMarkdown(selectJson([{ s: { type: "literal", value: "x" } }]), {
+            durationMs: 3,
+            rowCount: 10000,
+            truncated: true,
+            resolvedTarget: null,
+        });
+        assert.ok(md.includes("10000+ results (server cap reached)"));
+    });
+});
+
+describe("askResultToMarkdown", () => {
+    it("renders true and false verdicts", () => {
+        assert.ok(askResultToMarkdown('{"head":{},"boolean":true}').includes("**true**"));
+        assert.ok(askResultToMarkdown('{"head":{},"boolean":false}').includes("**false**"));
+    });
+});
+
+describe("turtleToMarkdown", () => {
+    it("fences the turtle payload", () => {
+        assert.equal(turtleToMarkdown("<a> <b> <c> .\n"), "```turtle\n<a> <b> <c> .\n```");
+    });
+
+    it("shows a message for an empty graph", () => {
+        assert.ok(turtleToMarkdown("   \n").startsWith("*Empty graph.*"));
+    });
+});
+
+describe("updateResultToMarkdown", () => {
+    it("confirms the update with stats", () => {
+        const md = updateResultToMarkdown({ durationMs: 8, truncated: false });
+        assert.ok(md.startsWith("✅ **Update executed.**"));
+        assert.ok(md.includes("8 ms"));
+    });
+});
+
+describe("error rendering", () => {
+    it("summarizes with code and parse position", () => {
+        assert.equal(
+            errorSummary({ code: "PARSE_ERROR", message: "bad token", line: 3, column: 7 }),
+            "PARSE_ERROR: bad token (line 3, column 7)",
+        );
+        assert.equal(errorSummary({ code: "HTTP_ERROR", message: "boom" }), "HTTP_ERROR: boom");
+    });
+});
+
+describe("outputItemsFor", () => {
+    // The items of one cell output are alternatives — VS Code renders the richest MIME type by
+    // its display order, which ranks application/json ABOVE text/markdown. An application/json
+    // item therefore hides the formatted result, whatever order the items are given in.
+    it("never offers application/json, which would outrank the markdown rendering", () => {
+        const responses = [
+            { status: "SUCCESS", queryKind: "SELECT", resultsJson: selectJson([]) },
+            { status: "SUCCESS", queryKind: "ASK", resultsJson: '{"boolean":true}' },
+            { status: "SUCCESS", queryKind: "CONSTRUCT", turtle: "<a> <b> <c> ." },
+            { status: "SUCCESS", queryKind: "UPDATE" },
+        ] as const;
+
+        for (const response of responses) {
+            const items = outputItemsFor(response);
+            assert.equal(items[0].mime, MIME_MARKDOWN, `${response.queryKind}: markdown first`);
+            assert.ok(
+                !items.some((i) => i.mime === "application/json"),
+                `${response.queryKind} must not offer application/json`,
+            );
+        }
+    });
+
+    it("carries the raw SELECT results alongside the table", () => {
+        const resultsJson = selectJson([{ s: { type: "uri", value: "http://x" } }]);
+        const items = outputItemsFor({ status: "SUCCESS", queryKind: "SELECT", resultsJson });
+
+        assert.deepEqual(
+            items.map((i) => i.mime),
+            [MIME_MARKDOWN, "application/sparql-results+json", "text/plain"],
+        );
+        assert.ok(items[0].text.includes("| http://x |"));
+        assert.equal(items[1].text, resultsJson);
+    });
+
+    it("has no items for an unknown result kind", () => {
+        assert.deepEqual(outputItemsFor({ status: "SUCCESS" }), []);
+    });
+});

--- a/cimnotebook/vscode/src/notebook/outputs.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.ts
@@ -1,0 +1,201 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Renders `cimvocabcheck.notebook.execute` responses as the items of one notebook cell
+ * output. Pure string module: the vscode `NotebookCellOutputItem` wrapping happens in the
+ * executor, so these builders stay unit-testable with plain `node --test`.
+ *
+ * The markdown item is the primary rendering (v1 ships no custom notebook renderer); the
+ * raw payload travels alongside under its own MIME type for other renderers and for
+ * *Change Presentation*.
+ */
+
+import { ExecError, ExecStats, ExecuteResponse } from "./endpoint";
+
+/** Rows shown in the markdown table; the raw output item carries the full result. */
+export const DISPLAY_ROW_CAP = 50;
+
+export const MIME_MARKDOWN = "text/markdown";
+export const MIME_SPARQL_JSON = "application/sparql-results+json";
+export const MIME_TEXT = "text/plain";
+
+/** One representation of a cell result — the executor turns these into output items. */
+export interface OutputItem {
+    mime: string;
+    text: string;
+}
+
+/**
+ * The items representing a successful result, primary rendering first.
+ *
+ * The items of one output are *alternatives*: VS Code renders exactly one of them, the
+ * richest MIME type by its display order. That order (`NOTEBOOK_DISPLAY_ORDER`) ranks
+ * **`application/json` above `text/markdown`**, so an `application/json` item silently
+ * wins over — and hides — the formatted table, whatever order the items are given in.
+ * Hence the raw results ship as `application/sparql-results+json` (which no built-in
+ * renderer claims) plus `text/plain` (which ranks *below* markdown, so it stays available
+ * under *Change Presentation* without taking over). Never add `application/json` here.
+ */
+export function outputItemsFor(response: ExecuteResponse): OutputItem[] {
+    const stats = response.stats;
+    switch (response.queryKind) {
+        case "SELECT": {
+            const resultsJson = response.resultsJson ?? "{}";
+            return [
+                { mime: MIME_MARKDOWN, text: selectResultsToMarkdown(resultsJson, stats) },
+                { mime: MIME_SPARQL_JSON, text: resultsJson },
+                { mime: MIME_TEXT, text: resultsJson },
+            ];
+        }
+        case "ASK": {
+            const resultsJson = response.resultsJson ?? "{}";
+            return [
+                { mime: MIME_MARKDOWN, text: askResultToMarkdown(resultsJson, stats) },
+                { mime: MIME_SPARQL_JSON, text: resultsJson },
+            ];
+        }
+        case "CONSTRUCT":
+        case "DESCRIBE": {
+            const turtle = response.turtle ?? "";
+            return [
+                { mime: MIME_MARKDOWN, text: turtleToMarkdown(turtle, stats) },
+                { mime: MIME_TEXT, text: turtle },
+            ];
+        }
+        case "UPDATE":
+            return [{ mime: MIME_MARKDOWN, text: updateResultToMarkdown(stats) }];
+        default:
+            return [];
+    }
+}
+
+interface SparqlResultsJson {
+    head: { vars?: string[] };
+    results?: { bindings: Record<string, SparqlTerm>[] };
+    boolean?: boolean;
+}
+
+interface SparqlTerm {
+    type: string;
+    value: string;
+    "xml:lang"?: string;
+    datatype?: string;
+}
+
+/** Markdown table for a SELECT result (SPARQL 1.1 Query Results JSON). */
+export function selectResultsToMarkdown(resultsJson: string, stats?: ExecStats | null): string {
+    const parsed = JSON.parse(resultsJson) as SparqlResultsJson;
+    const vars = parsed.head.vars ?? [];
+    const bindings = parsed.results?.bindings ?? [];
+
+    if (bindings.length === 0) {
+        return "*No results.*" + statsFooter(stats);
+    }
+
+    const header = `| ${vars.map(escapeCell).join(" | ")} |`;
+    const divider = `| ${vars.map(() => "---").join(" | ")} |`;
+    const rows = bindings
+        .slice(0, DISPLAY_ROW_CAP)
+        .map((b) => `| ${vars.map((v) => escapeCell(termToText(b[v]))).join(" | ")} |`);
+
+    const capNote =
+        bindings.length > DISPLAY_ROW_CAP
+            ? `\n\n*Table shows the first ${DISPLAY_ROW_CAP} of ${bindings.length} fetched rows.*`
+            : "";
+    return [header, divider, ...rows].join("\n") + capNote + statsFooter(stats);
+}
+
+/** Markdown verdict for an ASK result. */
+export function askResultToMarkdown(resultsJson: string, stats?: ExecStats | null): string {
+    const parsed = JSON.parse(resultsJson) as SparqlResultsJson;
+    return (parsed.boolean === true ? "✅ **true**" : "❌ **false**") + statsFooter(stats);
+}
+
+/** Fenced turtle block for a CONSTRUCT/DESCRIBE result. */
+export function turtleToMarkdown(turtle: string, stats?: ExecStats | null): string {
+    const body = turtle.trimEnd();
+    if (body.length === 0) {
+        return "*Empty graph.*" + statsFooter(stats);
+    }
+    return "```turtle\n" + body + "\n```" + statsFooter(stats);
+}
+
+/** Confirmation line for a successful UPDATE. */
+export function updateResultToMarkdown(stats?: ExecStats | null): string {
+    return "✅ **Update executed.**" + statsFooter(stats);
+}
+
+/** One-line summary for `NotebookCellOutputItem.error`, with parse position if known. */
+export function errorSummary(error: ExecError): string {
+    const position =
+        error.line != null
+            ? ` (line ${error.line}${error.column != null ? `, column ${error.column}` : ""})`
+            : "";
+    return `${error.code}: ${error.message}${position}`;
+}
+
+function statsFooter(stats?: ExecStats | null): string {
+    if (!stats) {
+        return "";
+    }
+    const parts: string[] = [];
+    if (stats.rowCount != null) {
+        parts.push(
+            stats.truncated
+                ? `${stats.rowCount}+ results (server cap reached)`
+                : `${stats.rowCount} results`,
+        );
+    }
+    parts.push(`${stats.durationMs} ms`);
+    if (stats.resolvedTarget) {
+        parts.push(stats.resolvedTarget);
+    }
+    return `\n\n<small>${parts.map(escapeHtml).join(" · ")}</small>`;
+}
+
+/** Escapes a value for use inside a markdown table cell. */
+function escapeCell(value: string): string {
+    return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>");
+}
+
+function escapeHtml(value: string | number): string {
+    return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Compact display text for one SPARQL JSON term. */
+function termToText(term: SparqlTerm | undefined): string {
+    if (term === undefined) {
+        return "";
+    }
+    switch (term.type) {
+        case "uri":
+            return term.value;
+        case "bnode":
+            return `_:${term.value}`;
+        default: {
+            if (term["xml:lang"]) {
+                return `"${term.value}"@${term["xml:lang"]}`;
+            }
+            if (term.datatype) {
+                return `"${term.value}"^^<${term.datatype}>`;
+            }
+            return term.value;
+        }
+    }
+}

--- a/cimnotebook/vscode/tsconfig.test.json
+++ b/cimnotebook/vscode/tsconfig.test.json
@@ -12,6 +12,8 @@
         "src/notebook/cells.ts",
         "src/notebook/markdown.ts",
         "src/notebook/sparqlbook.ts",
+        "src/notebook/endpoint.ts",
+        "src/notebook/outputs.ts",
         "src/notebook/*.test.ts"
     ]
 }

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -78,7 +78,47 @@ back) and opens it. The source file is never modified. Zazuko per-cell metadata 
 
 ## Running cells
 
-Cell execution (running SPARQL queries and SHACL validation against endpoints or local
-files) ships in an upcoming CIMNotebook release; today CIM Notebooks are an authoring and
-validation surface. To *run* `.sparqlbook` notebooks you can meanwhile keep using the Zazuko
-SPARQL Notebook extension side by side — CIMNotebook validates its cells too.
+SPARQL cells have a **Run** button (the *CIM Notebook* kernel). Execution happens inside
+CIMLangServer — the same Java process that validates your queries — using Apache Jena's
+SPARQL 1.1 engine, so there is nothing extra to install.
+
+A cell names its target with the same `# [endpoint=...]` directive used for validation —
+one directive drives both *validate against* and *run against*:
+
+```sparql
+# [endpoint=http://localhost:3030/cgmes/query]
+SELECT ?class (COUNT(?s) AS ?n)
+WHERE { ?s a ?class }
+GROUP BY ?class ORDER BY DESC(?n)
+```
+
+What you get per query kind:
+
+| Query                               | Output                                                                                                                    |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `SELECT`                            | Result table (first 50 rows rendered; the full result travels alongside as `application/sparql-results+json`) |
+| `ASK`                               | ✅ **true** / ❌ **false**                                                                                                |
+| `CONSTRUCT` / `DESCRIBE`            | The result graph as Turtle                                                                                                |
+| `INSERT` / `DELETE` / other updates | A confirmation with the update endpoint used                                                                              |
+
+Each output ends with a small stats line — row count, duration, and the resolved endpoint.
+Results are capped server-side (10 000 rows/triples by default) and the output says so when
+the cap was hit. The raw payload of a result is one click away: the output's **⋯ → Change
+Presentation** menu switches between the rendered view and the plain-text payload (the
+SPARQL Results JSON, or the Turtle of a graph/report).
+
+**Updates** run against the endpoint's update service: for Fuseki-style URLs the client
+derives it from the query URL (`…/query` or `…/sparql` → `…/update`); any other URL is
+assumed to accept updates directly.
+
+**Cancel and timeout.** The notebook Stop button cancels the running request (the server
+stops waiting and aborts the query where the endpoint supports it). Requests time out
+after 30 seconds by default.
+
+**Current limitations:**
+
+- Only `http(s)://` endpoints can be executed. A directive pointing at a local file is
+  still used for *validation*, but running such a cell reports it as unsupported —
+  querying local RDF and CIMXML files is planned next.
+- SHACL cells are validated statically but cannot be *run* yet.
+- No authentication support yet — the endpoint must be reachable without credentials.


### PR DESCRIPTION
Wires the notebook controllers (kernels) to the language server's execution command: running a cell sends its text and resolved target over LSP and renders the response. The Stop button cancels through the cell's execution token, which is forwarded to the server request.

Results render as a markdown table (SELECT), a verdict (ASK), or a fenced turtle block (CONSTRUCT/DESCRIBE), with the raw payload alongside for *Change Presentation*. A cell's target comes from its own `# [endpoint=...]` directive — the same magic comment the validator reads to pick a schema, so a cell validates against what it runs against.

Closes #48