### PR TITLE
feat(cimvocabcheck): run notebook cells against local RDF and CIMXML files (GH-49)

### DIFF
--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -58,14 +58,24 @@ describe("resolveTarget", () => {
         });
     });
 
-    it("reports non-URL directives as unsupported (files come later)", () => {
+    it("resolves a non-URL directive to a local-files target", () => {
         assert.deepEqual(resolveTarget("# [endpoint=./data.ttl]\nASK {}"), {
-            type: "unsupported",
-            directive: "./data.ttl",
+            type: "files",
+            files: ["./data.ttl"],
         });
     });
 
-    it("skips file directives when an http one is also present", () => {
+    it("collects every file directive into one union target, in order", () => {
+        assert.deepEqual(
+            resolveTarget("# [endpoint=./model.xml]\n# [endpoint=extra.ttl]\nASK {}"),
+            {
+                type: "files",
+                files: ["./model.xml", "extra.ttl"],
+            },
+        );
+    });
+
+    it("prefers the http directive when files are also present", () => {
         const target = resolveTarget(
             "# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}",
         );

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -36,13 +36,14 @@ export function parseEndpointDirectives(text: string): string[] {
 
 export type ResolvedTarget =
     | { type: "http"; url: string; updateUrl: string }
-    | { type: "unsupported"; directive: string }
+    | { type: "files"; files: string[] }
     | { type: "none" };
 
 /**
- * Resolves the target for a cell: the first `http(s)://` directive wins. Non-URL
- * directives (file paths, names) are recognised but not yet executable — they resolve to
- * `unsupported` so the cell can show a precise message instead of a parse error.
+ * Resolves the target for a cell: the first `http(s)://` directive wins; otherwise every
+ * directive is taken as a local file path and the cell queries their union. The server
+ * resolves relative paths against the notebook's directory — the same base validation
+ * uses — so one directive means one file for both.
  */
 export function resolveTarget(cellText: string): ResolvedTarget {
     const directives = parseEndpointDirectives(cellText);
@@ -51,7 +52,7 @@ export function resolveTarget(cellText: string): ResolvedTarget {
     }
     const url = directives.find((d) => /^https?:\/\//i.test(d));
     if (url === undefined) {
-        return { type: "unsupported", directive: directives[0] };
+        return { type: "files", files: directives };
     }
     return { type: "http", url, updateUrl: deriveUpdateUrl(url) };
 }
@@ -73,13 +74,16 @@ export function deriveUpdateUrl(url: string): string {
 export const EXECUTE_COMMAND = "cimvocabcheck.notebook.execute";
 
 export interface ExecuteTarget {
-    type: "http";
-    url: string;
+    type: "http" | "files";
+    url?: string;
     updateUrl?: string;
+    files?: string[];
 }
 
 export interface ExecuteRequest {
     cellUri: string;
+    /** Base for resolving relative file paths server-side; omitted for untitled notebooks. */
+    notebookUri?: string;
     languageId: string;
     text: string;
     target: ExecuteTarget;

--- a/cimnotebook/vscode/src/notebook/executor.ts
+++ b/cimnotebook/vscode/src/notebook/executor.ts
@@ -82,24 +82,22 @@ export class CellExecutor {
             await replaceMarkdown(
                 execution,
                 "**No endpoint configured.** Add a directive to the cell, e.g.\n\n" +
-                    "```\n# [endpoint=http://localhost:3030/dataset/query]\n```",
-            );
-            return false;
-        }
-        if (target.type === "unsupported") {
-            await replaceMarkdown(
-                execution,
-                `**Unsupported endpoint \`${target.directive}\`.** Only \`http(s)://\` URLs can ` +
-                    "be executed in this version; local files are used for validation only.",
+                    "```\n# [endpoint=http://localhost:3030/dataset/query]\n```\n\n" +
+                    "or point it at a local RDF or CIMXML file:\n\n" +
+                    "```\n# [endpoint=./model.xml]\n```",
             );
             return false;
         }
 
         const request: ExecuteRequest = {
             cellUri: cell.document.uri.toString(),
+            notebookUri: cell.notebook.uri.toString(),
             languageId: cell.document.languageId,
             text,
-            target: { type: "http", url: target.url, updateUrl: target.updateUrl },
+            target:
+                target.type === "http"
+                    ? { type: "http", url: target.url, updateUrl: target.updateUrl }
+                    : { type: "files", files: target.files },
         };
         const response = await client.sendRequest<ExecuteResponse>(
             "workspace/executeCommand",

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -126,6 +127,13 @@ final class SchemaManager {
   /** How long a failed endpoint load is negatively cached before a retry is allowed. */
   private static final Duration FAILURE_TTL = Duration.ofSeconds(30);
 
+  /**
+   * Extensions a local {@code # [endpoint=...]} directive must have to be loaded as a schema.
+   * Anything else (a CIMXML {@code .xml} model, {@code .nt}/{@code .nq}/{@code .trig} data) is
+   * instance data for notebook execution, not a schema — see {@link #resolveSchema}.
+   */
+  private static final Set<String> SCHEMA_FILE_EXTENSIONS = Set.of("ttl", "rdf", "owl");
+
   /** Schemas loaded from a {@code # [endpoint=...]} directive, keyed by resolved source. */
   private final Map<String, ResolvedSchema> endpointCache = new ConcurrentHashMap<>();
 
@@ -206,9 +214,27 @@ final class SchemaManager {
     if (endpoint == null || endpoint.isBlank()) {
       return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
     }
-    return isRemote(endpoint)
-        ? resolveRemote(endpoint)
-        : resolveLocal(resolveLocalEndpoint(endpoint, docDir));
+    if (isRemote(endpoint)) {
+      return resolveRemote(endpoint);
+    }
+    Path file = resolveLocalEndpoint(endpoint, docDir);
+    if (!isSchemaFile(file)) {
+      // The same # [endpoint=...] directive is also the notebook execution target, which may be
+      // instance data (a CIMXML model, an .nt/.nq/.trig dump). Loading that as a schema would
+      // produce misleading diagnostics, so validation quietly keeps the workspace schema instead.
+      LOG.debug("Endpoint directive {} is not a schema file; using the workspace schema", file);
+      return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
+    }
+    return resolveLocal(file);
+  }
+
+  /** Whether a local endpoint directive names a schema file (vs instance data — see above). */
+  private static boolean isSchemaFile(Path file) {
+    Path fileName = file.getFileName();
+    String name = fileName != null ? fileName.toString() : "";
+    int dot = name.lastIndexOf('.');
+    String extension = dot >= 0 ? name.substring(dot + 1).toLowerCase(Locale.ROOT) : "";
+    return SCHEMA_FILE_EXTENSIONS.contains(extension);
   }
 
   /**

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ErrorCode.java
@@ -18,12 +18,7 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
-/**
- * Machine-readable failure reason reported in {@link ExecError#code()}.
- *
- * <p>Local-file targets (and their file-specific failure modes) are added once local-file execution
- * is implemented; every code needed for HTTP-endpoint execution is declared here.
- */
+/** Machine-readable failure reason reported in {@link ExecError#code()}. */
 enum ErrorCode {
   /** The command argument could not be parsed as an {@link ExecuteRequest} at all. */
   INVALID_REQUEST,
@@ -35,10 +30,17 @@ enum ErrorCode {
   PARSE_ERROR,
 
   /**
-   * The cell parsed as a SPARQL Update, but its target has no update endpoint configured (see
-   * {@link ExecuteTarget#updateUrl()}).
+   * The cell parsed as a SPARQL Update, but its target cannot execute updates: an HTTP target
+   * without an update endpoint (see {@link ExecuteTarget#updateUrl()}), or a read-only local-file
+   * target.
    */
   UPDATE_NOT_ALLOWED,
+
+  /** A file named in {@link ExecuteTarget#files()} does not exist (or is not a regular file). */
+  FILE_NOT_FOUND,
+
+  /** A file named in {@link ExecuteTarget#files()} could not be parsed as RDF/CIMXML. */
+  FILE_PARSE_ERROR,
 
   /** The endpoint answered with an HTTP error, or the connection otherwise failed. */
   HTTP_ERROR,

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecContext.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecContext.java
@@ -18,12 +18,16 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
 /**
- * Per-execution overrides for the server-side defaults (see {@link ExecSupport#DEFAULT_TIMEOUT_MS}
- * / {@link ExecSupport#DEFAULT_MAX_ROWS}).
- *
- * @param timeoutMs request timeout in milliseconds, or {@code null} to use the default.
- * @param maxRows maximum number of solutions/triples to include in the result before truncating, or
- *     {@code null} to use the default.
+ * Resources a single cell execution needs for cancellation wiring, bundled to keep the executor
+ * call sites short. Shared by {@link HttpQueryExecutor} and {@link LocalQueryExecutor} via {@link
+ * ExecSupport#runCancellable}.
  */
-record ExecuteOptions(Integer timeoutMs, Integer maxRows) {}
+record ExecContext(
+    ExecutorService executionPool,
+    ScheduledExecutorService watchdogScheduler,
+    CancelChecker cancelChecker) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
@@ -1,0 +1,136 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.jena.query.QueryExecution;
+
+/**
+ * Execution plumbing shared by {@link HttpQueryExecutor} and {@link LocalQueryExecutor}:
+ * cancellation racing, the query-kind result dispatch, and option defaulting. The executors keep
+ * only what genuinely differs between them — how the {@link QueryExecution} is built and how its
+ * failures are classified.
+ *
+ * <p><b>Cancellation.</b> Jena's {@code abort()} support varies by execution type ({@code
+ * QueryExecution.abort()} interrupts an in-flight HTTP query, {@code UpdateExecution.abort()} does
+ * not — see {@link HttpQueryExecutor}), so the blocking Jena call always runs on a background task
+ * ({@link #runCancellable}) raced against a {@link CancellationWatchdog}-driven signal: whichever
+ * finishes first — the real result, or the cancellation signal — determines the response. {@code
+ * abort()} is still called as a best-effort courtesy to unblock the background task sooner, but the
+ * client-visible CANCELLED outcome never depends on it.
+ */
+final class ExecSupport {
+
+  /** Default request timeout, matching {@code SchemaManager}'s remote-fetch timeout. */
+  static final int DEFAULT_TIMEOUT_MS = 30_000;
+
+  /** Default cap on returned rows/triples before the result is marked truncated. */
+  static final int DEFAULT_MAX_ROWS = 10_000;
+
+  private ExecSupport() {}
+
+  /**
+   * Runs {@code work} on {@code ctx.executionPool()} and races it against cancellation of {@code
+   * ctx.cancelChecker()}, returning whichever resolves first. {@code bestEffortAbort} is invoked
+   * (on the watchdog thread) the moment cancellation is observed, as a courtesy to unblock {@code
+   * work} sooner where the underlying Jena execution supports it — see the class-level note on why
+   * this is not relied upon for correctness.
+   */
+  static ExecuteResponse runCancellable(
+      ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work) {
+    CompletableFuture<ExecuteResponse> workFuture =
+        CompletableFuture.supplyAsync(work, ctx.executionPool());
+    CompletableFuture<ExecuteResponse> cancelFuture = new CompletableFuture<>();
+
+    ScheduledFuture<?> watchdogTask =
+        CancellationWatchdog.watch(
+            ctx.watchdogScheduler(),
+            ctx.cancelChecker(),
+            () -> {
+              // Complete cancelFuture before aborting: aborting can itself unblock the blocked
+              // Jena call on ctx.executionPool(), which would otherwise race workFuture's own
+              // completion against cancelFuture below. Signalling cancellation first guarantees
+              // workFuture cannot win that race as a side effect of the abort it triggers.
+              cancelFuture.complete(ExecuteResponse.cancelled());
+              bestEffortAbort.run();
+            });
+    try {
+      return workFuture.applyToEither(cancelFuture, Function.identity()).join();
+    } finally {
+      watchdogTask.cancel(true);
+    }
+  }
+
+  /**
+   * Executes a SELECT/ASK/CONSTRUCT/DESCRIBE on an already-built {@link QueryExecution} and
+   * serializes the result into a success response. Exceptions propagate — each executor classifies
+   * its own failure modes ({@link HttpQueryExecutor}: HTTP status codes; {@link
+   * LocalQueryExecutor}: timeouts of the in-process engine).
+   */
+  static ExecuteResponse successFor(
+      QueryExecution qe, QueryKind kind, String resolvedTarget, int maxRows) {
+    long start = System.currentTimeMillis();
+    return switch (kind) {
+      case SELECT -> {
+        ResultSerializer.Serialized s = ResultSerializer.selectToJson(qe.execSelect(), maxRows);
+        yield ExecuteResponse.successJson(
+            kind, s.payload(), stats(start, s.count(), s.truncated(), resolvedTarget));
+      }
+      case ASK -> {
+        String json = ResultSerializer.askToJson(qe.execAsk());
+        yield ExecuteResponse.successJson(kind, json, stats(start, null, false, resolvedTarget));
+      }
+      case CONSTRUCT -> {
+        ResultSerializer.Serialized s =
+            ResultSerializer.constructToTurtle(qe.execConstructTriples(), maxRows);
+        yield ExecuteResponse.successTurtle(
+            kind, s.payload(), stats(start, s.count(), s.truncated(), resolvedTarget));
+      }
+      case DESCRIBE -> {
+        ResultSerializer.Serialized s =
+            ResultSerializer.constructToTurtle(qe.execDescribeTriples(), maxRows);
+        yield ExecuteResponse.successTurtle(
+            kind, s.payload(), stats(start, s.count(), s.truncated(), resolvedTarget));
+      }
+      case UPDATE ->
+          throw new IllegalStateException("UPDATE must be routed through executeUpdate(...)");
+    };
+  }
+
+  static ExecStats stats(long startMs, Integer rowCount, boolean truncated, String resolvedTarget) {
+    return new ExecStats(System.currentTimeMillis() - startMs, rowCount, truncated, resolvedTarget);
+  }
+
+  static long timeoutMs(ExecuteOptions options) {
+    return options != null && options.timeoutMs() != null
+        ? options.timeoutMs()
+        : DEFAULT_TIMEOUT_MS;
+  }
+
+  static int maxRows(ExecuteOptions options) {
+    return options != null && options.maxRows() != null ? options.maxRows() : DEFAULT_MAX_ROWS;
+  }
+
+  static boolean isBlank(String s) {
+    return s == null || s.isBlank();
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteRequest.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteRequest.java
@@ -23,11 +23,20 @@ package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
  * notebook controller for each cell execution.
  *
  * @param cellUri URI of the executing cell; used only for logging/diagnostics.
+ * @param notebookUri URI of the notebook document the cell belongs to; relative paths in {@link
+ *     ExecuteTarget#files()} are resolved against its directory, matching how validation resolves
+ *     relative {@code # [endpoint=...]} directives. May be {@code null} (e.g. an untitled
+ *     notebook), in which case only absolute file paths can be executed.
  * @param languageId the cell's language id (e.g. {@code sparql}).
  * @param text the cell's source text.
- * @param target the endpoint to execute against, resolved client-side; {@code null} when the cell
- *     (and its notebook) has no {@code # [endpoint=...]} directive.
+ * @param target the endpoint or files to execute against, resolved client-side; {@code null} when
+ *     the cell (and its notebook) has no {@code # [endpoint=...]} directive.
  * @param options per-execution overrides; {@code null} to use all defaults.
  */
 record ExecuteRequest(
-    String cellUri, String languageId, String text, ExecuteTarget target, ExecuteOptions options) {}
+    String cellUri,
+    String notebookUri,
+    String languageId,
+    String text,
+    ExecuteTarget target,
+    ExecuteOptions options) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
@@ -18,19 +18,29 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
-/**
- * The endpoint a cell is executed against, resolved client-side from the cell's {@code #
- * [endpoint=...]} directive (see {@code EndpointDirective} in the parent package).
- *
- * @param type {@code "http"} for a remote SPARQL endpoint; other target types (local file, SHACL)
- *     are added in later milestones.
- * @param url the SPARQL query endpoint URL.
- * @param updateUrl the SPARQL Update endpoint URL. {@code null}/blank means this target has no
- *     configured update endpoint, so a cell that parses as a SPARQL Update is rejected with {@link
- *     ErrorCode#UPDATE_NOT_ALLOWED} rather than silently reusing {@link #url()}.
- */
-record ExecuteTarget(String type, String url, String updateUrl) {
+import java.util.List;
 
-  /** The only target {@link #type()} understood in this milestone. */
+/**
+ * The endpoint or local files a cell is executed against, resolved client-side from the cell's
+ * {@code # [endpoint=...]} directives (see {@code EndpointDirective} in the parent package).
+ *
+ * @param type {@code "http"} for a remote SPARQL endpoint, {@code "files"} for local RDF/CIMXML
+ *     files queried in-process.
+ * @param url the SPARQL query endpoint URL ({@code "http"} targets only).
+ * @param updateUrl the SPARQL Update endpoint URL ({@code "http"} targets only). {@code null}/blank
+ *     means this target has no configured update endpoint, so a cell that parses as a SPARQL Update
+ *     is rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED} rather than silently reusing {@link
+ *     #url()}.
+ * @param files the local files to query, exactly as written in the directives ({@code "files"}
+ *     targets only). Relative paths are resolved server-side against the directory of {@link
+ *     ExecuteRequest#notebookUri()}; multiple files are queried as one union store. Local files are
+ *     read-only — updates are rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED}.
+ */
+record ExecuteTarget(String type, String url, String updateUrl, List<String> files) {
+
+  /** Target {@link #type()}: a remote SPARQL endpoint. */
   static final String TYPE_HTTP = "http";
+
+  /** Target {@link #type()}: local RDF/CIMXML files queried in-process. */
+  static final String TYPE_FILES = "files";
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
@@ -20,13 +20,7 @@ package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
 import java.net.http.HttpTimeoutException;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
@@ -35,7 +29,6 @@ import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
 import org.apache.jena.sparql.exec.http.UpdateExecutionHTTP;
 import org.apache.jena.update.UpdateExecution;
 import org.apache.jena.update.UpdateRequest;
-import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,33 +41,15 @@ import org.slf4j.LoggerFactory;
  * UpdateExecution.abort()} does not: an in-flight {@code UpdateExecutionHTTP.execute()} call keeps
  * blocking until the request's own timeout elapses regardless of {@code abort()} being called from
  * another thread. Rather than rely on that asymmetric, version-specific behavior, the blocking Jena
- * call always runs on a background task ({@link #runCancellable}) raced against a {@link
- * CancellationWatchdog}-driven signal: whichever finishes first — the real result, or the
- * cancellation signal — determines the response. {@code abort()} is still called as a best-effort
- * courtesy (it does help for queries, and costs nothing when it does not), but correctness of the
- * client-visible CANCELLED outcome never depends on it. One consequence: a cancelled UPDATE's HTTP
- * request may continue running against the endpoint in the background until it completes or times
- * out; the notebook simply stops waiting for it.
+ * call is raced against the cancellation signal via {@link ExecSupport#runCancellable}. One
+ * consequence: a cancelled UPDATE's HTTP request may continue running against the endpoint in the
+ * background until it completes or times out; the notebook simply stops waiting for it.
  */
 final class HttpQueryExecutor {
 
   private static final Logger LOG = LoggerFactory.getLogger(HttpQueryExecutor.class);
 
-  /** Default request timeout, matching {@code SchemaManager}'s remote-fetch timeout. */
-  static final int DEFAULT_TIMEOUT_MS = 30_000;
-
-  /** Default cap on returned rows/triples before the result is marked truncated. */
-  static final int DEFAULT_MAX_ROWS = 10_000;
-
   private HttpQueryExecutor() {}
-
-  /**
-   * Resources a single execution needs for cancellation wiring, bundled to keep call sites short.
-   */
-  record ExecContext(
-      ExecutorService executionPool,
-      ScheduledExecutorService watchdogScheduler,
-      CancelChecker cancelChecker) {}
 
   /**
    * Executes a SELECT/ASK/CONSTRUCT/DESCRIBE query, returning a populated {@link ExecuteResponse}.
@@ -87,13 +62,13 @@ final class HttpQueryExecutor {
     }
 
     String url = target.url();
-    int maxRows = maxRows(options);
+    int maxRows = ExecSupport.maxRows(options);
     QueryExecution qe =
         QueryExecutionHTTP.service(url)
             .query(query)
-            .timeout(timeoutMs(options), TimeUnit.MILLISECONDS)
+            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS)
             .build();
-    return runCancellable(
+    return ExecSupport.runCancellable(
         ctx,
         qe::abort,
         () -> {
@@ -111,7 +86,7 @@ final class HttpQueryExecutor {
       return ExecuteResponse.failed(targetError);
     }
     String updateUrl = target.updateUrl();
-    if (isBlank(updateUrl)) {
+    if (ExecSupport.isBlank(updateUrl)) {
       return ExecuteResponse.failed(
           new ExecError(
               ErrorCode.UPDATE_NOT_ALLOWED,
@@ -124,42 +99,17 @@ final class HttpQueryExecutor {
     UpdateExecution ue =
         UpdateExecutionHTTP.service(updateUrl)
             .update(update)
-            .timeout(timeoutMs(options), TimeUnit.MILLISECONDS)
+            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS)
             .build();
-    return runCancellable(ctx, ue::abort, () -> runUpdate(ue, updateUrl));
+    return ExecSupport.runCancellable(ctx, ue::abort, () -> runUpdate(ue, updateUrl));
   }
 
   // ---- query/update execution (runs on ctx.executionPool()) -------------------------------
 
   private static ExecuteResponse runQuery(
       QueryExecution qe, QueryKind kind, String url, int maxRows) {
-    long start = System.currentTimeMillis();
     try {
-      return switch (kind) {
-        case SELECT -> {
-          ResultSerializer.Serialized s = ResultSerializer.selectToJson(qe.execSelect(), maxRows);
-          yield ExecuteResponse.successJson(
-              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
-        }
-        case ASK -> {
-          String json = ResultSerializer.askToJson(qe.execAsk());
-          yield ExecuteResponse.successJson(kind, json, stats(start, null, false, url));
-        }
-        case CONSTRUCT -> {
-          ResultSerializer.Serialized s =
-              ResultSerializer.constructToTurtle(qe.execConstructTriples(), maxRows);
-          yield ExecuteResponse.successTurtle(
-              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
-        }
-        case DESCRIBE -> {
-          ResultSerializer.Serialized s =
-              ResultSerializer.constructToTurtle(qe.execDescribeTriples(), maxRows);
-          yield ExecuteResponse.successTurtle(
-              kind, s.payload(), stats(start, s.count(), s.truncated(), url));
-        }
-        case UPDATE ->
-            throw new IllegalStateException("UPDATE must be routed through executeUpdate(...)");
-      };
+      return ExecSupport.successFor(qe, kind, url, maxRows);
     } catch (QueryExceptionHTTP e) {
       return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
     } catch (CancellationException e) {
@@ -179,7 +129,7 @@ final class HttpQueryExecutor {
     long start = System.currentTimeMillis();
     try {
       ue.execute();
-      return ExecuteResponse.successUpdate(stats(start, null, false, updateUrl));
+      return ExecuteResponse.successUpdate(ExecSupport.stats(start, null, false, updateUrl));
     } catch (HttpException e) {
       return ExecuteResponse.failed(classify(e.getStatusCode(), e.getMessage(), e));
     } catch (CancellationException e) {
@@ -191,40 +141,6 @@ final class HttpQueryExecutor {
       LOG.error("Unexpected error executing update: {}", e.getMessage(), e);
       return ExecuteResponse.failed(
           new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
-    }
-  }
-
-  // ---- cancellation racing -----------------------------------------------------------------
-
-  /**
-   * Runs {@code work} on {@code ctx.executionPool()} and races it against cancellation of {@code
-   * ctx.cancelChecker()}, returning whichever resolves first. {@code bestEffortAbort} is invoked
-   * (on the watchdog thread) the moment cancellation is observed, as a courtesy to unblock {@code
-   * work} sooner where the underlying Jena execution supports it — see the class-level note on why
-   * this is not relied upon for correctness.
-   */
-  private static ExecuteResponse runCancellable(
-      ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work) {
-    CompletableFuture<ExecuteResponse> workFuture =
-        CompletableFuture.supplyAsync(work, ctx.executionPool());
-    CompletableFuture<ExecuteResponse> cancelFuture = new CompletableFuture<>();
-
-    ScheduledFuture<?> watchdogTask =
-        CancellationWatchdog.watch(
-            ctx.watchdogScheduler(),
-            ctx.cancelChecker(),
-            () -> {
-              // Complete cancelFuture before aborting: aborting can itself unblock the blocked
-              // Jena call on ctx.executionPool(), which would otherwise race workFuture's own
-              // completion against cancelFuture below. Signalling cancellation first guarantees
-              // workFuture cannot win that race as a side effect of the abort it triggers.
-              cancelFuture.complete(ExecuteResponse.cancelled());
-              bestEffortAbort.run();
-            });
-    try {
-      return workFuture.applyToEither(cancelFuture, Function.identity()).join();
-    } finally {
-      watchdogTask.cancel(true);
     }
   }
 
@@ -257,7 +173,7 @@ final class HttpQueryExecutor {
   // ---- small helpers ------------------------------------------------------------------------
 
   private static ExecError checkTarget(ExecuteTarget target) {
-    if (target == null || isBlank(target.url())) {
+    if (target == null || ExecSupport.isBlank(target.url())) {
       return new ExecError(
           ErrorCode.NO_TARGET,
           "No endpoint configured. Add a `# [endpoint=<url>]` directive to the cell.",
@@ -266,24 +182,5 @@ final class HttpQueryExecutor {
           null);
     }
     return null;
-  }
-
-  private static ExecStats stats(
-      long startMs, Integer rowCount, boolean truncated, String resolvedTarget) {
-    return new ExecStats(System.currentTimeMillis() - startMs, rowCount, truncated, resolvedTarget);
-  }
-
-  private static long timeoutMs(ExecuteOptions options) {
-    return options != null && options.timeoutMs() != null
-        ? options.timeoutMs()
-        : DEFAULT_TIMEOUT_MS;
-  }
-
-  private static int maxRows(ExecuteOptions options) {
-    return options != null && options.maxRows() != null ? options.maxRows() : DEFAULT_MAX_ROWS;
-  }
-
-  private static boolean isBlank(String s) {
-    return s == null || s.isBlank();
   }
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutor.java
@@ -1,0 +1,182 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryCancelledException;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a parsed SPARQL query in-process against local data files ({@link
+ * ExecuteTarget#TYPE_FILES}): RDF files and CIMXML models, parsed and cached by {@link
+ * LocalStoreManager}. Local files are read-only — SPARQL updates are rejected by {@code
+ * NotebookCommandHandler} before reaching this class.
+ *
+ * <p>Relative paths are resolved against the directory of {@link ExecuteRequest#notebookUri()},
+ * matching how validation resolves relative {@code # [endpoint=...]} directives, so the same
+ * directive means the same file for both.
+ *
+ * <p>Cancellation uses the same racing scheme as {@link HttpQueryExecutor} (via {@link
+ * ExecSupport#runCancellable}); for the in-process engine {@code QueryExecution.abort()} and the
+ * timeout both surface as {@link QueryCancelledException}, told apart by whether the client
+ * actually cancelled.
+ */
+final class LocalQueryExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalQueryExecutor.class);
+
+  private LocalQueryExecutor() {}
+
+  /**
+   * Executes a SELECT/ASK/CONSTRUCT/DESCRIBE query against the request's local files, returning a
+   * populated {@link ExecuteResponse}.
+   */
+  static ExecuteResponse executeQuery(
+      Query query,
+      QueryKind kind,
+      ExecuteRequest request,
+      LocalStoreManager stores,
+      ExecContext ctx) {
+    ExecuteTarget target = request.target();
+    if (target.files() == null || target.files().isEmpty()) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.NO_TARGET,
+              "No endpoint configured. Add a `# [endpoint=<url or file>]` directive to the cell.",
+              null,
+              null,
+              null));
+    }
+
+    List<Path> paths;
+    DatasetGraph data;
+    try {
+      paths = resolvePaths(target.files(), notebookDir(request.notebookUri()));
+      data = stores.unionFor(paths);
+    } catch (LocalStoreManager.StoreException e) {
+      return ExecuteResponse.failed(new ExecError(e.code(), e.getMessage(), null, null, null));
+    }
+
+    // The stats line shows the files as the user wrote them in the directive, not the resolved
+    // absolute paths — the notebook-relative form is the meaningful one to a reader.
+    String resolvedTarget = String.join(", ", target.files());
+    int maxRows = ExecSupport.maxRows(request.options());
+    QueryExecution qe =
+        QueryExecution.dataset(DatasetFactory.wrap(data))
+            .query(query)
+            .timeout(ExecSupport.timeoutMs(request.options()), TimeUnit.MILLISECONDS)
+            .build();
+    return ExecSupport.runCancellable(
+        ctx,
+        qe::abort,
+        () -> {
+          try (qe) {
+            return runQuery(qe, kind, resolvedTarget, maxRows, ctx);
+          }
+        });
+  }
+
+  // ---- query execution (runs on ctx.executionPool()) ----------------------------------------
+
+  private static ExecuteResponse runQuery(
+      QueryExecution qe, QueryKind kind, String resolvedTarget, int maxRows, ExecContext ctx) {
+    try {
+      return ExecSupport.successFor(qe, kind, resolvedTarget, maxRows);
+    } catch (QueryCancelledException e) {
+      // The in-process engine raises the same exception for both ways an execution is cut short:
+      // the timeout, and the best-effort abort() runCancellable fires on client cancellation.
+      if (ctx.cancelChecker().isCanceled()) {
+        LOG.debug("{} query aborted after cancellation", kind);
+        return ExecuteResponse.cancelled();
+      }
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.TIMEOUT, "Query timed out.", e.getMessage(), null, null));
+    } catch (CancellationException e) {
+      LOG.debug("{} query aborted after cancellation", kind);
+      return ExecuteResponse.cancelled();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error executing local {} query: {}", kind, e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  // ---- path resolution -----------------------------------------------------------------------
+
+  private static List<Path> resolvePaths(List<String> files, Path notebookDir)
+      throws LocalStoreManager.StoreException {
+    List<Path> paths = new ArrayList<>(files.size());
+    for (String file : files) {
+      paths.add(resolvePath(file, notebookDir));
+    }
+    return paths;
+  }
+
+  private static Path resolvePath(String file, Path notebookDir)
+      throws LocalStoreManager.StoreException {
+    Path path;
+    try {
+      path = Path.of(file);
+    } catch (InvalidPathException e) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND, "Not a valid file path: " + file, e);
+    }
+    if (path.isAbsolute()) {
+      return path.normalize();
+    }
+    if (notebookDir == null) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND,
+          "Cannot resolve the relative path "
+              + file
+              + " — save the notebook first so relative paths have a base directory.",
+          null);
+    }
+    return notebookDir.resolve(path).normalize();
+  }
+
+  /** The notebook's directory, or {@code null} when the notebook has no on-disk location. */
+  private static Path notebookDir(String notebookUri) {
+    if (notebookUri == null || notebookUri.isBlank()) {
+      return null;
+    }
+    try {
+      URI uri = new URI(notebookUri);
+      if (!"file".equalsIgnoreCase(uri.getScheme())) {
+        return null;
+      }
+      return Path.of(uri).getParent();
+    } catch (URISyntaxException | IllegalArgumentException e) {
+      LOG.debug("Ignoring unusable notebook URI {}: {}", notebookUri, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManager.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManager.java
@@ -1,0 +1,242 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import de.soptim.opencgmes.cimxml.parser.CimXmlParser;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.compose.MultiUnion;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphMapLink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parses local data files into query-ready {@link DatasetGraph}s for {@link LocalQueryExecutor},
+ * caching the parses so re-running a cell does not re-read a large model.
+ *
+ * <p><b>File formats.</b> {@code *.xml} is parsed as a IEC 61970-552 CIMXML model via {@link
+ * CimXmlParser} (header in a named graph, body in the default graph); everything else is handed to
+ * Jena's {@link RDFDataMgr}, which picks the parser from the extension ({@code .ttl}, {@code .rdf},
+ * {@code .owl}, {@code .nt}, {@code .nq}, {@code .trig}, …).
+ *
+ * <p><b>Caching.</b> Entries are keyed by absolute path and invalidated when the file's
+ * modification time or size changes, checked on every access — editing a model and re-running the
+ * cell always queries the current file. The cache is future-valued so concurrent cells hitting the
+ * same not-yet-parsed file share one parse instead of racing, and LRU-bounded ({@value
+ * #DEFAULT_CAPACITY} files by default) because CIMXML models can be large; evicted files are simply
+ * re-parsed on next use.
+ *
+ * <p><b>Union semantics.</b> {@link #unionFor} exposes multiple files as one dataset: every named
+ * graph of every file stays addressable via {@code GRAPH}, while the default graph is the union of
+ * <em>all</em> graphs (default and named) of all files, so a bare {@code ?s ?p ?o} sees everything
+ * — including a CIMXML model's header. Files with identical named-graph names (e.g. two CIMXML
+ * FullModel headers, both {@code md:FullModel}) collide in {@code GRAPH} lookups — the last file
+ * wins there — but remain fully visible in the default-graph union.
+ *
+ * <p>The returned datasets are read-only by convention: updates are rejected before execution (see
+ * {@link ErrorCode#UPDATE_NOT_ALLOWED}), and nothing else writes to the cached graphs.
+ */
+final class LocalStoreManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalStoreManager.class);
+
+  /** Default maximum number of parsed files kept in memory. */
+  static final int DEFAULT_CAPACITY = 8;
+
+  /** A cached parse: the file's attributes at parse time, used to detect staleness on access. */
+  private record CachedEntry(FileTime mtime, long size, DatasetGraph graph) {}
+
+  private final Map<Path, CompletableFuture<CachedEntry>> cache;
+
+  LocalStoreManager() {
+    this(DEFAULT_CAPACITY);
+  }
+
+  LocalStoreManager(int capacity) {
+    this.cache = Collections.synchronizedMap(new LruCache(capacity));
+  }
+
+  /** Access-ordered {@link LinkedHashMap} bounded at {@code capacity} entries. */
+  private static final class LruCache extends LinkedHashMap<Path, CompletableFuture<CachedEntry>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int capacity;
+
+    LruCache(int capacity) {
+      super(16, 0.75f, true);
+      this.capacity = capacity;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<Path, CompletableFuture<CachedEntry>> eldest) {
+      boolean evict = size() > capacity;
+      if (evict) {
+        LOG.debug(
+            "Evicting parsed store {} (cache holds at most {} files)", eldest.getKey(), capacity);
+      }
+      return evict;
+    }
+  }
+
+  /**
+   * A file could not be read or parsed; {@link #code()} says which of the two it was, and the
+   * message is already user-presentable (it names the file).
+   */
+  static final class StoreException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ErrorCode code;
+
+    StoreException(ErrorCode code, String message, Throwable cause) {
+      super(message, cause);
+      this.code = code;
+    }
+
+    ErrorCode code() {
+      return code;
+    }
+  }
+
+  /**
+   * Returns one queryable dataset over {@code files} (absolute paths), parsing or re-using cached
+   * parses per file — see the class comment for the union semantics.
+   */
+  DatasetGraph unionFor(List<Path> files) throws StoreException {
+    List<DatasetGraph> parts = new ArrayList<>(files.size());
+    for (Path file : files) {
+      parts.add(datasetGraphFor(file));
+    }
+
+    MultiUnion defaultUnion = new MultiUnion();
+    DatasetGraph union = new DatasetGraphMapLink(defaultUnion);
+    for (DatasetGraph part : parts) {
+      defaultUnion.addGraph(part.getDefaultGraph());
+      part.listGraphNodes()
+          .forEachRemaining(
+              name -> {
+                Graph graph = part.getGraph(name);
+                defaultUnion.addGraph(graph);
+                union.addGraph(name, graph);
+              });
+    }
+    return union;
+  }
+
+  /**
+   * Returns the (possibly cached) parse of one file, re-parsing when the file changed on disk.
+   * Package-private so tests can observe cache behavior through instance identity.
+   */
+  DatasetGraph datasetGraphFor(Path file) throws StoreException {
+    while (true) {
+      BasicFileAttributes attrs = readAttributes(file);
+
+      AtomicBoolean isLoader = new AtomicBoolean();
+      CompletableFuture<CachedEntry> future =
+          cache.computeIfAbsent(
+              file,
+              p -> {
+                isLoader.set(true);
+                return new CompletableFuture<>();
+              });
+
+      if (isLoader.get()) {
+        // This thread inserted the future, so it owns the parse; concurrent callers of the same
+        // file are waiting on the future below. A failed parse is not cached — the mapping is
+        // removed so the next run retries (the file has usually been edited by then anyway).
+        try {
+          CachedEntry entry = new CachedEntry(attrs.lastModifiedTime(), attrs.size(), parse(file));
+          future.complete(entry);
+          return entry.graph();
+        } catch (StoreException | RuntimeException | Error e) {
+          cache.remove(file, future);
+          future.completeExceptionally(e);
+          throw e;
+        }
+      }
+
+      CachedEntry entry = awaitEntry(file, future);
+      if (entry.mtime().equals(attrs.lastModifiedTime()) && entry.size() == attrs.size()) {
+        return entry.graph();
+      }
+      LOG.debug("Cached store for {} is stale, re-parsing", file);
+      cache.remove(file, future);
+    }
+  }
+
+  private static CachedEntry awaitEntry(Path file, CompletableFuture<CachedEntry> future)
+      throws StoreException {
+    try {
+      return future.join();
+    } catch (CompletionException | CancellationException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof StoreException storeException) {
+        throw storeException;
+      }
+      throw new StoreException(
+          ErrorCode.FILE_PARSE_ERROR, "Failed to parse " + file + ": " + e.getMessage(), e);
+    }
+  }
+
+  private static BasicFileAttributes readAttributes(Path file) throws StoreException {
+    try {
+      BasicFileAttributes attrs = Files.readAttributes(file, BasicFileAttributes.class);
+      if (!attrs.isRegularFile()) {
+        throw new StoreException(ErrorCode.FILE_NOT_FOUND, "Not a file: " + file, null);
+      }
+      return attrs;
+    } catch (IOException e) {
+      throw new StoreException(ErrorCode.FILE_NOT_FOUND, "File not found: " + file, e);
+    }
+  }
+
+  private static DatasetGraph parse(Path file) throws StoreException {
+    long start = System.currentTimeMillis();
+    try {
+      Path fileName = file.getFileName();
+      String name = fileName != null ? fileName.toString().toLowerCase(Locale.ROOT) : "";
+      DatasetGraph parsed =
+          name.endsWith(".xml")
+              ? new CimXmlParser().parseCimModel(file)
+              : RDFDataMgr.loadDatasetGraph(file.toUri().toString());
+      LOG.debug("Parsed {} in {} ms", file, System.currentTimeMillis() - start);
+      return parsed;
+    } catch (IOException | RuntimeException e) {
+      throw new StoreException(
+          ErrorCode.FILE_PARSE_ERROR, "Failed to parse " + file + ": " + e.getMessage(), e);
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -38,7 +38,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@value #CMD_EXECUTE} workspace command: runs a notebook cell's SPARQL query or
- * update against the endpoint resolved by the client, and returns an {@link ExecuteResponse}.
+ * update against the target resolved by the client — an HTTP endpoint ({@link HttpQueryExecutor})
+ * or local RDF/CIMXML files ({@link LocalQueryExecutor}) — and returns an {@link ExecuteResponse}.
  *
  * <p>Wired into {@code SparqlWorkspaceService#executeCommand} by {@code SparqlLanguageServer},
  * which also forwards {@link #shutdown()} from its own shutdown sequence.
@@ -52,16 +53,18 @@ public final class NotebookCommandHandler {
   public static final String CMD_EXECUTE = "cimvocabcheck.notebook.execute";
 
   /**
-   * Pool the blocking Jena HTTP call runs on. Must stay unbounded (cached, not fixed): {@link
-   * HttpQueryExecutor#executeQuery} submits its own nested task to this same pool and joins on it
-   * from the calling thread, so a fixed-size pool could deadlock once all threads are blocked
-   * waiting on a nested task that has no thread left to run on.
+   * Pool the blocking Jena call runs on. Must stay unbounded (cached, not fixed): the executors'
+   * {@link ExecSupport#runCancellable} racing submits its own nested task to this same pool and
+   * joins on it from the calling thread, so a fixed-size pool could deadlock once all threads are
+   * blocked waiting on a nested task that has no thread left to run on.
    */
   private final ExecutorService executionPool =
       Executors.newCachedThreadPool(threadFactory("cimvocabcheck-notebook-exec"));
 
   private final ScheduledExecutorService watchdogScheduler =
       Executors.newSingleThreadScheduledExecutor(threadFactory("cimvocabcheck-notebook-watchdog"));
+
+  private final LocalStoreManager localStores = new LocalStoreManager();
 
   /**
    * Handles one {@value #CMD_EXECUTE} invocation. {@code arguments} must have a single element that
@@ -105,12 +108,26 @@ public final class NotebookCommandHandler {
   private Object doExecute(ExecuteRequest request, CancelChecker cancelChecker) {
     LOG.debug("Executing {} cell {}", request.languageId(), request.cellUri());
     try {
-      var ctx = new HttpQueryExecutor.ExecContext(executionPool, watchdogScheduler, cancelChecker);
+      var ctx = new ExecContext(executionPool, watchdogScheduler, cancelChecker);
+      boolean filesTarget =
+          request.target() != null && ExecuteTarget.TYPE_FILES.equals(request.target().type());
       return switch (QueryKindDetector.detect(request.text())) {
         case QueryKindDetector.AsQuery(var kind, var query) ->
-            HttpQueryExecutor.executeQuery(query, kind, request.target(), request.options(), ctx);
+            filesTarget
+                ? LocalQueryExecutor.executeQuery(query, kind, request, localStores, ctx)
+                : HttpQueryExecutor.executeQuery(
+                    query, kind, request.target(), request.options(), ctx);
         case QueryKindDetector.AsUpdate(var update) ->
-            HttpQueryExecutor.executeUpdate(update, request.target(), request.options(), ctx);
+            filesTarget
+                ? ExecuteResponse.failed(
+                    new ExecError(
+                        ErrorCode.UPDATE_NOT_ALLOWED,
+                        "Local files are read-only — running a SPARQL Update needs an HTTP"
+                            + " endpoint.",
+                        null,
+                        null,
+                        null))
+                : HttpQueryExecutor.executeUpdate(update, request.target(), request.options(), ctx);
         case QueryKindDetector.ParseFailure(var message, var line, var column) ->
             ExecuteResponse.failed(
                 new ExecError(ErrorCode.PARSE_ERROR, message, null, line, column));

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerInstanceDataGuardTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerInstanceDataGuardTest.java
@@ -1,0 +1,117 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the dual-semantics guard in {@link SchemaManager#resolveSchema}: a {@code #
+ * [endpoint=...]} directive is both validation schema source and notebook execution data target,
+ * and when it names <em>instance data</em> — a CIMXML {@code .xml} model, an {@code .nt} dump —
+ * validation must fall back to the workspace schema instead of loading the data file as a schema.
+ * Without the guard, a CIMXML model (valid RDF/XML!) silently loads as an empty-ish schema and
+ * every {@code cim:} term in the cell turns into a false diagnostic.
+ */
+public class SchemaManagerInstanceDataGuardTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  /** A perfectly valid CIMXML instance model — which is exactly why it must not become a schema. */
+  private static final String CIMXML_MODEL =
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+       <md:FullModel rdf:about="urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6">
+         <md:Model.profile>http://soptim.de/CIM/MyProfile/1.1</md:Model.profile>
+       </md:FullModel>
+       <cim:MyEquipment rdf:ID="_f67fc354-9e39-4191-a456-67537399bc48">
+         <cim:IdentifiedObject.name>My Custom Equipment</cim:IdentifiedObject.name>
+       </cim:MyEquipment>
+      </rdf:RDF>
+      """;
+
+  @Test
+  public void instanceDataDirectivesFallBackToTheWorkspaceSchema() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    Files.writeString(docDir.resolve("model.xml"), CIMXML_MODEL);
+    Files.writeString(
+        docDir.resolve("data.nt"),
+        "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n");
+
+    List<MessageParams> messages = new CopyOnWriteArrayList<>();
+    SchemaManager manager = new SchemaManager();
+    manager.setClient(recordingClient(messages));
+    try {
+      // No opencgmes.jsonc anywhere near docDir, so the workspace-schema fallback is empty —
+      // syntax-only validation. Before the guard, the .xml resolved to a garbage schema (or, when
+      // schema construction rejected it, a user-facing load-failure notification) instead.
+      assertTrue(
+          "a CIMXML model directive must not load as an endpoint schema",
+          manager.resolveSchema("./model.xml", docDir).isEmpty());
+      assertTrue(
+          "an N-Triples data directive must not load as an endpoint schema",
+          manager.resolveSchema("./data.nt", docDir).isEmpty());
+      assertEquals(
+          "the quiet fallback must not raise schema-load notifications: " + messages,
+          List.of(),
+          messages);
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  private static LanguageClient recordingClient(List<MessageParams> messages) {
+    return new LanguageClient() {
+      @Override
+      public void telemetryEvent(Object object) {}
+
+      @Override
+      public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {}
+
+      @Override
+      public void showMessage(MessageParams messageParams) {
+        messages.add(messageParams);
+      }
+
+      @Override
+      public CompletableFuture<MessageActionItem> showMessageRequest(
+          ShowMessageRequestParams requestParams) {
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      public void logMessage(MessageParams message) {}
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
@@ -421,12 +421,12 @@ public class HttpQueryExecutorTest {
 
   // ---- helpers ---------------------------------------------------------------------------------
 
-  private HttpQueryExecutor.ExecContext ctx(CancelChecker checker) {
-    return new HttpQueryExecutor.ExecContext(executionPool, watchdogScheduler, checker);
+  private ExecContext ctx(CancelChecker checker) {
+    return new ExecContext(executionPool, watchdogScheduler, checker);
   }
 
   private static ExecuteTarget target(String url, String updateUrl) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl);
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null);
   }
 
   private static String uniqueSubject() {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
@@ -1,0 +1,350 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises {@link LocalQueryExecutor}: in-process query kinds over local files, relative-path
+ * resolution against the notebook URI, the {@link LocalStoreManager} failure modes surfacing as
+ * responses, and timeout/cancellation of the in-process engine. File parsing and union/cache
+ * mechanics themselves are covered by {@link LocalStoreManagerTest}.
+ */
+public class LocalQueryExecutorTest {
+
+  private static final String EX = "http://example.org/";
+
+  private static final CancelChecker NEVER_CANCELLED =
+      new CancelChecker() {
+        @Override
+        public void checkCanceled() {}
+
+        @Override
+        public boolean isCanceled() {
+          return false;
+        }
+      };
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private ExecutorService executionPool;
+  private ScheduledExecutorService watchdogScheduler;
+  private LocalStoreManager stores;
+
+  @Before
+  public void setUp() {
+    executionPool = Executors.newCachedThreadPool();
+    watchdogScheduler = Executors.newSingleThreadScheduledExecutor();
+    stores = new LocalStoreManager();
+  }
+
+  @After
+  public void tearDown() {
+    executionPool.shutdownNow();
+    watchdogScheduler.shutdownNow();
+  }
+
+  // ---- happy paths -----------------------------------------------------------------------------
+
+  @Test
+  public void selectAgainstAnAbsolutePathReturnsBindings() throws IOException {
+    Path file = dataFile("data.ttl", "<" + EX + "s> <" + EX + "p> \"v\" .");
+
+    ExecuteResponse response =
+        execute(
+            "SELECT ?o WHERE { <" + EX + "s> <" + EX + "p> ?o }",
+            QueryKind.SELECT,
+            request(null, file.toString()));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.SELECT.name(), response.queryKind());
+    assertNull(response.error());
+    JsonArray bindings = bindings(response);
+    assertEquals(1, bindings.size());
+    assertEquals(
+        "v", bindings.get(0).getAsJsonObject().getAsJsonObject("o").get("value").getAsString());
+    assertEquals(Integer.valueOf(1), response.stats().rowCount());
+    assertEquals(file.toString(), response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void relativePathsResolveAgainstTheNotebookDirectory() throws IOException {
+    dataFile("data.ttl", "<" + EX + "s> <" + EX + "p> \"v\" .");
+    String notebookUri = tmp.getRoot().toPath().resolve("demo.cimnb.md").toUri().toString();
+
+    ExecuteResponse response =
+        execute("ASK { ?s ?p ?o }", QueryKind.ASK, request(notebookUri, "./data.ttl"));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertTrue(
+        JsonParser.parseString(response.resultsJson())
+            .getAsJsonObject()
+            .get("boolean")
+            .getAsBoolean());
+    assertEquals("./data.ttl", response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void multipleFilesAreQueriedAsOneUnion() throws IOException {
+    Path a = dataFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    Path b = dataFile("b.ttl", "<" + EX + "b> <" + EX + "p> 2 .");
+
+    ExecuteResponse response =
+        execute(
+            "SELECT ?s WHERE { ?s <" + EX + "p> ?o }",
+            QueryKind.SELECT,
+            request(null, a.toString(), b.toString()));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(2, bindings(response).size());
+    assertEquals(a + ", " + b, response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void constructReturnsTheResultGraphAsTurtle() throws IOException {
+    Path file = dataFile("data.ttl", "<" + EX + "s> <" + EX + "p> \"v\" .");
+
+    ExecuteResponse response =
+        execute(
+            "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+            QueryKind.CONSTRUCT,
+            request(null, file.toString()));
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.CONSTRUCT.name(), response.queryKind());
+    assertTrue(response.turtle().contains(EX + "s"));
+  }
+
+  @Test
+  public void selectOverACimxmlModelSeesBodyAndHeader() throws IOException {
+    Path model = dataFile("model.xml", CIMXML_FULL_MODEL);
+
+    ExecuteResponse names =
+        execute(
+            "SELECT ?name WHERE { ?s <http://iec.ch/TC57/CIM100#IdentifiedObject.name> ?name }",
+            QueryKind.SELECT,
+            request(null, model.toString()));
+    assertEquals(ExecutionStatus.SUCCESS.name(), names.status());
+    assertEquals(
+        "My Custom Equipment",
+        bindings(names)
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonObject("name")
+            .get("value")
+            .getAsString());
+
+    ExecuteResponse header =
+        execute(
+            "ASK { ?m <http://iec.ch/TC57/61970-552/ModelDescription/1#Model.profile> ?p }",
+            QueryKind.ASK,
+            request(null, model.toString()));
+    assertTrue(
+        "the model header must be visible to bare patterns via the union default graph",
+        JsonParser.parseString(header.resultsJson())
+            .getAsJsonObject()
+            .get("boolean")
+            .getAsBoolean());
+  }
+
+  // ---- failure modes ---------------------------------------------------------------------------
+
+  @Test
+  public void missingFileReportsFileNotFound() {
+    ExecuteResponse response =
+        execute(
+            "ASK {}",
+            QueryKind.ASK,
+            request(null, tmp.getRoot().toPath().resolve("nope.ttl").toString()));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.name(), response.error().code());
+    assertTrue(response.error().message().contains("nope.ttl"));
+  }
+
+  @Test
+  public void unparseableFileReportsFileParseError() throws IOException {
+    Path file = dataFile("broken.ttl", "not turtle @@@");
+
+    ExecuteResponse response = execute("ASK {}", QueryKind.ASK, request(null, file.toString()));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_PARSE_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void relativePathWithoutANotebookLocationReportsFileNotFound() {
+    ExecuteResponse response = execute("ASK {}", QueryKind.ASK, request(null, "./data.ttl"));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.name(), response.error().code());
+    assertTrue(response.error().message().contains("save the notebook"));
+  }
+
+  @Test
+  public void emptyFileListReportsNoTarget() {
+    ExecuteResponse response = execute("ASK {}", QueryKind.ASK, request(null));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  // ---- timeout and cancellation ----------------------------------------------------------------
+
+  @Test
+  public void slowQueryReportsTimeout() throws IOException {
+    ExecuteResponse response =
+        execute(PATHOLOGICAL_QUERY, QueryKind.SELECT, slowRequest(50), NEVER_CANCELLED);
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.TIMEOUT.name(), response.error().code());
+  }
+
+  @Test
+  public void cancellationWinsOverASlowQuery() throws IOException {
+    long start = System.nanoTime();
+    ExecuteResponse response =
+        execute(PATHOLOGICAL_QUERY, QueryKind.SELECT, slowRequest(60_000), cancelAfter(300));
+    long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+    assertEquals(ExecutionStatus.CANCELLED.name(), response.status());
+    assertEquals(ErrorCode.CANCELLED.name(), response.error().code());
+    assertTrue(
+        "expected cancellation well before the timeout, took " + elapsedMs + "ms",
+        elapsedMs < 30_000);
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------------
+
+  /**
+   * A COUNT over an unrestricted five-way cross join (120⁵ ≈ 2.5 × 10¹⁰ combinations on the fixture
+   * data): the aggregation forces the whole join to be exhausted before the first row can be
+   * emitted, so — unlike a plain SELECT, which streams rows immediately and would finish within the
+   * row cap — this reliably still runs when the timeout or cancellation fires.
+   */
+  private static final String PATHOLOGICAL_QUERY =
+      "SELECT (COUNT(*) AS ?n) WHERE { ?a ?p1 ?o1 . ?b ?p2 ?o2 . ?c ?p3 ?o3 . ?d ?p4 ?o4 ."
+          + " ?e ?p5 ?o5 }";
+
+  /** From the CIMXML FullModel structure exercised in the cimxml module's own tests. */
+  private static final String CIMXML_FULL_MODEL =
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+       <md:FullModel rdf:about="urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6">
+         <md:Model.profile>http://soptim.de/CIM/MyProfile/1.1</md:Model.profile>
+       </md:FullModel>
+       <cim:MyEquipment rdf:ID="_f67fc354-9e39-4191-a456-67537399bc48">
+         <cim:IdentifiedObject.name>My Custom Equipment</cim:IdentifiedObject.name>
+       </cim:MyEquipment>
+      </rdf:RDF>
+      """;
+
+  private ExecuteRequest slowRequest(int timeoutMs) throws IOException {
+    StringBuilder turtle = new StringBuilder();
+    for (int i = 0; i < 120; i++) {
+      turtle
+          .append('<')
+          .append(EX)
+          .append('s')
+          .append(i)
+          .append("> <")
+          .append(EX)
+          .append("p> ")
+          .append(i)
+          .append(" .\n");
+    }
+    Path file = dataFile("big.ttl", turtle.toString());
+    return new ExecuteRequest(
+        "file:///cell1.sparql",
+        null,
+        "sparql",
+        PATHOLOGICAL_QUERY,
+        filesTarget(file.toString()),
+        new ExecuteOptions(timeoutMs, null));
+  }
+
+  private ExecuteResponse execute(String queryText, QueryKind kind, ExecuteRequest request) {
+    return execute(queryText, kind, request, NEVER_CANCELLED);
+  }
+
+  private ExecuteResponse execute(
+      String queryText, QueryKind kind, ExecuteRequest request, CancelChecker checker) {
+    Query query = QueryFactory.create(queryText);
+    return LocalQueryExecutor.executeQuery(
+        query, kind, request, stores, new ExecContext(executionPool, watchdogScheduler, checker));
+  }
+
+  private static ExecuteRequest request(String notebookUri, String... files) {
+    return new ExecuteRequest(
+        "file:///cell1.sparql", notebookUri, "sparql", "unused", filesTarget(files), null);
+  }
+
+  private static ExecuteTarget filesTarget(String... files) {
+    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, List.of(files));
+  }
+
+  private Path dataFile(String name, String content) throws IOException {
+    Path file = tmp.getRoot().toPath().resolve(name);
+    Files.writeString(file, content);
+    return file;
+  }
+
+  private static JsonArray bindings(ExecuteResponse response) {
+    return JsonParser.parseString(response.resultsJson())
+        .getAsJsonObject()
+        .getAsJsonObject("results")
+        .getAsJsonArray("bindings");
+  }
+
+  /** A {@link CancelChecker} that reports cancelled once {@code delayMs} has elapsed. */
+  private static CancelChecker cancelAfter(long delayMs) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayMs);
+    return new CancelChecker() {
+      @Override
+      public void checkCanceled() {}
+
+      @Override
+      public boolean isCanceled() {
+        return System.nanoTime() >= deadlineNanos;
+      }
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManagerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalStoreManagerTest.java
@@ -1,0 +1,243 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.List;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises {@link LocalStoreManager}: format dispatch (Turtle/TriG via Jena, {@code .xml} via the
+ * CIMXML parser), the union semantics documented on the class, and the cache behavior (reuse,
+ * mtime/size invalidation, LRU eviction, failed parses not cached).
+ */
+public class LocalStoreManagerTest {
+
+  private static final String EX = "http://example.org/";
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private final LocalStoreManager manager = new LocalStoreManager();
+
+  // ---- parsing and union semantics ------------------------------------------------------------
+
+  @Test
+  public void parsesTurtleIntoTheDefaultGraph() throws Exception {
+    Path file = turtleFile("data.ttl", "<" + EX + "s> <" + EX + "p> <" + EX + "o> .");
+
+    DatasetGraph union = manager.unionFor(List.of(file));
+
+    assertTrue(union.getDefaultGraph().contains(uri(EX + "s"), uri(EX + "p"), uri(EX + "o")));
+  }
+
+  @Test
+  public void unionOfTwoFilesSeesTriplesFromBoth() throws Exception {
+    Path a = turtleFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    Path b = turtleFile("b.ttl", "<" + EX + "b> <" + EX + "p> 2 .");
+
+    Graph defaultGraph = manager.unionFor(List.of(a, b)).getDefaultGraph();
+
+    assertTrue(defaultGraph.contains(uri(EX + "a"), uri(EX + "p"), null));
+    assertTrue(defaultGraph.contains(uri(EX + "b"), uri(EX + "p"), null));
+  }
+
+  @Test
+  public void namedGraphsStayAddressableAndJoinTheDefaultUnion() throws Exception {
+    Path file = write("data.trig", "<" + EX + "g> { <" + EX + "s> <" + EX + "p> <" + EX + "o> . }");
+
+    DatasetGraph union = manager.unionFor(List.of(file));
+
+    assertTrue("GRAPH lookup must still work", union.containsGraph(uri(EX + "g")));
+    assertTrue(union.getGraph(uri(EX + "g")).contains(uri(EX + "s"), uri(EX + "p"), uri(EX + "o")));
+    assertTrue(
+        "a bare triple pattern must see named-graph data",
+        union.getDefaultGraph().contains(uri(EX + "s"), uri(EX + "p"), uri(EX + "o")));
+  }
+
+  @Test
+  public void parsesCimxmlModelWithBodyAndHeaderVisibleInTheUnion() throws Exception {
+    Path file = write("model.xml", CIMXML_FULL_MODEL);
+
+    Graph defaultGraph = manager.unionFor(List.of(file)).getDefaultGraph();
+
+    assertTrue(
+        "model body must be queryable",
+        defaultGraph.contains(
+            uri("urn:uuid:f67fc354-9e39-4191-a456-67537399bc48"),
+            uri("http://iec.ch/TC57/CIM100#IdentifiedObject.name"),
+            null));
+    assertTrue(
+        "the FullModel header (a named graph in the parsed dataset) must join the union",
+        defaultGraph.contains(
+            uri("urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6"),
+            uri("http://iec.ch/TC57/61970-552/ModelDescription/1#Model.profile"),
+            null));
+  }
+
+  // ---- failure modes ---------------------------------------------------------------------------
+
+  @Test
+  public void missingFileReportsFileNotFound() {
+    Path missing = tmp.getRoot().toPath().resolve("nope.ttl");
+
+    LocalStoreManager.StoreException e = expectStoreException(List.of(missing));
+
+    assertEquals(ErrorCode.FILE_NOT_FOUND, e.code());
+    assertTrue(e.getMessage().contains("nope.ttl"));
+  }
+
+  @Test
+  public void directoryReportsFileNotFound() throws IOException {
+    Path dir = tmp.newFolder("adir").toPath();
+
+    assertEquals(ErrorCode.FILE_NOT_FOUND, expectStoreException(List.of(dir)).code());
+  }
+
+  @Test
+  public void unparseableFileReportsFileParseErrorAndIsRetriedAfterAFix() throws Exception {
+    Path file = turtleFile("broken.ttl", "this is not turtle @@@");
+
+    LocalStoreManager.StoreException e = expectStoreException(List.of(file));
+    assertEquals(ErrorCode.FILE_PARSE_ERROR, e.code());
+    assertTrue("message should name the file", e.getMessage().contains("broken.ttl"));
+
+    Files.writeString(file, "<" + EX + "s> <" + EX + "p> <" + EX + "o> .");
+    assertTrue(
+        "a failed parse must not be cached",
+        manager
+            .unionFor(List.of(file))
+            .getDefaultGraph()
+            .contains(uri(EX + "s"), uri(EX + "p"), uri(EX + "o")));
+  }
+
+  // ---- caching ---------------------------------------------------------------------------------
+
+  // Cache reuse vs re-parse is observed through the identity of the per-file DatasetGraph
+  // (datasetGraphFor is package-private for exactly this): a cache hit returns the identical
+  // instance, a re-parse a fresh one. (Instance identity of getDefaultGraph() would not work —
+  // in-memory datasets hand out a new GraphView wrapper on every call.)
+
+  @Test
+  public void unchangedFileIsServedFromTheCache() throws Exception {
+    Path file = turtleFile("data.ttl", "<" + EX + "s> <" + EX + "p> 1 .");
+
+    assertSame(manager.datasetGraphFor(file), manager.datasetGraphFor(file));
+  }
+
+  @Test
+  public void changedMtimeInvalidatesTheCachedParse() throws Exception {
+    Path file = turtleFile("data.ttl", "<" + EX + "s> <" + EX + "p> 1 .");
+    DatasetGraph before = manager.datasetGraphFor(file);
+
+    // Same byte length, different content: only the modification time reveals the change.
+    Files.writeString(file, "<" + EX + "s> <" + EX + "p> 2 .");
+    FileTime bumped = FileTime.fromMillis(Files.getLastModifiedTime(file).toMillis() + 2_000);
+    Files.setLastModifiedTime(file, bumped);
+
+    DatasetGraph after = manager.datasetGraphFor(file);
+    assertNotSame(before, after);
+    assertTrue(
+        "the re-parse must expose the new content",
+        after.getDefaultGraph().contains(uri(EX + "s"), uri(EX + "p"), integerLiteral("2")));
+  }
+
+  @Test
+  public void changedSizeInvalidatesTheCachedParse() throws Exception {
+    Path file = turtleFile("data.ttl", "<" + EX + "s> <" + EX + "p> 1 .");
+    FileTime originalMtime = Files.getLastModifiedTime(file);
+    DatasetGraph before = manager.datasetGraphFor(file);
+
+    Files.writeString(file, "<" + EX + "s> <" + EX + "p> 1 . <" + EX + "s2> <" + EX + "p> 2 .");
+    // Pin the mtime back to the cached one so only the size reveals the change.
+    Files.setLastModifiedTime(file, originalMtime);
+
+    assertNotSame(before, manager.datasetGraphFor(file));
+  }
+
+  @Test
+  public void leastRecentlyUsedEntryIsEvictedBeyondCapacity() throws Exception {
+    LocalStoreManager small = new LocalStoreManager(1);
+    Path a = turtleFile("a.ttl", "<" + EX + "a> <" + EX + "p> 1 .");
+    Path b = turtleFile("b.ttl", "<" + EX + "b> <" + EX + "p> 2 .");
+
+    DatasetGraph firstParse = small.datasetGraphFor(a);
+    assertSame("sanity: a cache hit while still resident", firstParse, small.datasetGraphFor(a));
+    small.datasetGraphFor(b); // capacity 1: evicts a
+    assertNotSame("evicted file must be re-parsed", firstParse, small.datasetGraphFor(a));
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------------
+
+  /** From the CIMXML FullModel structure exercised in the cimxml module's own tests. */
+  private static final String CIMXML_FULL_MODEL =
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+       <md:FullModel rdf:about="urn:uuid:08984e27-811f-4042-9125-1531ae0de0f6">
+         <md:Model.profile>http://soptim.de/CIM/MyProfile/1.1</md:Model.profile>
+       </md:FullModel>
+       <cim:MyEquipment rdf:ID="_f67fc354-9e39-4191-a456-67537399bc48">
+         <cim:IdentifiedObject.name>My Custom Equipment</cim:IdentifiedObject.name>
+       </cim:MyEquipment>
+      </rdf:RDF>
+      """;
+
+  private Path turtleFile(String name, String turtle) throws IOException {
+    return write(name, turtle);
+  }
+
+  private Path write(String name, String content) throws IOException {
+    Path file = tmp.getRoot().toPath().resolve(name);
+    Files.writeString(file, content);
+    return file;
+  }
+
+  private LocalStoreManager.StoreException expectStoreException(List<Path> files) {
+    try {
+      manager.unionFor(files);
+      fail("expected a StoreException for " + files);
+      throw new AssertionError("unreachable");
+    } catch (LocalStoreManager.StoreException e) {
+      return e;
+    }
+  }
+
+  private static org.apache.jena.graph.Node uri(String uri) {
+    return NodeFactory.createURI(uri);
+  }
+
+  private static org.apache.jena.graph.Node integerLiteral(String lexicalForm) {
+    return NodeFactory.createLiteralDT(lexicalForm, XSDDatatype.XSDinteger);
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -24,8 +24,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -162,6 +165,45 @@ public class NotebookCommandHandlerTest {
     assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
   }
 
+  // ---- local-file targets ----------------------------------------------------------------------
+
+  @Test
+  public void executeCommandRoutesFilesTargetToTheLocalExecutor() throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-handler");
+    try {
+      Files.writeString(
+          dir.resolve("data.ttl"), "<http://example.org/s> <http://example.org/p> \"v\" .");
+      JsonObject arg = filesRequestJson("ASK { ?s ?p ?o }", dir, "./data.ttl");
+
+      ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+      assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+      assertEquals(QueryKind.ASK.name(), response.queryKind());
+      assertEquals("./data.ttl", response.stats().resolvedTarget());
+    } finally {
+      try (var paths = Files.walk(dir)) {
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
+  @Test
+  public void executeCommandRejectsUpdatesAgainstFilesTargets() throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-handler");
+    try {
+      JsonObject arg =
+          filesRequestJson(
+              "INSERT DATA { <http://example.org/s> <http://example.org/p> 1 }", dir, "./data.ttl");
+
+      ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+      assertEquals(ExecutionStatus.ERROR.name(), response.status());
+      assertEquals(ErrorCode.UPDATE_NOT_ALLOWED.name(), response.error().code());
+    } finally {
+      Files.delete(dir);
+    }
+  }
+
   // ---- wire shape ----------------------------------------------------------------------------
 
   /**
@@ -228,6 +270,23 @@ public class NotebookCommandHandlerTest {
   }
 
   // ---- helpers ------------------------------------------------------------------------------
+
+  private static JsonObject filesRequestJson(String text, Path notebookDir, String... files) {
+    JsonObject arg = new JsonObject();
+    arg.addProperty("cellUri", "file:///cell1.sparql");
+    arg.addProperty("notebookUri", notebookDir.resolve("demo.cimnb.md").toUri().toString());
+    arg.addProperty("languageId", "sparql");
+    arg.addProperty("text", text);
+    JsonObject target = new JsonObject();
+    target.addProperty("type", ExecuteTarget.TYPE_FILES);
+    JsonArray fileArray = new JsonArray();
+    for (String file : files) {
+      fileArray.add(file);
+    }
+    target.add("files", fileArray);
+    arg.add("target", target);
+    return arg;
+  }
 
   private static JsonObject requestJson(String text, String url, String updateUrl) {
     JsonObject arg = new JsonObject();

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 # CIM Notebooks
 
 CIM Notebooks are CIMNotebook's own notebook documents for VS Code: markdown files whose
-```` ```sparql ```` and ```` ```shacl ```` code blocks open as notebook cells. Because the
+` ```sparql ` and ` ```shacl ` code blocks open as notebook cells. Because the
 on-disk format **is** plain markdown, notebooks diff and merge cleanly in git, render on any
 git forge, and need no special tooling to read.
 
@@ -30,13 +30,13 @@ reads and writes Zazuko's `.sparqlbook` format for interoperability.
 
 ## File formats
 
-| Format | Opens as notebook | Notes |
-| --- | --- | --- |
-| `*.cimnb.md` | by default | The native format. A regular markdown file — the suffix just tells VS Code to open it as a notebook. |
-| any `*.md` / `*.markdown` | via **Open With… → CIM Notebook (Markdown)** | Turn any markdown document (a README, a runbook) into a notebook without renaming it. |
-| `*.sparqlbook` | via **Open With… → CIM Notebook (SPARQL Book)** | Zazuko SPARQL Notebook interop (JSON). |
+| Format                    | Opens as notebook                               | Notes                                                                                                |
+| ------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `*.cimnb.md`              | by default                                      | The native format. A regular markdown file — the suffix just tells VS Code to open it as a notebook. |
+| any `*.md` / `*.markdown` | via **Open With… → CIM Notebook (Markdown)**    | Turn any markdown document (a README, a runbook) into a notebook without renaming it.                |
+| `*.sparqlbook`            | via **Open With… → CIM Notebook (SPARQL Book)** | Zazuko SPARQL Notebook interop (JSON).                                                               |
 
-To use **Open With…**: right-click the file in the Explorer → *Open With…* → pick the CIM
+To use **Open With…**: right-click the file in the Explorer → _Open With…_ → pick the CIM
 Notebook editor. VS Code remembers the choice per file type if you set it as default.
 
 ## The markdown format
@@ -78,18 +78,24 @@ back) and opens it. The source file is never modified. Zazuko per-cell metadata 
 
 ## Running cells
 
-SPARQL cells have a **Run** button (the *CIM Notebook* kernel). Execution happens inside
+SPARQL cells have a **Run** button (the _CIM Notebook_ kernel). Execution happens inside
 CIMLangServer — the same Java process that validates your queries — using Apache Jena's
 SPARQL 1.1 engine, so there is nothing extra to install.
 
 A cell names its target with the same `# [endpoint=...]` directive used for validation —
-one directive drives both *validate against* and *run against*:
+one directive drives both _validate against_ and _run against_. The target can be a SPARQL
+endpoint or local data files:
 
 ```sparql
 # [endpoint=http://localhost:3030/cgmes/query]
 SELECT ?class (COUNT(?s) AS ?n)
 WHERE { ?s a ?class }
 GROUP BY ?class ORDER BY DESC(?n)
+```
+
+```sparql
+# [endpoint=./model.xml]
+SELECT ?name WHERE { ?s cim:IdentifiedObject.name ?name }
 ```
 
 What you get per query kind:
@@ -115,10 +121,36 @@ assumed to accept updates directly.
 stops waiting and aborts the query where the endpoint supports it). Requests time out
 after 30 seconds by default.
 
+### Querying local files — including CIMXML models
+
+When a directive is not an `http(s)://` URL it is taken as a file path, relative to the
+notebook's own directory. The file is parsed in-process and queried directly — no triple
+store, no import step:
+
+- **CIMXML models** (`*.xml`): parsed by OpenCGMES's IEC 61970-552 parser. The model body
+  and its `md:FullModel` header are both queryable.
+- **RDF files**: anything Jena reads by extension — `.ttl`, `.rdf`, `.owl`, `.nt`, `.nq`,
+  `.trig`, ….
+
+Several directives in one cell query the **union** of the files: named graphs stay
+addressable with `GRAPH`, and a bare `?s ?p ?o` sees everything.
+
+```sparql
+# [endpoint=./model.xml]
+# [endpoint=./boundary.ttl]
+SELECT (COUNT(*) AS ?triples) WHERE { ?s ?p ?o }
+```
+
+Parsed files are cached in the language server and re-parsed automatically when the file
+changes on disk, so _edit model → re-run cell_ just works. Local files are **read-only**:
+a SPARQL Update against a file target is rejected — updates need an HTTP endpoint.
+
+Note the dual meaning of the directive: for _validation_, a `.ttl`/`.rdf`/`.owl` file is
+loaded as the schema, while instance-data files (`.xml` models, `.nt`/`.nq`/`.trig` dumps)
+keep the workspace schema so diagnostics stay meaningful — and either way the file is what
+the cell _runs_ against.
+
 **Current limitations:**
 
-- Only `http(s)://` endpoints can be executed. A directive pointing at a local file is
-  still used for *validation*, but running such a cell reports it as unsupported —
-  querying local RDF and CIMXML files is planned next.
-- SHACL cells are validated statically but cannot be *run* yet.
-- No authentication support yet — the endpoint must be reachable without credentials.
+- SHACL cells are validated statically but cannot be _run_ yet.
+- No authentication support yet — HTTP endpoints must be reachable without credentials.


### PR DESCRIPTION
A cell's `# [endpoint=...]` directive may name local files instead of an HTTP endpoint: *.xml is parsed as an IEC 61970-552 CIMXML model, anything else by Jena from its extension (.ttl, .rdf, .owl, .nt, .nq, .trig, …). Relative paths resolve against the notebook's directory, matching how validation resolves the same directive.

Several directives query the union of the files: every named graph stays addressable with GRAPH, while the default graph unions all graphs of all files, so a bare ?s ?p ?o sees everything — including a CIMXML model's header. Parses are cached per file and invalidated on mtime/size change, so "edit model → re-run cell" just works; the cache is LRU-bounded because CIMXML models can be large. Local files are read-only: a SPARQL Update against a file target is rejected.

Closes #49