### PR TITLE
feat(cimvocabcheck): SHACL validation for notebook cells (GH-50)

### DIFF
--- a/cimnotebook/vscode/src/notebook/controller.ts
+++ b/cimnotebook/vscode/src/notebook/controller.ts
@@ -42,10 +42,9 @@ export function registerNotebookControllers(
             notebookType,
             "CIM Notebook",
         );
-        // SPARQL only until SHACL execution lands; the LSP still validates shacl cells.
-        controller.supportedLanguages = ["sparql"];
+        controller.supportedLanguages = ["sparql", "shacl"];
         controller.supportsExecutionOrder = true;
-        controller.description = "Runs SPARQL cells via CIMLangServer";
+        controller.description = "Runs SPARQL and SHACL cells via CIMLangServer";
         controller.executeHandler = async (cells) => {
             for (const cell of cells) {
                 const execution = controller.createNotebookCellExecution(cell);

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -19,7 +19,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { deriveUpdateUrl, parseEndpointDirectives, resolveTarget } from "./endpoint";
+import {
+    deriveShaclUrl,
+    deriveUpdateUrl,
+    parseEndpointDirectives,
+    resolveTarget,
+} from "./endpoint";
 
 describe("parseEndpointDirectives", () => {
     it("finds every directive, in order, with flexible spacing", () => {
@@ -49,12 +54,13 @@ describe("resolveTarget", () => {
         assert.deepEqual(resolveTarget("SELECT * WHERE { ?s ?p ?o }"), { type: "none" });
     });
 
-    it("picks the first http(s) directive and derives the update sibling", () => {
+    it("picks the first http(s) directive and derives the update and shacl siblings", () => {
         const target = resolveTarget("# [endpoint=https://host/ds/query]\nASK {}");
         assert.deepEqual(target, {
             type: "http",
             url: "https://host/ds/query",
             updateUrl: "https://host/ds/update",
+            shaclUrl: "https://host/ds/shacl?graph=default",
         });
     });
 
@@ -80,6 +86,32 @@ describe("resolveTarget", () => {
             "# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}",
         );
         assert.equal(target.type, "http");
+    });
+});
+
+describe("deriveShaclUrl", () => {
+    it("maps Fuseki-style query/sparql services to the shacl sibling with a default graph", () => {
+        assert.equal(
+            deriveShaclUrl("http://h:3030/ds/query"),
+            "http://h:3030/ds/shacl?graph=default",
+        );
+        assert.equal(deriveShaclUrl("http://h/ds/sparql"), "http://h/ds/shacl?graph=default");
+    });
+
+    it("appends /shacl to dataset-style URLs", () => {
+        assert.equal(deriveShaclUrl("http://h/ds"), "http://h/ds/shacl?graph=default");
+        assert.equal(deriveShaclUrl("http://h/ds/"), "http://h/ds/shacl?graph=default");
+    });
+
+    it("keeps an explicit shacl service and preserves an existing query string", () => {
+        assert.equal(
+            deriveShaclUrl("http://h/ds/shacl?graph=urn:x"),
+            "http://h/ds/shacl?graph=urn:x",
+        );
+        assert.equal(
+            deriveShaclUrl("http://h/ds/query?graph=urn:x"),
+            "http://h/ds/shacl?graph=urn:x",
+        );
     });
 });
 

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -35,7 +35,7 @@ export function parseEndpointDirectives(text: string): string[] {
 }
 
 export type ResolvedTarget =
-    | { type: "http"; url: string; updateUrl: string }
+    | { type: "http"; url: string; updateUrl: string; shaclUrl: string }
     | { type: "files"; files: string[] }
     | { type: "none" };
 
@@ -54,7 +54,7 @@ export function resolveTarget(cellText: string): ResolvedTarget {
     if (url === undefined) {
         return { type: "files", files: directives };
     }
-    return { type: "http", url, updateUrl: deriveUpdateUrl(url) };
+    return { type: "http", url, updateUrl: deriveUpdateUrl(url), shaclUrl: deriveShaclUrl(url) };
 }
 
 /**
@@ -69,6 +69,26 @@ export function deriveUpdateUrl(url: string): string {
     return sibling ? sibling[1] + "update" : url;
 }
 
+/**
+ * Best-effort SHACL service URL for a query endpoint URL: Fuseki-style `…/query` or
+ * `…/sparql` services get their `…/shacl` sibling, a URL already ending in `/shacl` is
+ * kept, and anything else gets `/shacl` appended. Fuseki's SHACL operation requires a
+ * `?graph=` selector, so an existing query string is preserved and `?graph=default`
+ * (the default graph) is added when there is none. As with updates, the server never
+ * derives this — an explicit `shaclUrl` is required there.
+ */
+export function deriveShaclUrl(url: string): string {
+    const query = /\?.*$/.exec(url)?.[0] ?? "";
+    const path = query ? url.slice(0, -query.length) : url;
+    const sibling = /^(.*\/)(?:query|sparql)$/i.exec(path);
+    const shaclPath = sibling
+        ? sibling[1] + "shacl"
+        : /\/shacl$/i.test(path)
+          ? path
+          : path.replace(/\/+$/, "") + "/shacl";
+    return shaclPath + (query || "?graph=default");
+}
+
 // ---- Wire types for cimvocabcheck.notebook.execute (mirror the server's records) ----
 
 export const EXECUTE_COMMAND = "cimvocabcheck.notebook.execute";
@@ -77,6 +97,7 @@ export interface ExecuteTarget {
     type: "http" | "files";
     url?: string;
     updateUrl?: string;
+    shaclUrl?: string;
     files?: string[];
 }
 
@@ -90,7 +111,14 @@ export interface ExecuteRequest {
     options?: { timeoutMs?: number; maxRows?: number };
 }
 
-export type QueryKind = "SELECT" | "ASK" | "CONSTRUCT" | "DESCRIBE" | "UPDATE";
+export type QueryKind = "SELECT" | "ASK" | "CONSTRUCT" | "DESCRIBE" | "UPDATE" | "SHACL";
+
+export interface ShaclSummary {
+    conforms: boolean;
+    violations: number;
+    warnings: number;
+    infos: number;
+}
 
 export interface ExecError {
     code: string;
@@ -112,6 +140,7 @@ export interface ExecuteResponse {
     queryKind?: QueryKind | null;
     resultsJson?: string | null;
     turtle?: string | null;
+    shaclSummary?: ShaclSummary | null;
     stats?: ExecStats | null;
     error?: ExecError | null;
 }

--- a/cimnotebook/vscode/src/notebook/outputs.test.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.test.ts
@@ -26,6 +26,7 @@ import {
     MIME_MARKDOWN,
     outputItemsFor,
     selectResultsToMarkdown,
+    shaclReportToMarkdown,
     turtleToMarkdown,
     updateResultToMarkdown,
 } from "./outputs";
@@ -125,6 +126,37 @@ describe("turtleToMarkdown", () => {
     });
 });
 
+describe("shaclReportToMarkdown", () => {
+    const report = "[] a sh:ValidationReport ; sh:conforms true .";
+
+    it("renders a conforming verdict with the fenced report", () => {
+        const md = shaclReportToMarkdown(
+            report,
+            { conforms: true, violations: 0, warnings: 0, infos: 0 },
+            { durationMs: 12, truncated: false, resolvedTarget: "./model.xml" },
+        );
+        assert.ok(md.startsWith("✅ **Conforms**"));
+        assert.ok(md.includes("```turtle\n" + report + "\n```"));
+        assert.ok(md.includes("12 ms"));
+    });
+
+    it("counts violations and mentions warnings/infos only when present", () => {
+        const md = shaclReportToMarkdown("report", {
+            conforms: false,
+            violations: 2,
+            warnings: 1,
+            infos: 0,
+        });
+        assert.ok(md.startsWith("❌ **Does not conform** — 2 violations, 1 warning."));
+        assert.ok(!md.includes("info"));
+    });
+
+    it("copes with a missing summary and an empty report", () => {
+        const md = shaclReportToMarkdown("", null);
+        assert.equal(md, "**Validation finished.**");
+    });
+});
+
 describe("updateResultToMarkdown", () => {
     it("confirms the update with stats", () => {
         const md = updateResultToMarkdown({ durationMs: 8, truncated: false });
@@ -153,6 +185,12 @@ describe("outputItemsFor", () => {
             { status: "SUCCESS", queryKind: "ASK", resultsJson: '{"boolean":true}' },
             { status: "SUCCESS", queryKind: "CONSTRUCT", turtle: "<a> <b> <c> ." },
             { status: "SUCCESS", queryKind: "UPDATE" },
+            {
+                status: "SUCCESS",
+                queryKind: "SHACL",
+                turtle: "",
+                shaclSummary: { conforms: true, violations: 0, warnings: 0, infos: 0 },
+            },
         ] as const;
 
         for (const response of responses) {

--- a/cimnotebook/vscode/src/notebook/outputs.ts
+++ b/cimnotebook/vscode/src/notebook/outputs.ts
@@ -26,7 +26,7 @@
  * *Change Presentation*.
  */
 
-import { ExecError, ExecStats, ExecuteResponse } from "./endpoint";
+import { ExecError, ExecStats, ExecuteResponse, ShaclSummary } from "./endpoint";
 
 /** Rows shown in the markdown table; the raw output item carries the full result. */
 export const DISPLAY_ROW_CAP = 50;
@@ -80,6 +80,16 @@ export function outputItemsFor(response: ExecuteResponse): OutputItem[] {
         }
         case "UPDATE":
             return [{ mime: MIME_MARKDOWN, text: updateResultToMarkdown(stats) }];
+        case "SHACL": {
+            const turtle = response.turtle ?? "";
+            return [
+                {
+                    mime: MIME_MARKDOWN,
+                    text: shaclReportToMarkdown(turtle, response.shaclSummary, stats),
+                },
+                { mime: MIME_TEXT, text: turtle },
+            ];
+        }
         default:
             return [];
     }
@@ -139,6 +149,38 @@ export function turtleToMarkdown(turtle: string, stats?: ExecStats | null): stri
 /** Confirmation line for a successful UPDATE. */
 export function updateResultToMarkdown(stats?: ExecStats | null): string {
     return "✅ **Update executed.**" + statsFooter(stats);
+}
+
+/** Verdict banner plus the fenced validation report for a SHACL run. */
+export function shaclReportToMarkdown(
+    turtle: string,
+    summary: ShaclSummary | null | undefined,
+    stats?: ExecStats | null,
+): string {
+    const banner =
+        summary == null
+            ? "**Validation finished.**"
+            : summary.conforms
+              ? "✅ **Conforms** — no validation results."
+              : `❌ **Does not conform** — ${shaclCounts(summary)}.`;
+    const report = turtle.trimEnd();
+    const fenced = report.length > 0 ? "\n\n```turtle\n" + report + "\n```" : "";
+    return banner + fenced + statsFooter(stats);
+}
+
+function shaclCounts(summary: ShaclSummary): string {
+    const parts = [plural(summary.violations, "violation")];
+    if (summary.warnings > 0) {
+        parts.push(plural(summary.warnings, "warning"));
+    }
+    if (summary.infos > 0) {
+        parts.push(plural(summary.infos, "info"));
+    }
+    return parts.join(", ");
+}
+
+function plural(n: number, noun: string): string {
+    return `${n} ${noun}${n === 1 ? "" : "s"}`;
 }
 
 /** One-line summary for `NotebookCellOutputItem.error`, with parse position if known. */

--- a/cimvocabcheck/lsp/pom.xml
+++ b/cimvocabcheck/lsp/pom.xml
@@ -54,9 +54,10 @@
         <ver.slf4j>2.0.18</ver.slf4j>
         <ver.log4j2>2.26.1</ver.log4j2>
         <ver.junit4>4.13.2</ver.junit4>
-        <!-- Test-only: in-process Fuseki server for notebook execution tests. Jena itself is
-             already on the classpath transitively via cimvocabcheck-core (${ver.jena} there);
-             kept in sync manually since this module has no direct compile-scope Jena dependency. -->
+        <!-- Jena bits this module needs directly: jena-shacl (compile, notebook SHACL cells) and
+             jena-fuseki-main (test, in-process endpoint for notebook execution tests). The Jena
+             core stack itself comes transitively via cimvocabcheck-core (${ver.jena} there);
+             kept in sync manually. -->
         <ver.jena>6.1.0</ver.jena>
 
         <ver.plugin.compiler>3.15.0</ver.plugin.compiler>
@@ -122,6 +123,13 @@
             <artifactId>log4j-core</artifactId>
             <version>${ver.log4j2}</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <!-- SHACL validation engine for notebook SHACL cells -->
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-shacl</artifactId>
+            <version>${ver.jena}</version>
         </dependency>
 
         <!-- Test -->

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
@@ -20,6 +20,7 @@ package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.jena.query.QueryExecution;
@@ -57,6 +58,18 @@ final class ExecSupport {
    */
   static ExecuteResponse runCancellable(
       ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work) {
+    return runCancellable(ctx, bestEffortAbort, work, 0);
+  }
+
+  /**
+   * Like {@link #runCancellable(ExecContext, Runnable, Supplier)}, but additionally resolves to a
+   * {@link ErrorCode#TIMEOUT} response after {@code timeoutMs} (when positive). For Jena query
+   * executions the engine's own {@code timeout(...)} is the better mechanism — this variant exists
+   * for blocking work without native timeout support, such as in-process SHACL validation; like a
+   * cancelled UPDATE, timed-out work keeps running in the background until it finishes on its own.
+   */
+  static ExecuteResponse runCancellable(
+      ExecContext ctx, Runnable bestEffortAbort, Supplier<ExecuteResponse> work, long timeoutMs) {
     CompletableFuture<ExecuteResponse> workFuture =
         CompletableFuture.supplyAsync(work, ctx.executionPool());
     CompletableFuture<ExecuteResponse> cancelFuture = new CompletableFuture<>();
@@ -73,10 +86,25 @@ final class ExecSupport {
               cancelFuture.complete(ExecuteResponse.cancelled());
               bestEffortAbort.run();
             });
+    ScheduledFuture<?> timeoutTask =
+        timeoutMs > 0
+            ? ctx.watchdogScheduler()
+                .schedule(
+                    () ->
+                        cancelFuture.complete(
+                            ExecuteResponse.failed(
+                                new ExecError(
+                                    ErrorCode.TIMEOUT, "Request timed out.", null, null, null))),
+                    timeoutMs,
+                    TimeUnit.MILLISECONDS)
+            : null;
     try {
       return workFuture.applyToEither(cancelFuture, Function.identity()).join();
     } finally {
       watchdogTask.cancel(true);
+      if (timeoutTask != null) {
+        timeoutTask.cancel(true);
+      }
     }
   }
 
@@ -113,6 +141,7 @@ final class ExecSupport {
       }
       case UPDATE ->
           throw new IllegalStateException("UPDATE must be routed through executeUpdate(...)");
+      case SHACL -> throw new IllegalStateException("SHACL must be routed through ShaclExecutor");
     };
   }
 

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteResponse.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteResponse.java
@@ -32,8 +32,10 @@ package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
  * @param queryKind the detected kind of the cell's text: a {@link QueryKind} name; {@code null}
  *     unless {@code status} is {@code SUCCESS}.
  * @param resultsJson SPARQL 1.1 Query Results JSON for a SELECT or ASK, {@code null} otherwise.
- * @param turtle Turtle serialization of the result graph for a CONSTRUCT or DESCRIBE, {@code null}
- *     otherwise.
+ * @param turtle Turtle serialization of the result graph for a CONSTRUCT or DESCRIBE, or of the
+ *     validation report for a SHACL run; {@code null} otherwise.
+ * @param shaclSummary aggregated verdict of a SHACL run; {@code null} unless {@code queryKind} is
+ *     {@code SHACL}.
  * @param stats execution metadata; {@code null} unless {@code status} is {@code SUCCESS}.
  * @param error failure details; {@code null} unless {@code status} is not {@code SUCCESS}.
  */
@@ -42,36 +44,50 @@ record ExecuteResponse(
     String queryKind,
     String resultsJson,
     String turtle,
+    ShaclSummary shaclSummary,
     ExecStats stats,
     ExecError error) {
 
   /** A successful SELECT or ASK execution. */
   static ExecuteResponse successJson(QueryKind kind, String resultsJson, ExecStats stats) {
     return new ExecuteResponse(
-        ExecutionStatus.SUCCESS.name(), kind.name(), resultsJson, null, stats, null);
+        ExecutionStatus.SUCCESS.name(), kind.name(), resultsJson, null, null, stats, null);
   }
 
   /** A successful CONSTRUCT or DESCRIBE execution. */
   static ExecuteResponse successTurtle(QueryKind kind, String turtle, ExecStats stats) {
     return new ExecuteResponse(
-        ExecutionStatus.SUCCESS.name(), kind.name(), null, turtle, stats, null);
+        ExecutionStatus.SUCCESS.name(), kind.name(), null, turtle, null, stats, null);
   }
 
   /** A successful UPDATE execution (no result payload). */
   static ExecuteResponse successUpdate(ExecStats stats) {
     return new ExecuteResponse(
-        ExecutionStatus.SUCCESS.name(), QueryKind.UPDATE.name(), null, null, stats, null);
+        ExecutionStatus.SUCCESS.name(), QueryKind.UPDATE.name(), null, null, null, stats, null);
+  }
+
+  /** A completed SHACL validation run (successful even when the data does not conform). */
+  static ExecuteResponse successShacl(String reportTurtle, ShaclSummary summary, ExecStats stats) {
+    return new ExecuteResponse(
+        ExecutionStatus.SUCCESS.name(),
+        QueryKind.SHACL.name(),
+        null,
+        reportTurtle,
+        summary,
+        stats,
+        null);
   }
 
   /** A failed execution. */
   static ExecuteResponse failed(ExecError error) {
-    return new ExecuteResponse(ExecutionStatus.ERROR.name(), null, null, null, null, error);
+    return new ExecuteResponse(ExecutionStatus.ERROR.name(), null, null, null, null, null, error);
   }
 
   /** An execution that was cancelled before it produced a result. */
   static ExecuteResponse cancelled() {
     return new ExecuteResponse(
         ExecutionStatus.CANCELLED.name(),
+        null,
         null,
         null,
         null,

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
@@ -31,12 +31,16 @@ import java.util.List;
  *     means this target has no configured update endpoint, so a cell that parses as a SPARQL Update
  *     is rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED} rather than silently reusing {@link
  *     #url()}.
+ * @param shaclUrl the SHACL validation service URL ({@code "http"} targets only), e.g. Fuseki's
+ *     {@code …/shacl} operation. {@code null}/blank means SHACL cells cannot run against this
+ *     target; like {@link #updateUrl()}, the server never derives it — the client does.
  * @param files the local files to query, exactly as written in the directives ({@code "files"}
  *     targets only). Relative paths are resolved server-side against the directory of {@link
  *     ExecuteRequest#notebookUri()}; multiple files are queried as one union store. Local files are
  *     read-only — updates are rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED}.
  */
-record ExecuteTarget(String type, String url, String updateUrl, List<String> files) {
+record ExecuteTarget(
+    String type, String url, String updateUrl, String shaclUrl, List<String> files) {
 
   /** Target {@link #type()}: a remote SPARQL endpoint. */
   static final String TYPE_HTTP = "http";

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpShaclClient.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpShaclClient.java
@@ -1,0 +1,160 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.shacl.ValidationReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates a SHACL cell against a remote SHACL service (Fuseki's {@code …/shacl} operation and
+ * compatibles): the cell's shapes are POSTed as {@code text/turtle} and the service validates its
+ * own data against them, answering with a validation report as Turtle. Any {@code ?graph=…} query
+ * parameter on the {@link ExecuteTarget#shaclUrl()} travels as-is, so a directive can pin the graph
+ * to validate.
+ *
+ * <p>The blocking HTTP call runs under the usual cancellation race ({@link
+ * ExecSupport#runCancellable}); the request timeout is enforced by the HTTP client itself.
+ */
+final class HttpShaclClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpShaclClient.class);
+
+  private static final String TEXT_TURTLE = "text/turtle";
+
+  /**
+   * One client for all SHACL requests. An {@link HttpClient} owns a selector thread and an
+   * executor, and is only released once it becomes unreachable — a per-request client would leave
+   * those threads behind on every SHACL cell run. The timeout is per-request ({@link
+   * HttpRequest#timeout()}), so nothing here needs to be per-execution.
+   */
+  private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+  private HttpShaclClient() {}
+
+  /** Validates {@code shapesTurtle} against the target's SHACL service. */
+  static ExecuteResponse validate(
+      String shapesTurtle, ExecuteTarget target, ExecuteOptions options, ExecContext ctx) {
+    String shaclUrl = target.shaclUrl();
+    if (ExecSupport.isBlank(shaclUrl)) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.NO_TARGET,
+              "This endpoint has no SHACL validation service configured.",
+              null,
+              null,
+              null));
+    }
+
+    HttpRequest request;
+    try {
+      request =
+          HttpRequest.newBuilder(URI.create(shaclUrl))
+              .timeout(Duration.ofMillis(ExecSupport.timeoutMs(options)))
+              .header("Content-Type", TEXT_TURTLE)
+              .header("Accept", TEXT_TURTLE)
+              .POST(HttpRequest.BodyPublishers.ofString(shapesTurtle))
+              .build();
+    } catch (IllegalArgumentException e) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.HTTP_ERROR, "Invalid SHACL service URL: " + shaclUrl, null, null, null));
+    }
+    return ExecSupport.runCancellable(ctx, () -> {}, () -> send(request, shaclUrl));
+  }
+
+  /** Runs on {@code ctx.executionPool()}. */
+  private static ExecuteResponse send(HttpRequest request, String shaclUrl) {
+    long start = System.currentTimeMillis();
+    try {
+      HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+      return toResponse(response, start, shaclUrl);
+    } catch (HttpTimeoutException e) {
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.TIMEOUT, "Request timed out.", e.getMessage(), null, null));
+    } catch (IOException e) {
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.HTTP_ERROR, e.getMessage(), null, null, null));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.debug("SHACL request interrupted after cancellation");
+      return ExecuteResponse.cancelled();
+    }
+  }
+
+  private static ExecuteResponse toResponse(
+      HttpResponse<String> response, long startMs, String shaclUrl) {
+    int status = response.statusCode();
+    String body = response.body();
+    if (status == 401 || status == 403) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.AUTH_FAILED,
+              "Authentication failed (HTTP " + status + ").",
+              trimmed(body),
+              null,
+              null));
+    }
+    if (status < 200 || status >= 300) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.HTTP_ERROR,
+              "SHACL service answered HTTP " + status + ".",
+              trimmed(body),
+              null,
+              null));
+    }
+
+    ValidationReport report;
+    try {
+      Model model = ModelFactory.createDefaultModel();
+      model.read(new StringReader(body), null, "TURTLE");
+      report = ValidationReport.fromModel(model);
+    } catch (RuntimeException e) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.HTTP_ERROR,
+              "SHACL service returned a report that could not be parsed: " + e.getMessage(),
+              trimmed(body),
+              null,
+              null));
+    }
+    // Keep the service's own serialization as the payload — it is what the user's endpoint said.
+    return ShaclExecutor.toResponse(report, body, startMs, shaclUrl);
+  }
+
+  /** Body excerpt for error details — services can answer with whole HTML error pages. */
+  private static String trimmed(String body) {
+    if (body == null || body.isBlank()) {
+      return null;
+    }
+    String trimmed = body.strip();
+    return trimmed.length() <= 1_000 ? trimmed : trimmed.substring(0, 1_000) + "…";
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutor.java
@@ -18,11 +18,7 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
@@ -76,10 +72,9 @@ final class LocalQueryExecutor {
               null));
     }
 
-    List<Path> paths;
     DatasetGraph data;
     try {
-      paths = resolvePaths(target.files(), notebookDir(request.notebookUri()));
+      List<Path> paths = NotebookPaths.resolvePaths(target.files(), request.notebookUri());
       data = stores.unionFor(paths);
     } catch (LocalStoreManager.StoreException e) {
       return ExecuteResponse.failed(new ExecError(e.code(), e.getMessage(), null, null, null));
@@ -126,57 +121,6 @@ final class LocalQueryExecutor {
       LOG.error("Unexpected error executing local {} query: {}", kind, e.getMessage(), e);
       return ExecuteResponse.failed(
           new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
-    }
-  }
-
-  // ---- path resolution -----------------------------------------------------------------------
-
-  private static List<Path> resolvePaths(List<String> files, Path notebookDir)
-      throws LocalStoreManager.StoreException {
-    List<Path> paths = new ArrayList<>(files.size());
-    for (String file : files) {
-      paths.add(resolvePath(file, notebookDir));
-    }
-    return paths;
-  }
-
-  private static Path resolvePath(String file, Path notebookDir)
-      throws LocalStoreManager.StoreException {
-    Path path;
-    try {
-      path = Path.of(file);
-    } catch (InvalidPathException e) {
-      throw new LocalStoreManager.StoreException(
-          ErrorCode.FILE_NOT_FOUND, "Not a valid file path: " + file, e);
-    }
-    if (path.isAbsolute()) {
-      return path.normalize();
-    }
-    if (notebookDir == null) {
-      throw new LocalStoreManager.StoreException(
-          ErrorCode.FILE_NOT_FOUND,
-          "Cannot resolve the relative path "
-              + file
-              + " — save the notebook first so relative paths have a base directory.",
-          null);
-    }
-    return notebookDir.resolve(path).normalize();
-  }
-
-  /** The notebook's directory, or {@code null} when the notebook has no on-disk location. */
-  private static Path notebookDir(String notebookUri) {
-    if (notebookUri == null || notebookUri.isBlank()) {
-      return null;
-    }
-    try {
-      URI uri = new URI(notebookUri);
-      if (!"file".equalsIgnoreCase(uri.getScheme())) {
-        return null;
-      }
-      return Path.of(uri).getParent();
-    } catch (URISyntaxException | IllegalArgumentException e) {
-      LOG.debug("Ignoring unusable notebook URI {}: {}", notebookUri, e.getMessage());
-      return null;
     }
   }
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -37,9 +37,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles the {@value #CMD_EXECUTE} workspace command: runs a notebook cell's SPARQL query or
- * update against the target resolved by the client — an HTTP endpoint ({@link HttpQueryExecutor})
- * or local RDF/CIMXML files ({@link LocalQueryExecutor}) — and returns an {@link ExecuteResponse}.
+ * Handles the {@value #CMD_EXECUTE} workspace command: runs a notebook cell — a SPARQL query or
+ * update, or a SHACL shapes cell ({@link ShaclExecutor}) — against the target resolved by the
+ * client, an HTTP endpoint ({@link HttpQueryExecutor}) or local RDF/CIMXML files ({@link
+ * LocalQueryExecutor}), and returns an {@link ExecuteResponse}.
  *
  * <p>Wired into {@code SparqlWorkspaceService#executeCommand} by {@code SparqlLanguageServer},
  * which also forwards {@link #shutdown()} from its own shutdown sequence.
@@ -109,6 +110,10 @@ public final class NotebookCommandHandler {
     LOG.debug("Executing {} cell {}", request.languageId(), request.cellUri());
     try {
       var ctx = new ExecContext(executionPool, watchdogScheduler, cancelChecker);
+      if ("shacl".equalsIgnoreCase(request.languageId())) {
+        // SHACL cells are Turtle shapes, not SPARQL — never route them through the query parser.
+        return ShaclExecutor.execute(request, localStores, ctx);
+      }
       boolean filesTarget =
           request.target() != null && ExecuteTarget.TYPE_FILES.equals(request.target().type());
       return switch (QueryKindDetector.detect(request.text())) {

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
@@ -1,0 +1,91 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the file paths of a {@link ExecuteTarget#TYPE_FILES} target against the notebook's
+ * directory — the same base validation uses for relative {@code # [endpoint=...]} directives.
+ * Shared by {@link LocalQueryExecutor} and {@link ShaclExecutor}.
+ */
+final class NotebookPaths {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookPaths.class);
+
+  private NotebookPaths() {}
+
+  /** Resolves each directive path, relative ones against {@code notebookDir(notebookUri)}. */
+  static List<Path> resolvePaths(List<String> files, String notebookUri)
+      throws LocalStoreManager.StoreException {
+    Path notebookDir = notebookDir(notebookUri);
+    List<Path> paths = new ArrayList<>(files.size());
+    for (String file : files) {
+      paths.add(resolvePath(file, notebookDir));
+    }
+    return paths;
+  }
+
+  private static Path resolvePath(String file, Path notebookDir)
+      throws LocalStoreManager.StoreException {
+    Path path;
+    try {
+      path = Path.of(file);
+    } catch (InvalidPathException e) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND, "Not a valid file path: " + file, e);
+    }
+    if (path.isAbsolute()) {
+      return path.normalize();
+    }
+    if (notebookDir == null) {
+      throw new LocalStoreManager.StoreException(
+          ErrorCode.FILE_NOT_FOUND,
+          "Cannot resolve the relative path "
+              + file
+              + " — save the notebook first so relative paths have a base directory.",
+          null);
+    }
+    return notebookDir.resolve(path).normalize();
+  }
+
+  /** The notebook's directory, or {@code null} when the notebook has no on-disk location. */
+  private static Path notebookDir(String notebookUri) {
+    if (notebookUri == null || notebookUri.isBlank()) {
+      return null;
+    }
+    try {
+      URI uri = new URI(notebookUri);
+      if (!"file".equalsIgnoreCase(uri.getScheme())) {
+        return null;
+      }
+      return Path.of(uri).getParent();
+    } catch (URISyntaxException | IllegalArgumentException e) {
+      LOG.debug("Ignoring unusable notebook URI {}: {}", notebookUri, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutor.java
@@ -1,0 +1,248 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.riot.system.ErrorHandler;
+import org.apache.jena.shacl.ShaclValidator;
+import org.apache.jena.shacl.Shapes;
+import org.apache.jena.shacl.ValidationReport;
+import org.apache.jena.shacl.validation.ReportEntry;
+import org.apache.jena.shacl.validation.Severity;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a notebook SHACL cell: the cell text is the <em>shapes graph</em> (Turtle), validated
+ * against the cell's target data. Local-file targets are validated in-process with jena-shacl over
+ * the {@link LocalStoreManager} union graph; HTTP targets hand the shapes to the endpoint's SHACL
+ * service via {@link HttpShaclClient}. Either way the response carries the full validation report
+ * as Turtle plus a {@link ShaclSummary} for the client's verdict banner.
+ *
+ * <p>A completed validation is a <em>successful</em> execution even when the data does not conform
+ * — non-conformance is the result, not an error.
+ *
+ * <p>In-process validation has no native timeout or abort hook, so it runs under the timeout-aware
+ * {@link ExecSupport#runCancellable} variant: cancellation and timeout resolve the response while
+ * the validation itself finishes in the background (same trade-off as a cancelled UPDATE,
+ * documented on {@link HttpQueryExecutor}).
+ */
+final class ShaclExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ShaclExecutor.class);
+
+  private ShaclExecutor() {}
+
+  /** Executes a SHACL cell, returning a populated {@link ExecuteResponse}. */
+  static ExecuteResponse execute(
+      ExecuteRequest request, LocalStoreManager stores, ExecContext ctx) {
+    Graph shapesGraph;
+    try {
+      shapesGraph = parseShapesTurtle(request.text());
+    } catch (ShapesSyntaxException e) {
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.PARSE_ERROR, e.getMessage(), null, e.line, e.column));
+    }
+
+    ExecuteTarget target = request.target();
+    if (target == null) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.NO_TARGET,
+              "No data to validate. Add a `# [endpoint=<url or file>]` directive to the cell.",
+              null,
+              null,
+              null));
+    }
+    if (ExecuteTarget.TYPE_FILES.equals(target.type())) {
+      return validateLocal(shapesGraph, request, stores, ctx);
+    }
+    return HttpShaclClient.validate(request.text(), target, request.options(), ctx);
+  }
+
+  // ---- local validation ------------------------------------------------------------------------
+
+  private static ExecuteResponse validateLocal(
+      Graph shapesGraph, ExecuteRequest request, LocalStoreManager stores, ExecContext ctx) {
+    ExecuteTarget target = request.target();
+    if (target.files() == null || target.files().isEmpty()) {
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.NO_TARGET,
+              "No data to validate. Add a `# [endpoint=<url or file>]` directive to the cell.",
+              null,
+              null,
+              null));
+    }
+
+    Shapes shapes;
+    try {
+      shapes = ShaclValidator.get().parse(shapesGraph);
+    } catch (RuntimeException e) {
+      // Syntactically valid Turtle that is not a well-formed shapes graph (e.g. a broken
+      // sh:property) — jena-shacl reports this without source positions.
+      return ExecuteResponse.failed(
+          new ExecError(
+              ErrorCode.PARSE_ERROR, "Invalid SHACL shapes: " + e.getMessage(), null, null, null));
+    }
+
+    DatasetGraph data;
+    try {
+      List<Path> paths = NotebookPaths.resolvePaths(target.files(), request.notebookUri());
+      data = stores.unionFor(paths);
+    } catch (LocalStoreManager.StoreException e) {
+      return ExecuteResponse.failed(new ExecError(e.code(), e.getMessage(), null, null, null));
+    }
+
+    // The union's default graph spans all graphs of all files (see LocalStoreManager), so the
+    // shapes validate everything the user pointed the cell at.
+    Graph dataGraph = data.getDefaultGraph();
+    String resolvedTarget = String.join(", ", target.files());
+    return ExecSupport.runCancellable(
+        ctx,
+        () -> {},
+        () -> runValidation(shapes, dataGraph, resolvedTarget),
+        ExecSupport.timeoutMs(request.options()));
+  }
+
+  /** Runs on {@code ctx.executionPool()}. */
+  private static ExecuteResponse runValidation(
+      Shapes shapes, Graph dataGraph, String resolvedTarget) {
+    long start = System.currentTimeMillis();
+    try {
+      ValidationReport report = ShaclValidator.get().validate(shapes, dataGraph);
+      return toResponse(report, reportTurtle(report), start, resolvedTarget);
+    } catch (CancellationException e) {
+      LOG.debug("SHACL validation aborted after cancellation");
+      return ExecuteResponse.cancelled();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error during SHACL validation: {}", e.getMessage(), e);
+      return ExecuteResponse.failed(
+          new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
+    }
+  }
+
+  // ---- shared report handling (also used by HttpShaclClient) ------------------------------------
+
+  /** Builds the SUCCESS response for a completed validation, whatever produced the report. */
+  static ExecuteResponse toResponse(
+      ValidationReport report, String reportTurtle, long startMs, String resolvedTarget) {
+    int violations = 0;
+    int warnings = 0;
+    int infos = 0;
+    for (ReportEntry entry : report.getEntries()) {
+      Severity severity = entry.severity();
+      if (Severity.Warning.equals(severity)) {
+        warnings++;
+      } else if (Severity.Info.equals(severity)) {
+        infos++;
+      } else {
+        violations++; // sh:Violation is also the SHACL default for unknown severities
+      }
+    }
+    ShaclSummary summary = new ShaclSummary(report.conforms(), violations, warnings, infos);
+    ExecStats stats = ExecSupport.stats(startMs, report.getEntries().size(), false, resolvedTarget);
+    return ExecuteResponse.successShacl(reportTurtle, summary, stats);
+  }
+
+  static String reportTurtle(ValidationReport report) {
+    StringWriter sw = new StringWriter();
+    RDFDataMgr.write(sw, report.getModel(), RDFFormat.TURTLE_PRETTY);
+    return sw.toString();
+  }
+
+  // ---- shapes parsing
+  // ----------------------------------------------------------------------------
+
+  /** The cell text is not valid Turtle; position is 1-based where the parser reported one. */
+  private static final class ShapesSyntaxException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Integer line;
+    private final Integer column;
+
+    ShapesSyntaxException(String message, Integer line, Integer column) {
+      super(message);
+      this.line = line;
+      this.column = column;
+    }
+  }
+
+  private static Graph parseShapesTurtle(String text) throws ShapesSyntaxException {
+    Graph graph = GraphFactory.createDefaultGraph();
+    PositionErrorHandler errors = new PositionErrorHandler();
+    try {
+      RDFParser.create()
+          .source(new StringReader(text))
+          .lang(Lang.TTL)
+          .errorHandler(errors)
+          .parse(graph);
+    } catch (RiotException e) {
+      throw new ShapesSyntaxException(
+          errors.message != null ? errors.message : e.getMessage(), errors.line, errors.column);
+    }
+    return graph;
+  }
+
+  /** Records the first reported parse error's message and 1-based position. */
+  private static final class PositionErrorHandler implements ErrorHandler {
+
+    private String message;
+    private Integer line;
+    private Integer column;
+
+    @Override
+    public void warning(String message, long line, long col) {
+      // Warnings don't fail the parse.
+    }
+
+    @Override
+    public void error(String message, long line, long col) {
+      record(message, line, col);
+      throw new RiotException(message);
+    }
+
+    @Override
+    public void fatal(String message, long line, long col) {
+      record(message, line, col);
+      throw new RiotException(message);
+    }
+
+    private void record(String message, long line, long col) {
+      if (this.message == null) {
+        this.message = message;
+        this.line = line > 0 ? (int) line : null;
+        this.column = col > 0 ? (int) col : null;
+      }
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclSummary.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclSummary.java
@@ -19,14 +19,12 @@
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
 /**
- * The kind of operation a cell was classified as: for SPARQL cells, by {@link QueryKindDetector};
- * {@link #SHACL} is assigned directly from the cell's language id (see {@code ShaclExecutor}).
+ * Aggregated outcome of a SHACL validation run, so the client can render a verdict banner without
+ * parsing the report graph in {@link ExecuteResponse#turtle()}.
+ *
+ * @param conforms the report's {@code sh:conforms} value.
+ * @param violations number of report entries with severity {@code sh:Violation}.
+ * @param warnings number of report entries with severity {@code sh:Warning}.
+ * @param infos number of report entries with severity {@code sh:Info}.
  */
-enum QueryKind {
-  SELECT,
-  ASK,
-  CONSTRUCT,
-  DESCRIBE,
-  UPDATE,
-  SHACL
-}
+record ShaclSummary(boolean conforms, int violations, int warnings, int infos) {}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
@@ -426,7 +426,7 @@ public class HttpQueryExecutorTest {
   }
 
   private static ExecuteTarget target(String url, String updateUrl) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null);
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null, null);
   }
 
   private static String uniqueSubject() {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
@@ -318,7 +318,7 @@ public class LocalQueryExecutorTest {
   }
 
   private static ExecuteTarget filesTarget(String... files) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, List.of(files));
+    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files));
   }
 
   private Path dataFile(String name, String content) throws IOException {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -204,6 +204,47 @@ public class NotebookCommandHandlerTest {
     }
   }
 
+  // ---- SHACL cells -----------------------------------------------------------------------------
+
+  @Test
+  public void executeCommandRoutesShaclCellsByLanguageIdAndPinsTheSummaryWireShape()
+      throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-shacl");
+    try {
+      Files.writeString(
+          dir.resolve("data.ttl"), "@prefix ex: <http://example.org/> . ex:bob a ex:Person .");
+      String shapes =
+          """
+          PREFIX sh: <http://www.w3.org/ns/shacl#>
+          PREFIX ex: <http://example.org/>
+          ex:PersonShape a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+          """;
+      JsonObject arg = filesRequestJson(shapes, dir, "./data.ttl");
+      arg.addProperty("languageId", "shacl");
+
+      ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+      assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+      assertEquals(QueryKind.SHACL.name(), response.queryKind());
+
+      // Wire shape of the summary, as the TS client parses it (see endpoint.ts).
+      Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
+      JsonObject json = wireGson.toJsonTree(response).getAsJsonObject();
+      assertEquals("SHACL", json.get("queryKind").getAsString());
+      JsonObject summary = json.getAsJsonObject("shaclSummary");
+      assertFalse(summary.get("conforms").getAsBoolean());
+      assertEquals(1, summary.get("violations").getAsInt());
+      assertEquals(0, summary.get("warnings").getAsInt());
+      assertEquals(0, summary.get("infos").getAsInt());
+      assertFalse(json.get("turtle").getAsString().isEmpty());
+    } finally {
+      try (var paths = Files.walk(dir)) {
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
   // ---- wire shape ----------------------------------------------------------------------------
 
   /**

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutorTest.java
@@ -1,0 +1,378 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.server.Operation;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.system.Txn;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises {@link ShaclExecutor} (and, through it, {@link HttpShaclClient}): local jena-shacl
+ * validation over file targets, remote validation against a real in-process Fuseki SHACL operation,
+ * shapes parsing failures, and the timeout/cancellation behavior of the racing variant that
+ * in-process validation relies on.
+ */
+public class ShaclExecutorTest {
+
+  private static final String EX = "http://example.org/";
+
+  private static final String SHAPES_NAME_REQUIRED =
+      """
+      PREFIX sh: <http://www.w3.org/ns/shacl#>
+      PREFIX ex: <http://example.org/>
+      ex:PersonShape a sh:NodeShape ;
+        sh:targetClass ex:Person ;
+        sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+      """;
+
+  private static final String DATA_CONFORMING =
+      """
+      PREFIX ex: <http://example.org/>
+      ex:alice a ex:Person ; ex:name "Alice" .
+      """;
+
+  private static final String DATA_VIOLATING =
+      """
+      PREFIX ex: <http://example.org/>
+      ex:bob a ex:Person .
+      """;
+
+  private static final CancelChecker NEVER_CANCELLED =
+      new CancelChecker() {
+        @Override
+        public void checkCanceled() {}
+
+        @Override
+        public boolean isCanceled() {
+          return false;
+        }
+      };
+
+  private static FusekiServer fuseki;
+  private static String shaclUrl;
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private ExecutorService executionPool;
+  private ScheduledExecutorService watchdogScheduler;
+  private LocalStoreManager stores;
+
+  @BeforeClass
+  public static void startFuseki() {
+    DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
+    Txn.executeWrite(
+        dsg,
+        () ->
+            dsg.getDefaultGraph()
+                .add(
+                    Triple.create(
+                        NodeFactory.createURI(EX + "bob"),
+                        NodeFactory.createURI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                        NodeFactory.createURI(EX + "Person"))));
+    fuseki =
+        FusekiServer.create()
+            .port(0)
+            .add("/ds", dsg)
+            .addEndpoint("/ds", "shacl", Operation.Shacl)
+            .build()
+            .start();
+    // Fuseki's SHACL operation requires the graph selector; "default" = the default graph. The
+    // TS client's deriveShaclUrl appends exactly this when the directive has no query string.
+    shaclUrl = fuseki.serverURL() + "ds/shacl?graph=default";
+  }
+
+  @AfterClass
+  public static void stopFuseki() {
+    fuseki.stop();
+  }
+
+  @Before
+  public void setUp() {
+    executionPool = Executors.newCachedThreadPool();
+    watchdogScheduler = Executors.newSingleThreadScheduledExecutor();
+    stores = new LocalStoreManager();
+  }
+
+  @After
+  public void tearDown() {
+    executionPool.shutdownNow();
+    watchdogScheduler.shutdownNow();
+  }
+
+  // ---- local validation --------------------------------------------------------------------
+
+  @Test
+  public void conformingDataReportsConforms() throws IOException {
+    Path data = dataFile("data.ttl", DATA_CONFORMING);
+
+    ExecuteResponse response = executeLocal(SHAPES_NAME_REQUIRED, data.toString());
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.SHACL.name(), response.queryKind());
+    ShaclSummary summary = response.shaclSummary();
+    assertNotNull(summary);
+    assertTrue(summary.conforms());
+    assertEquals(0, summary.violations());
+    assertTrue("the report itself travels as turtle", response.turtle().contains("conforms"));
+    assertEquals(data.toString(), response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void violationsAreCountedBySeverity() throws IOException {
+    Path data = dataFile("data.ttl", DATA_VIOLATING);
+    String shapes =
+        """
+        PREFIX sh: <http://www.w3.org/ns/shacl#>
+        PREFIX ex: <http://example.org/>
+        ex:NameShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+        ex:AgeShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:path ex:age ; sh:minCount 1 ; sh:severity sh:Warning ] .
+        """;
+
+    ExecuteResponse response = executeLocal(shapes, data.toString());
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    ShaclSummary summary = response.shaclSummary();
+    assertFalse(summary.conforms());
+    assertEquals(1, summary.violations());
+    assertEquals(1, summary.warnings());
+    assertEquals(0, summary.infos());
+    assertEquals(Integer.valueOf(2), response.stats().rowCount());
+    assertTrue(response.turtle().contains("ValidationResult"));
+  }
+
+  @Test
+  public void validationSpansTheUnionOfAllTargetFiles() throws IOException {
+    Path good = dataFile("good.ttl", DATA_CONFORMING);
+    Path bad = dataFile("bad.ttl", DATA_VIOLATING);
+
+    ExecuteResponse response = executeLocal(SHAPES_NAME_REQUIRED, good.toString(), bad.toString());
+
+    ShaclSummary summary = response.shaclSummary();
+    assertFalse("the violating file must be seen through the union", summary.conforms());
+    assertEquals(1, summary.violations());
+  }
+
+  @Test
+  public void invalidTurtleShapesReportParseErrorWithPosition() throws IOException {
+    Path data = dataFile("data.ttl", DATA_CONFORMING);
+
+    ExecuteResponse response = executeLocal("this is not turtle @@@", data.toString());
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.PARSE_ERROR.name(), response.error().code());
+    assertNotNull("riot reports a line for syntax errors", response.error().line());
+  }
+
+  @Test
+  public void wellFormedTurtleButBrokenShapesReportParseError() throws IOException {
+    Path data = dataFile("data.ttl", DATA_CONFORMING);
+    // Valid Turtle, invalid SHACL: a property shape without sh:path.
+    String shapes =
+        """
+        PREFIX sh: <http://www.w3.org/ns/shacl#>
+        PREFIX ex: <http://example.org/>
+        ex:Broken a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:minCount 1 ] .
+        """;
+
+    ExecuteResponse response = executeLocal(shapes, data.toString());
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.PARSE_ERROR.name(), response.error().code());
+    assertTrue(response.error().message().contains("SHACL"));
+  }
+
+  @Test
+  public void missingDataFileReportsFileNotFound() {
+    ExecuteResponse response =
+        executeLocal(SHAPES_NAME_REQUIRED, tmp.getRoot().toPath().resolve("nope.ttl").toString());
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.name(), response.error().code());
+  }
+
+  @Test
+  public void missingTargetReportsNoTarget() {
+    ExecuteResponse response =
+        ShaclExecutor.execute(request(SHAPES_NAME_REQUIRED, null), stores, ctx(NEVER_CANCELLED));
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+  }
+
+  // ---- timeout / cancellation of the racing variant used for in-process validation ----------
+
+  @Test
+  public void timeoutOverloadResolvesToTimeoutWhileWorkIsStillRunning() {
+    ExecuteResponse response =
+        ExecSupport.runCancellable(
+            ctx(NEVER_CANCELLED), () -> {}, ShaclExecutorTest::sleepForever, 100);
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.TIMEOUT.name(), response.error().code());
+  }
+
+  @Test
+  public void cancellationWinsOverBlockedWork() {
+    long start = System.nanoTime();
+    ExecuteResponse response =
+        ExecSupport.runCancellable(
+            ctx(cancelAfter(200)), () -> {}, ShaclExecutorTest::sleepForever, 30_000);
+    long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+    assertEquals(ExecutionStatus.CANCELLED.name(), response.status());
+    assertTrue(
+        "expected cancellation to resolve quickly, took " + elapsedMs + "ms", elapsedMs < 10_000);
+  }
+
+  // ---- remote validation (real Fuseki SHACL operation) --------------------------------------
+
+  @Test
+  public void remoteValidationReportsViolationsFromTheService() {
+    ExecuteResponse response = executeRemote(SHAPES_NAME_REQUIRED, shaclUrl);
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(QueryKind.SHACL.name(), response.queryKind());
+    ShaclSummary summary = response.shaclSummary();
+    assertNotNull(summary);
+    assertFalse("bob has no name, the service must report it", summary.conforms());
+    assertTrue(summary.violations() >= 1);
+    assertTrue(response.turtle().contains("ValidationResult"));
+    assertEquals(shaclUrl, response.stats().resolvedTarget());
+  }
+
+  @Test
+  public void remoteValidationCanConform() {
+    // Shapes that the server's data satisfies: bob is typed, nothing more required.
+    String shapes =
+        """
+        PREFIX sh: <http://www.w3.org/ns/shacl#>
+        PREFIX ex: <http://example.org/>
+        ex:TypedShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:path <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ;
+                        sh:minCount 1 ] .
+        """;
+
+    ExecuteResponse response = executeRemote(shapes, shaclUrl);
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertTrue(response.shaclSummary().conforms());
+  }
+
+  @Test
+  public void remoteErrorsSurfaceAsHttpError() {
+    ExecuteResponse response = executeRemote(SHAPES_NAME_REQUIRED, fuseki.serverURL() + "ds/query");
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.HTTP_ERROR.name(), response.error().code());
+  }
+
+  @Test
+  public void httpTargetWithoutShaclServiceReportsNoTarget() {
+    ExecuteResponse response = executeRemote(SHAPES_NAME_REQUIRED, null);
+
+    assertEquals(ExecutionStatus.ERROR.name(), response.status());
+    assertEquals(ErrorCode.NO_TARGET.name(), response.error().code());
+    assertTrue(response.error().message().contains("SHACL"));
+  }
+
+  // ---- helpers -------------------------------------------------------------------------------
+
+  private ExecuteResponse executeLocal(String shapes, String... files) {
+    ExecuteTarget target =
+        new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files));
+    return ShaclExecutor.execute(request(shapes, target), stores, ctx(NEVER_CANCELLED));
+  }
+
+  private ExecuteResponse executeRemote(String shapes, String shaclServiceUrl) {
+    ExecuteTarget target =
+        new ExecuteTarget(
+            ExecuteTarget.TYPE_HTTP, fuseki.serverURL() + "ds", null, shaclServiceUrl, null);
+    return ShaclExecutor.execute(request(shapes, target), stores, ctx(NEVER_CANCELLED));
+  }
+
+  private static ExecuteRequest request(String shapes, ExecuteTarget target) {
+    return new ExecuteRequest("file:///cell1.shacl", null, "shacl", shapes, target, null);
+  }
+
+  private ExecContext ctx(CancelChecker checker) {
+    return new ExecContext(executionPool, watchdogScheduler, checker);
+  }
+
+  private Path dataFile(String name, String content) throws IOException {
+    Path file = tmp.getRoot().toPath().resolve(name);
+    Files.writeString(file, content);
+    return file;
+  }
+
+  private static ExecuteResponse sleepForever() {
+    try {
+      Thread.sleep(60_000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    return ExecuteResponse.failed(
+        new ExecError(ErrorCode.INTERNAL, "work was not interrupted", null, null, null));
+  }
+
+  /** A {@link CancelChecker} that reports cancelled once {@code delayMs} has elapsed. */
+  private static CancelChecker cancelAfter(long delayMs) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayMs);
+    return new CancelChecker() {
+      @Override
+      public void checkCanceled() {}
+
+      @Override
+      public boolean isCanceled() {
+        return System.nanoTime() >= deadlineNanos;
+      }
+    };
+  }
+}

--- a/cimvocabcheck/sbom/maven/THIRD-PARTY.txt
+++ b/cimvocabcheck/sbom/maven/THIRD-PARTY.txt
@@ -1,5 +1,5 @@
 
-Lists of 38 third-party dependencies.
+Lists of 39 third-party dependencies.
      (Apache-2.0) aalto-xml (com.fasterxml:aalto-xml:1.4.0 - https://github.com/FasterXML/aalto-xml)
      (Apache-2.0) Apache Commons Codec (commons-codec:commons-codec:1.22.0 - https://commons.apache.org/proper/commons-codec/)
      (Apache-2.0) Apache Commons Collections (org.apache.commons:commons-collections4:4.5.0 - https://commons.apache.org/proper/commons-collections/)
@@ -12,6 +12,7 @@ Lists of 38 third-party dependencies.
      (Apache-2.0) Apache Jena - Core (org.apache.jena:jena-core:6.1.0 - https://jena.apache.org/jena-core/)
      (Apache-2.0) Apache Jena - IRI3986 (org.apache.jena:jena-iri3986:6.1.0 - https://jena.apache.org/jena-iri3986/)
      (Apache-2.0) Apache Jena - Language tags (org.apache.jena:jena-langtag:6.1.0 - https://jena.apache.org/jena-langtag/)
+     (Apache-2.0) Apache Jena - SHACL (org.apache.jena:jena-shacl:6.1.0 - https://jena.apache.org/jena-shacl/)
      (Apache-2.0) Apache Log4j API (org.apache.logging.log4j:log4j-api:2.26.1 - https://logging.apache.org/log4j/2.x/)
      (Apache-2.0) Apache Log4j Core (org.apache.logging.log4j:log4j-core:2.26.1 - https://logging.apache.org/log4j/2.x/)
      (Apache-2.0) Apache Thrift (org.apache.thrift:libthrift:0.22.0 - https://thrift.apache.org/)

--- a/cimvocabcheck/sbom/maven/bom.json
+++ b/cimvocabcheck/sbom/maven/bom.json
@@ -2028,6 +2028,80 @@
     },
     {
       "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.jena/jena-shacl@6.1.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.jena",
+      "name" : "jena-shacl",
+      "version" : "6.1.0",
+      "description" : "SHACL engine for Apache Jena",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c778b89c251c4d59c6bb865266a8d9f6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9bf215ed23b30b88347ac5be5310e788c5bc1c11"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d03e61141624b45ea601c4bf10dc65f9b17c9637cbf534425e88edecb74c2f9b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4e6555f12f70228c91c021f3c171186db2518fad8cfb8f18f432bf9e2367a00be71bdf271c75944626c74652378699180f02ce7570748786a89bcacec6ee4286"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "77794195c9fb924148de4f3c071d4ecf78d8122ae1101f82c90a1b39fbd414a4a0830342dcdf5b23c6538fa8770791f7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a4927c736b08530f55ac404d43be0b54ae4eae0402c752bcc937336335ec40bd129f80549eaa9919062c845cd5a8bb0d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "700fe5f3c34fac7366970019430c2ccde2e694e9d153092d73b4d0d942d1275a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5066c8012f6be15f8927ea85f3d3db3dc68f461f95e1acdd3e9c4b0c03dc5d3012b1d15dd50394d8e416e6ee1b82d5f77a291d54e1468838221e0b381b7344cf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.jena/jena-shacl@6.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://jena.apache.org/jena-shacl/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/JENA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?users@jena.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/jena.git/jena-shacl"
+        }
+      ]
+    },
+    {
+      "type" : "library",
       "bom-ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.26.1?type=jar",
       "publisher" : "The Apache Software Foundation",
       "group" : "org.apache.logging.log4j",
@@ -3012,6 +3086,7 @@
       "dependsOn" : [
         "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.22.1?type=jar",
         "pkg:maven/de.soptim.opencgmes/cimvocabcheck-core@0.0.0-SNAPSHOT?type=jar",
+        "pkg:maven/org.apache.jena/jena-shacl@6.1.0?type=jar",
         "pkg:maven/org.apache.logging.log4j/log4j-core@2.26.1?type=jar",
         "pkg:maven/org.apache.logging.log4j/log4j-slf4j2-impl@2.26.1?type=jar",
         "pkg:maven/org.eclipse.lsp4j/org.eclipse.lsp4j@1.0.0?type=jar",
@@ -3108,6 +3183,12 @@
     {
       "ref" : "pkg:maven/org.apache.jena/jena-langtag@6.1.0?type=jar",
       "dependsOn" : []
+    },
+    {
+      "ref" : "pkg:maven/org.apache.jena/jena-shacl@6.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.jena/jena-arq@6.1.0?type=jar"
+      ]
     },
     {
       "ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.26.1?type=jar",

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -78,9 +78,9 @@ back) and opens it. The source file is never modified. Zazuko per-cell metadata 
 
 ## Running cells
 
-SPARQL cells have a **Run** button (the _CIM Notebook_ kernel). Execution happens inside
-CIMLangServer — the same Java process that validates your queries — using Apache Jena's
-SPARQL 1.1 engine, so there is nothing extra to install.
+SPARQL and SHACL cells have a **Run** button (the _CIM Notebook_ kernel). Execution
+happens inside CIMLangServer — the same Java process that validates your queries — using
+Apache Jena's SPARQL 1.1 and SHACL engines, so there is nothing extra to install.
 
 A cell names its target with the same `# [endpoint=...]` directive used for validation —
 one directive drives both _validate against_ and _run against_. The target can be a SPARQL
@@ -106,6 +106,7 @@ What you get per query kind:
 | `ASK`                               | ✅ **true** / ❌ **false**                                                                                                |
 | `CONSTRUCT` / `DESCRIBE`            | The result graph as Turtle                                                                                                |
 | `INSERT` / `DELETE` / other updates | A confirmation with the update endpoint used                                                                              |
+| SHACL cell                          | A conforms / does-not-conform verdict with severity counts, plus the full validation report as Turtle                     |
 
 Each output ends with a small stats line — row count, duration, and the resolved endpoint.
 Results are capped server-side (10 000 rows/triples by default) and the output says so when
@@ -150,7 +151,32 @@ loaded as the schema, while instance-data files (`.xml` models, `.nt`/`.nq`/`.tr
 keep the workspace schema so diagnostics stay meaningful — and either way the file is what
 the cell _runs_ against.
 
+### Running SHACL cells
+
+A SHACL cell's text is the **shapes graph**; running the cell validates the target data
+against those shapes. The same `# [endpoint=...]` directives pick the data:
+
+- **Local files** — the shapes are checked in-process (Apache Jena SHACL) against the
+  union of the referenced files, CIMXML models included:
+
+  ```shacl
+  # [endpoint=./model.xml]
+  ex:SwitchNameShape a sh:NodeShape ;
+    sh:targetClass cim:Switch ;
+    sh:property [ sh:path cim:IdentifiedObject.name ; sh:minCount 1 ] .
+  ```
+
+- **HTTP endpoints** — the shapes are POSTed as Turtle to the endpoint's SHACL service
+  (Fuseki's `shacl` operation and compatibles), which validates its own data. For
+  Fuseki-style URLs the service is derived from the query URL (`…/query` → `…/shacl`);
+  because Fuseki requires a graph selector, `?graph=default` (the default graph) is added
+  automatically — put an explicit `?graph=…` in the directive to validate a named graph.
+
+The output is a ✅ conforms / ❌ does-not-conform banner with counts per severity
+(violations, warnings, infos), followed by the full `sh:ValidationReport` as Turtle. A
+run that finds violations is still a _successful_ run — non-conformance is the result,
+not an error.
+
 **Current limitations:**
 
-- SHACL cells are validated statically but cannot be _run_ yet.
 - No authentication support yet — HTTP endpoints must be reachable without credentials.


### PR DESCRIPTION
A cell with languageId "shacl" is a shapes graph (Turtle), not SPARQL, and is routed to the SHACL executor before the query parser ever sees it. Local-file targets are validated in-process with jena-shacl over the union graph; HTTP targets POST the shapes to the endpoint's SHACL service and read back its report. Either way the response carries the full validation report as Turtle plus a summary for the cell's verdict banner.

A completed validation is a successful execution even when the data does not conform — non-conformance is the result, not an error. In-process validation has no native abort hook, so it runs under the timeout-aware cancellation race. Note Fuseki's SHACL operation answers 400 without a ?graph= selector, so the derived service URL appends ?graph=default.

Closes #50