### PR TITLE
feat(cimnotebook): connection management and secret storage (GH-51)

### DIFF
--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -142,6 +142,21 @@
                 "command": "cimnotebook.notebook.convert",
                 "title": "Convert Notebook (Markdown ⇔ SPARQL Book)",
                 "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.notebook.setEndpoint",
+                "title": "Set Cell Endpoint…",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.notebook.setCredentials",
+                "title": "Set Connection Credentials…",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.notebook.clearCredentials",
+                "title": "Clear Connection Credentials…",
+                "category": "CIMNotebook"
             }
         ],
         "menus": {
@@ -163,6 +178,16 @@
                 {
                     "command": "cimnotebook.notebook.convert",
                     "when": "activeNotebookType =~ /^cimnotebook/"
+                },
+                {
+                    "command": "cimnotebook.notebook.setEndpoint",
+                    "when": "activeNotebookType =~ /^cimnotebook/"
+                },
+                {
+                    "command": "cimnotebook.notebook.setCredentials"
+                },
+                {
+                    "command": "cimnotebook.notebook.clearCredentials"
                 }
             ]
         },

--- a/cimnotebook/vscode/schemas/validation.schema.json
+++ b/cimnotebook/vscode/schemas/validation.schema.json
@@ -5,6 +5,59 @@
     "type": "object",
     "additionalProperties": true,
     "properties": {
+        "cimnotebook": {
+            "type": "object",
+            "description": "CIM Notebook execution settings (VS Code). Named connections referenced by # [endpoint=<name>] directives, plus workspace defaults for running cells. Passwords are NEVER stored here — declare \"authType\": \"basic\" and CIMNotebook keeps the credentials in VS Code secret storage.",
+            "additionalProperties": false,
+            "properties": {
+                "connections": {
+                    "type": "array",
+                    "description": "Named SPARQL endpoint connections for notebook cells.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["name", "url"],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The connection's name — cells reference it with # [endpoint=<name>]. Use letters, digits, dashes and underscores (no dots or slashes, which would read as a file path)."
+                            },
+                            "url": {
+                                "type": "string",
+                                "description": "SPARQL query endpoint URL, e.g. http://localhost:3030/dataset/query."
+                            },
+                            "updateUrl": {
+                                "type": "string",
+                                "description": "SPARQL Update endpoint URL. Omit to derive it from \"url\" (Fuseki-style …/query → …/update)."
+                            },
+                            "shaclUrl": {
+                                "type": "string",
+                                "description": "SHACL validation service URL. Omit to derive it from \"url\" (…/query → …/shacl?graph=default)."
+                            },
+                            "authType": {
+                                "type": "string",
+                                "enum": ["none", "basic"],
+                                "description": "Authentication scheme. With \"basic\", CIMNotebook prompts once for username/password and stores them in VS Code secret storage — never in this file."
+                            },
+                            "default": {
+                                "type": "boolean",
+                                "description": "Cells without a # [endpoint=...] directive run against this connection."
+                            }
+                        }
+                    }
+                },
+                "queryTimeoutSeconds": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Default timeout for notebook cell executions, in seconds (built-in default: 30)."
+                },
+                "maxRows": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Default cap on returned rows/triples per execution (built-in default: 10000)."
+                }
+            }
+        },
         "cimvocabcheck": {
             "type": "object",
             "description": "CIMVocabCheck SPARQL/SHACL validation settings. All fields are optional; when neither \"schemas\" nor \"schemasDirectory\" is set, the bundled CGMES 3.0 profiles are used.",

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -29,6 +29,9 @@ import {
 import { registerNotebookSerializers } from "./notebook/serializers";
 import { registerNotebookControllers } from "./notebook/controller";
 import { registerConvertCommand } from "./notebook/convert";
+import { ConnectionStore } from "./notebook/connections";
+import { registerEndpointCommands } from "./notebook/endpointCommands";
+import { registerCellStatusBar } from "./notebook/statusBar";
 
 const CHANNEL = "CIMNotebook";
 
@@ -63,11 +66,14 @@ export function activate(context: vscode.ExtensionContext): void {
     // the vscode-notebook-cell entries of the LSP documentSelector below and executed
     // via the server's cimvocabcheck.notebook.execute command).
     registerNotebookSerializers(context);
-    registerNotebookControllers(context, () => client);
+    const connectionStore = new ConnectionStore(context, () => client);
+    registerNotebookControllers(context, () => client, connectionStore);
     registerConvertCommand(context);
+    registerEndpointCommands(context, connectionStore);
+    registerCellStatusBar(context, connectionStore);
 
     try {
-        doActivate(context);
+        doActivate(context, connectionStore);
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         out.appendLine(`FATAL during activation: ${msg}`);
@@ -76,7 +82,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
 }
 
-function doActivate(context: vscode.ExtensionContext): void {
+function doActivate(context: vscode.ExtensionContext, connectionStore: ConnectionStore): void {
     const serverJar = resolveServerJar(context);
     if (!serverJar) {
         const hint =
@@ -91,7 +97,17 @@ function doActivate(context: vscode.ExtensionContext): void {
     }
 
     client = buildClient(serverJar, context);
-    client.start();
+    client.start().then(
+        () => {
+            // The notebook defaults live in workspace state, so a freshly started server knows
+            // none of them — replay them, or directive-less cells would validate syntax-only.
+            void connectionStore.syncNotebookDefaults();
+        },
+        (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            out.appendLine(`Language server failed to start: ${msg}`);
+        },
+    );
     out.appendLine("Language client started — waiting for server handshake.");
 
     // Offer a reload when the user changes launch settings.

--- a/cimnotebook/vscode/src/notebook/connections.ts
+++ b/cimnotebook/vscode/src/notebook/connections.ts
@@ -1,0 +1,176 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Client-side view of a notebook's named connections: fetches the `cimnotebook` config
+ * section from the language server (`listConnections`, nearest-config discovery happens
+ * there), caches it per notebook, and invalidates the cache when any `opencgmes.jsonc`
+ * changes. Also holds the per-notebook default directive (workspaceState) that cells
+ * without their own directive fall back to — and pushes it to the server, which needs it
+ * to validate those cells against the same endpoint they run against.
+ */
+
+import * as vscode from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+import {
+    CellResolution,
+    LIST_CONNECTIONS_COMMAND,
+    ListConnectionsResponse,
+    resolveCellTarget,
+    SET_DEFAULT_ENDPOINT_COMMAND,
+    SetDefaultEndpointRequest,
+} from "./endpoint";
+
+const EMPTY: ListConnectionsResponse = { connections: [] };
+
+const DEFAULT_DIRECTIVE_KEY = "cimnotebook.defaultEndpoint";
+
+export class ConnectionStore {
+    /**
+     * Keyed by notebook URI. Holds the *in-flight* request, not just its result: the cell
+     * status-bar provider resolves every visible cell, so a cold cache would otherwise fire one
+     * `listConnections` per cell instead of one per notebook.
+     */
+    private readonly cache = new Map<string, Promise<ListConnectionsResponse>>();
+    private readonly changeEmitter = new vscode.EventEmitter<void>();
+
+    /** Fires when connections or notebook defaults may have changed (config edit, command). */
+    readonly onDidChange = this.changeEmitter.event;
+
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly getClient: () => LanguageClient | undefined,
+    ) {
+        const watcher = vscode.workspace.createFileSystemWatcher("**/opencgmes.{jsonc,json}");
+        context.subscriptions.push(
+            watcher,
+            watcher.onDidChange(() => this.invalidate()),
+            watcher.onDidCreate(() => this.invalidate()),
+            watcher.onDidDelete(() => this.invalidate()),
+            this.changeEmitter,
+        );
+    }
+
+    /** The connections config applying to a notebook; empty when unavailable. */
+    forNotebook(notebook: vscode.NotebookDocument): Promise<ListConnectionsResponse> {
+        const key = notebook.uri.toString();
+        const cached = this.cache.get(key);
+        if (cached) {
+            return cached;
+        }
+        const client = this.getClient();
+        if (!client) {
+            return Promise.resolve(EMPTY);
+        }
+        const pending = client
+            .sendRequest<ListConnectionsResponse | null>("workspace/executeCommand", {
+                command: LIST_CONNECTIONS_COMMAND,
+                arguments: [{ notebookUri: key }],
+            })
+            .then((response) => response ?? EMPTY)
+            .catch(() => {
+                // Server not ready or command failed — behave as "no connections", and drop the
+                // entry so the next call retries. Only evict our own: invalidate() may already
+                // have replaced it with a newer request.
+                if (this.cache.get(key) === pending) {
+                    this.cache.delete(key);
+                }
+                return EMPTY;
+            });
+        this.cache.set(key, pending);
+        return pending;
+    }
+
+    /** Full resolution for a cell, including notebook default and config default. */
+    async resolveCell(cell: vscode.NotebookCell): Promise<CellResolution> {
+        const { connections } = await this.forNotebook(cell.notebook);
+        return resolveCellTarget(
+            cell.document.getText(),
+            connections,
+            this.notebookDefault(cell.notebook),
+        );
+    }
+
+    /** The notebook's stored default directive (URL, file, or connection name), if any. */
+    notebookDefault(notebook: vscode.NotebookDocument): string | undefined {
+        const all = this.context.workspaceState.get<Record<string, string>>(
+            DEFAULT_DIRECTIVE_KEY,
+            {},
+        );
+        return all[notebook.uri.toString()];
+    }
+
+    /** Stores (or clears, with undefined) the notebook's default directive. */
+    async setNotebookDefault(
+        notebook: vscode.NotebookDocument,
+        directive: string | undefined,
+    ): Promise<void> {
+        const all = {
+            ...this.context.workspaceState.get<Record<string, string>>(DEFAULT_DIRECTIVE_KEY, {}),
+        };
+        if (directive === undefined) {
+            delete all[notebook.uri.toString()];
+        } else {
+            all[notebook.uri.toString()] = directive;
+        }
+        await this.context.workspaceState.update(DEFAULT_DIRECTIVE_KEY, all);
+        await this.pushNotebookDefault(notebook.uri.toString(), directive ?? null);
+        this.changeEmitter.fire();
+    }
+
+    /**
+     * Re-sends every stored notebook default to the language server. The defaults live in workspace
+     * state, so the server — which validates cells and has no notion of notebooks — starts out
+     * knowing none of them: without this, a directive-less cell would be validated syntax-only
+     * (no completion, no hover, no go-to-definition) until the user picked its endpoint again.
+     * Called once the client is running, and on every restart.
+     */
+    async syncNotebookDefaults(): Promise<void> {
+        const all = this.context.workspaceState.get<Record<string, string>>(
+            DEFAULT_DIRECTIVE_KEY,
+            {},
+        );
+        for (const [notebookUri, directive] of Object.entries(all)) {
+            await this.pushNotebookDefault(notebookUri, directive);
+        }
+    }
+
+    private async pushNotebookDefault(notebookUri: string, endpoint: string | null): Promise<void> {
+        const client = this.getClient();
+        if (!client) {
+            return; // Server not up yet; syncNotebookDefaults() replays the state when it is.
+        }
+        const request: SetDefaultEndpointRequest = { notebookUri, endpoint };
+        try {
+            await client.sendRequest("workspace/executeCommand", {
+                command: SET_DEFAULT_ENDPOINT_COMMAND,
+                arguments: [request],
+            });
+        } catch {
+            // Server not ready or command unsupported (an older server jar): execution still works
+            // — only the cell's schema-based validation keeps using the workspace schema.
+        }
+    }
+
+    /** Drops all cached config responses (config file changed). */
+    invalidate(): void {
+        this.cache.clear();
+        this.changeEmitter.fire();
+    }
+}

--- a/cimnotebook/vscode/src/notebook/controller.ts
+++ b/cimnotebook/vscode/src/notebook/controller.ts
@@ -26,14 +26,16 @@
 import * as vscode from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 
+import { ConnectionStore } from "./connections";
 import { CellExecutor } from "./executor";
 import { NOTEBOOK_TYPES } from "./serializers";
 
 export function registerNotebookControllers(
     context: vscode.ExtensionContext,
     getClient: () => LanguageClient | undefined,
+    store: ConnectionStore,
 ): void {
-    const executor = new CellExecutor(getClient);
+    const executor = new CellExecutor(getClient, store, context.secrets);
     let executionOrder = 0;
 
     for (const notebookType of NOTEBOOK_TYPES) {

--- a/cimnotebook/vscode/src/notebook/credentials.ts
+++ b/cimnotebook/vscode/src/notebook/credentials.ts
@@ -1,0 +1,122 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Credentials for `authType: "basic"` connections. Stored exclusively in VS Code
+ * SecretStorage (key `cimnotebook.auth.<connectionName>`) — never in `opencgmes.jsonc`,
+ * never in settings, never in git. They leave the client only inside an execute request
+ * to the local language server, which turns them into the HTTP Authorization header.
+ */
+
+import * as vscode from "vscode";
+
+import { ConnectionInfo, ExecAuth } from "./endpoint";
+
+function secretKey(connectionName: string): string {
+    return `cimnotebook.auth.${connectionName}`;
+}
+
+/**
+ * The credentials to attach for a connection: stored ones when present, otherwise (when
+ * `interactive`) a one-time prompt with an offer to save. Returns undefined for
+ * connections without basic auth, or when the user cancels the prompt — execution then
+ * proceeds anonymously and surfaces the endpoint's 401 as AUTH_FAILED.
+ */
+export async function authFor(
+    secrets: vscode.SecretStorage,
+    connection: ConnectionInfo,
+    interactive: boolean,
+): Promise<ExecAuth | undefined> {
+    if (connection.authType?.toLowerCase() !== "basic") {
+        return undefined;
+    }
+    const stored = await secrets.get(secretKey(connection.name));
+    if (stored) {
+        try {
+            const parsed = JSON.parse(stored) as { username: string; password: string };
+            return { type: "basic", username: parsed.username, password: parsed.password };
+        } catch {
+            await secrets.delete(secretKey(connection.name));
+        }
+    }
+    if (!interactive) {
+        return undefined;
+    }
+    const entered = await promptForCredentials(connection.name);
+    if (!entered) {
+        return undefined;
+    }
+    const save = await vscode.window.showQuickPick(["Yes", "No"], {
+        title: `Save credentials for "${connection.name}" in VS Code secret storage?`,
+    });
+    if (save === "Yes") {
+        await storeCredentials(secrets, connection.name, entered);
+    }
+    return entered;
+}
+
+/** Prompts for and stores credentials (the *Set Connection Credentials* command). */
+export async function setCredentials(
+    secrets: vscode.SecretStorage,
+    connectionName: string,
+): Promise<boolean> {
+    const entered = await promptForCredentials(connectionName);
+    if (!entered) {
+        return false;
+    }
+    await storeCredentials(secrets, connectionName, entered);
+    return true;
+}
+
+/** Deletes stored credentials (the *Clear Connection Credentials* command). */
+export async function clearCredentials(
+    secrets: vscode.SecretStorage,
+    connectionName: string,
+): Promise<void> {
+    await secrets.delete(secretKey(connectionName));
+}
+
+async function promptForCredentials(connectionName: string): Promise<ExecAuth | undefined> {
+    const username = await vscode.window.showInputBox({
+        title: `Username for connection "${connectionName}"`,
+        ignoreFocusOut: true,
+    });
+    if (username === undefined || username === "") {
+        return undefined;
+    }
+    const password = await vscode.window.showInputBox({
+        title: `Password for "${username}" @ "${connectionName}"`,
+        password: true,
+        ignoreFocusOut: true,
+    });
+    if (password === undefined) {
+        return undefined;
+    }
+    return { type: "basic", username, password };
+}
+
+async function storeCredentials(
+    secrets: vscode.SecretStorage,
+    connectionName: string,
+    auth: ExecAuth,
+): Promise<void> {
+    await secrets.store(
+        secretKey(connectionName),
+        JSON.stringify({ username: auth.username, password: auth.password }),
+    );
+}

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -20,10 +20,14 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+    applyEndpointDirective,
+    classifyDirective,
+    ConnectionInfo,
     deriveShaclUrl,
     deriveUpdateUrl,
     parseEndpointDirectives,
-    resolveTarget,
+    resolveCellTarget,
+    statusBarText,
 } from "./endpoint";
 
 describe("parseEndpointDirectives", () => {
@@ -49,43 +53,197 @@ describe("parseEndpointDirectives", () => {
     });
 });
 
-describe("resolveTarget", () => {
-    it("returns none without a directive", () => {
-        assert.deepEqual(resolveTarget("SELECT * WHERE { ?s ?p ?o }"), { type: "none" });
+describe("classifyDirective", () => {
+    it("splits URLs, connection names, and file paths like the server does", () => {
+        assert.equal(classifyDirective("http://host/ds/query"), "url");
+        assert.equal(classifyDirective("HTTPS://host"), "url");
+        assert.equal(classifyDirective("local-fuseki"), "name");
+        assert.equal(classifyDirective("prod"), "name");
+        assert.equal(classifyDirective("./data.ttl"), "file");
+        assert.equal(classifyDirective("model.xml"), "file");
+        assert.equal(classifyDirective("sub/dir"), "file");
     });
+});
 
-    it("picks the first http(s) directive and derives the update and shacl siblings", () => {
-        const target = resolveTarget("# [endpoint=https://host/ds/query]\nASK {}");
-        assert.deepEqual(target, {
-            type: "http",
-            url: "https://host/ds/query",
-            updateUrl: "https://host/ds/update",
-            shaclUrl: "https://host/ds/shacl?graph=default",
+describe("resolveCellTarget", () => {
+    const CONNECTIONS: ConnectionInfo[] = [
+        {
+            name: "local-fuseki",
+            url: "http://localhost:3030/cgmes/query",
+            updateUrl: "http://localhost:3030/cgmes/upd",
+            authType: "basic",
+        },
+        { name: "prod", url: "https://sparql.example.org/query", default: true },
+    ];
+
+    it("returns none without directives, defaults, or a default connection", () => {
+        assert.deepEqual(resolveCellTarget("SELECT * WHERE { ?s ?p ?o }", []), {
+            kind: "none",
         });
     });
 
-    it("resolves a non-URL directive to a local-files target", () => {
-        assert.deepEqual(resolveTarget("# [endpoint=./data.ttl]\nASK {}"), {
-            type: "files",
-            files: ["./data.ttl"],
+    it("picks the first http(s) directive and derives the update and shacl siblings", () => {
+        const res = resolveCellTarget("# [endpoint=https://host/ds/query]\nASK {}", []);
+        assert.deepEqual(res, {
+            kind: "target",
+            label: "https://host/ds/query",
+            target: {
+                type: "http",
+                url: "https://host/ds/query",
+                updateUrl: "https://host/ds/update",
+                shaclUrl: "https://host/ds/shacl?graph=default",
+            },
         });
     });
 
     it("collects every file directive into one union target, in order", () => {
+        const res = resolveCellTarget(
+            "# [endpoint=./model.xml]\n# [endpoint=extra.ttl]\nASK {}",
+            [],
+        );
+        assert.equal(res.kind, "target");
+        assert.deepEqual(res.kind === "target" && res.target, {
+            type: "files",
+            files: ["./model.xml", "extra.ttl"],
+        });
+    });
+
+    it("reports directives of mixed kinds instead of silently picking one", () => {
         assert.deepEqual(
-            resolveTarget("# [endpoint=./model.xml]\n# [endpoint=extra.ttl]\nASK {}"),
+            resolveCellTarget("# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}", []),
             {
-                type: "files",
-                files: ["./model.xml", "extra.ttl"],
+                kind: "ambiguous-directives",
+                directives: ["./a.ttl", "http://host/sparql"],
+            },
+        );
+        assert.deepEqual(
+            resolveCellTarget(
+                "# [endpoint=./a.ttl]\n# [endpoint=local-fuseki]\nASK {}",
+                CONNECTIONS,
+            ),
+            {
+                kind: "ambiguous-directives",
+                directives: ["./a.ttl", "local-fuseki"],
             },
         );
     });
 
-    it("prefers the http directive when files are also present", () => {
-        const target = resolveTarget(
-            "# [endpoint=./a.ttl]\n# [endpoint=http://host/sparql]\nASK {}",
+    it("reports repeated URL or connection directives — only files union", () => {
+        assert.equal(
+            resolveCellTarget("# [endpoint=http://a/q]\n# [endpoint=http://b/q]\nASK {}", []).kind,
+            "ambiguous-directives",
         );
-        assert.equal(target.type, "http");
+        assert.equal(
+            resolveCellTarget("# [endpoint=local-fuseki]\n# [endpoint=prod]\nASK {}", CONNECTIONS)
+                .kind,
+            "ambiguous-directives",
+        );
+    });
+
+    it("resolves a connection name, keeping its explicit URLs and deriving the rest", () => {
+        const res = resolveCellTarget("# [endpoint=local-fuseki]\nASK {}", CONNECTIONS);
+        assert.ok(res.kind === "target");
+        if (res.kind === "target") {
+            assert.equal(res.label, "local-fuseki");
+            assert.deepEqual(res.target, {
+                type: "http",
+                url: "http://localhost:3030/cgmes/query",
+                updateUrl: "http://localhost:3030/cgmes/upd",
+                shaclUrl: "http://localhost:3030/cgmes/shacl?graph=default",
+            });
+            assert.equal(res.authConnection?.name, "local-fuseki");
+        }
+    });
+
+    it("reports an unknown connection name with the known ones", () => {
+        assert.deepEqual(resolveCellTarget("# [endpoint=nope]\nASK {}", CONNECTIONS), {
+            kind: "unknown-connection",
+            name: "nope",
+            known: ["local-fuseki", "prod"],
+        });
+    });
+
+    it("falls back to the notebook default directive, then the default connection", () => {
+        const viaDefault = resolveCellTarget("ASK {}", CONNECTIONS, "./model.xml");
+        assert.ok(viaDefault.kind === "target" && viaDefault.target.type === "files");
+
+        const viaConfig = resolveCellTarget("ASK {}", CONNECTIONS);
+        assert.ok(viaConfig.kind === "target");
+        if (viaConfig.kind === "target") {
+            assert.equal(viaConfig.label, "prod");
+            assert.equal(viaConfig.authConnection, undefined);
+        }
+    });
+
+    it("cell directives beat the notebook default", () => {
+        const res = resolveCellTarget(
+            "# [endpoint=./cell.ttl]\nASK {}",
+            CONNECTIONS,
+            "local-fuseki",
+        );
+        assert.ok(res.kind === "target" && res.target.type === "files");
+    });
+});
+
+describe("statusBarText", () => {
+    it("labels each resolution kind distinctly", () => {
+        assert.equal(
+            statusBarText({
+                kind: "target",
+                label: "local-fuseki",
+                target: { type: "http", url: "http://h/q" },
+            }),
+            "$(plug) local-fuseki",
+        );
+        assert.equal(
+            statusBarText({
+                kind: "target",
+                label: "http://h:3030/ds/query?x=1",
+                target: { type: "http", url: "http://h:3030/ds/query?x=1" },
+            }),
+            "$(globe) h:3030/ds/query",
+        );
+        assert.equal(
+            statusBarText({
+                kind: "target",
+                label: "./a/model.xml, b.ttl",
+                target: { type: "files", files: ["./a/model.xml", "b.ttl"] },
+            }),
+            "$(file) model.xml (+1)",
+        );
+        assert.equal(
+            statusBarText({ kind: "unknown-connection", name: "x", known: [] }),
+            "$(warning) unknown connection: x",
+        );
+        assert.equal(
+            statusBarText({ kind: "ambiguous-directives", directives: ["a.ttl", "http://h/q"] }),
+            "$(warning) conflicting endpoint directives",
+        );
+        assert.equal(statusBarText({ kind: "none" }), "$(warning) no endpoint");
+    });
+});
+
+describe("applyEndpointDirective", () => {
+    it("inserts a directive as the first line when none exists", () => {
+        assert.equal(
+            applyEndpointDirective("ASK {}", "local-fuseki"),
+            "# [endpoint=local-fuseki]\nASK {}",
+        );
+    });
+
+    it("replaces the first directive and drops any further ones", () => {
+        const text = "# [endpoint=./a.ttl]\nASK {}\n# [endpoint=./b.ttl]";
+        assert.equal(applyEndpointDirective(text, "http://h/q"), "# [endpoint=http://h/q]\nASK {}");
+    });
+
+    it("removes all directive lines when clearing", () => {
+        const text = "# [endpoint=./a.ttl]\nASK {}\n# [endpoint=./b.ttl]";
+        assert.equal(applyEndpointDirective(text, null), "ASK {}");
+    });
+
+    it("leaves ordinary comments alone", () => {
+        const text = "# just a comment\nASK {}";
+        assert.equal(applyEndpointDirective(text, null), text);
     });
 });
 

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -34,27 +34,181 @@ export function parseEndpointDirectives(text: string): string[] {
     return [...text.matchAll(DIRECTIVE)].map((m) => m[1].trim());
 }
 
-export type ResolvedTarget =
-    | { type: "http"; url: string; updateUrl: string; shaclUrl: string }
-    | { type: "files"; files: string[] }
-    | { type: "none" };
+/**
+ * What one directive value means: an endpoint URL, a named connection from the config's
+ * `cimnotebook.connections`, or a file path. Mirrors the server's heuristic — a
+ * connection name has no path separators and no extension dot, files virtually always
+ * have one ("model.xml" is a file, "local-fuseki" a name).
+ */
+export function classifyDirective(directive: string): "url" | "name" | "file" {
+    if (/^https?:\/\//i.test(directive)) {
+        return "url";
+    }
+    if (!/[/\\.]/.test(directive)) {
+        return "name";
+    }
+    return "file";
+}
 
 /**
- * Resolves the target for a cell: the first `http(s)://` directive wins; otherwise every
- * directive is taken as a local file path and the cell queries their union. The server
- * resolves relative paths against the notebook's directory — the same base validation
- * uses — so one directive means one file for both.
+ * How a cell's execution target was resolved. `authConnection` is set when the target
+ * came from a connection declaring `authType: "basic"` — the executor then attaches
+ * stored credentials before sending the request.
  */
-export function resolveTarget(cellText: string): ResolvedTarget {
+export type CellResolution =
+    | { kind: "target"; target: ExecuteTarget; label: string; authConnection?: ConnectionInfo }
+    | { kind: "unknown-connection"; name: string; known: string[] }
+    | { kind: "ambiguous-directives"; directives: string[] }
+    | { kind: "none" };
+
+/**
+ * Resolves a cell's execution target with the full precedence chain: the cell's own
+ * directives → the notebook's default directive (set via the *Set Cell Endpoint*
+ * command) → the config connection marked `"default": true` → none. Pure — the caller
+ * supplies the config connections (from `listConnections`) and the stored notebook
+ * default.
+ */
+export function resolveCellTarget(
+    cellText: string,
+    connections: ConnectionInfo[],
+    notebookDefaultDirective?: string,
+): CellResolution {
     const directives = parseEndpointDirectives(cellText);
-    if (directives.length === 0) {
-        return { type: "none" };
+    if (directives.length > 0) {
+        return resolveDirectives(directives, connections);
     }
-    const url = directives.find((d) => /^https?:\/\//i.test(d));
-    if (url === undefined) {
-        return { type: "files", files: directives };
+    if (notebookDefaultDirective) {
+        return resolveDirectives([notebookDefaultDirective], connections);
     }
-    return { type: "http", url, updateUrl: deriveUpdateUrl(url), shaclUrl: deriveShaclUrl(url) };
+    const defaultConnection = connections.find((c) => c.default === true);
+    if (defaultConnection) {
+        return connectionResolution(defaultConnection, connections);
+    }
+    return { kind: "none" };
+}
+
+/**
+ * One target per cell. Several *file* directives are a union (the M3 multi-file target),
+ * but any other repetition — two URLs, two connection names, or a mix of kinds — has no
+ * single meaning, and quietly running the cell against whichever one came first would
+ * send the query somewhere the author didn't ask for. Those are reported instead.
+ */
+function resolveDirectives(directives: string[], connections: ConnectionInfo[]): CellResolution {
+    const kinds = new Set(directives.map(classifyDirective));
+    if (kinds.size > 1 || (directives.length > 1 && !kinds.has("file"))) {
+        return { kind: "ambiguous-directives", directives };
+    }
+
+    if (kinds.has("url")) {
+        const url = directives[0];
+        return {
+            kind: "target",
+            target: {
+                type: "http",
+                url,
+                updateUrl: deriveUpdateUrl(url),
+                shaclUrl: deriveShaclUrl(url),
+            },
+            label: url,
+        };
+    }
+    if (kinds.has("name")) {
+        const name = directives[0];
+        const connection = connections.find((c) => c.name === name);
+        if (!connection) {
+            return {
+                kind: "unknown-connection",
+                name,
+                known: connections.map((c) => c.name),
+            };
+        }
+        return connectionResolution(connection, connections);
+    }
+    return {
+        kind: "target",
+        target: { type: "files", files: directives },
+        label: directives.join(", "),
+    };
+}
+
+function connectionResolution(
+    connection: ConnectionInfo,
+    connections: ConnectionInfo[],
+): CellResolution {
+    if (!connection.url) {
+        return {
+            kind: "unknown-connection",
+            name: connection.name,
+            known: connections.filter((c) => c.url).map((c) => c.name),
+        };
+    }
+    return {
+        kind: "target",
+        target: {
+            type: "http",
+            url: connection.url,
+            updateUrl: connection.updateUrl || deriveUpdateUrl(connection.url),
+            shaclUrl: connection.shaclUrl || deriveShaclUrl(connection.url),
+        },
+        label: connection.name,
+        authConnection: connection.authType?.toLowerCase() === "basic" ? connection : undefined,
+    };
+}
+
+/** Short status-bar text for a cell's resolution, with a codicon hinting the kind. */
+export function statusBarText(resolution: CellResolution): string {
+    switch (resolution.kind) {
+        case "target": {
+            const target = resolution.target;
+            if (target.type === "files") {
+                const files = target.files ?? [];
+                const first = files[0]?.replace(/^.*[/\\]/, "") ?? "?";
+                return `$(file) ${first}${files.length > 1 ? ` (+${files.length - 1})` : ""}`;
+            }
+            const viaConnection = resolution.label !== target.url;
+            return viaConnection
+                ? `$(plug) ${resolution.label}`
+                : `$(globe) ${shortUrl(target.url ?? "")}`;
+        }
+        case "unknown-connection":
+            return `$(warning) unknown connection: ${resolution.name}`;
+        case "ambiguous-directives":
+            return "$(warning) conflicting endpoint directives";
+        case "none":
+            return "$(warning) no endpoint";
+    }
+}
+
+function shortUrl(url: string): string {
+    return url.replace(/^https?:\/\//i, "").replace(/\?.*$/, "");
+}
+
+/**
+ * Returns the cell text with its endpoint directive set to `value` (replacing the first
+ * existing directive line and dropping any further ones), or with all directive lines
+ * removed when `value` is null. Used by the *Set Cell Endpoint* command — the directive
+ * stays the portable source of truth inside the file.
+ */
+export function applyEndpointDirective(cellText: string, value: string | null): string {
+    const directiveLine = /^\s*#\s*\[\s*endpoint\s*=\s*[^\]\s]+\s*\][^\n]*$/;
+    const lines = cellText.split("\n");
+    const kept: string[] = [];
+    let replaced = false;
+    for (const line of lines) {
+        if (!directiveLine.test(line)) {
+            kept.push(line);
+            continue;
+        }
+        if (value !== null && !replaced) {
+            kept.push(`# [endpoint=${value}]`);
+            replaced = true;
+        }
+        // Further directive lines (and all of them when clearing) are dropped.
+    }
+    if (value !== null && !replaced) {
+        kept.unshift(`# [endpoint=${value}]`);
+    }
+    return kept.join("\n");
 }
 
 /**
@@ -89,9 +243,49 @@ export function deriveShaclUrl(url: string): string {
     return shaclPath + (query || "?graph=default");
 }
 
-// ---- Wire types for cimvocabcheck.notebook.execute (mirror the server's records) ----
+// ---- Wire types for the cimvocabcheck.notebook.* commands (mirror the server's records) ----
 
 export const EXECUTE_COMMAND = "cimvocabcheck.notebook.execute";
+export const LIST_CONNECTIONS_COMMAND = "cimvocabcheck.notebook.listConnections";
+export const SET_DEFAULT_ENDPOINT_COMMAND = "cimvocabcheck.notebook.setDefaultEndpoint";
+
+/**
+ * Tells the server which endpoint a notebook's directive-less cells use, so they validate against
+ * what they run against. The default lives in the client's workspace state (not in the notebook
+ * file), hence this push; `endpoint: null` clears it.
+ */
+export interface SetDefaultEndpointRequest {
+    notebookUri: string;
+    endpoint: string | null;
+}
+
+/**
+ * Credentials attached to an execute request. They come from VS Code SecretStorage —
+ * never from the config file — and travel only inside this request.
+ */
+export interface ExecAuth {
+    type: "basic";
+    username: string;
+    password: string;
+}
+
+/** One connection from the config's `cimnotebook.connections`, as the server lists it. */
+export interface ConnectionInfo {
+    name: string;
+    url?: string;
+    updateUrl?: string;
+    shaclUrl?: string;
+    authType?: string;
+    default?: boolean;
+}
+
+/** Result of `cimvocabcheck.notebook.listConnections`. */
+export interface ListConnectionsResponse {
+    configPath?: string | null;
+    connections: ConnectionInfo[];
+    queryTimeoutSeconds?: number | null;
+    maxRows?: number | null;
+}
 
 export interface ExecuteTarget {
     type: "http" | "files";
@@ -99,6 +293,7 @@ export interface ExecuteTarget {
     updateUrl?: string;
     shaclUrl?: string;
     files?: string[];
+    auth?: ExecAuth;
 }
 
 export interface ExecuteRequest {

--- a/cimnotebook/vscode/src/notebook/endpointCommands.ts
+++ b/cimnotebook/vscode/src/notebook/endpointCommands.ts
@@ -1,0 +1,222 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Commands for endpoints and credentials:
+ *
+ * - *Set Cell Endpoint* — QuickPick over the config's connections plus free-form URL /
+ *   file input; writes a `# [endpoint=…]` directive into the cell (the directive is the
+ *   portable source of truth, versioned with the file), or stores a notebook-wide
+ *   default in workspaceState without touching the file.
+ * - *Set / Clear Connection Credentials* — manage the SecretStorage entries for
+ *   `authType: "basic"` connections.
+ */
+
+import * as vscode from "vscode";
+
+import { ConnectionStore } from "./connections";
+import { clearCredentials, setCredentials } from "./credentials";
+import { applyEndpointDirective, ConnectionInfo } from "./endpoint";
+
+export const SET_ENDPOINT_COMMAND = "cimnotebook.notebook.setEndpoint";
+export const SET_CREDENTIALS_COMMAND = "cimnotebook.notebook.setCredentials";
+export const CLEAR_CREDENTIALS_COMMAND = "cimnotebook.notebook.clearCredentials";
+
+export function registerEndpointCommands(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(SET_ENDPOINT_COMMAND, (cell?: vscode.NotebookCell) =>
+            setEndpoint(store, cell),
+        ),
+        vscode.commands.registerCommand(SET_CREDENTIALS_COMMAND, () =>
+            manageCredentials(context, store, "set"),
+        ),
+        vscode.commands.registerCommand(CLEAR_CREDENTIALS_COMMAND, () =>
+            manageCredentials(context, store, "clear"),
+        ),
+    );
+}
+
+// ---- Set Cell Endpoint -----------------------------------------------------------------------
+
+interface EndpointPick extends vscode.QuickPickItem {
+    action: "connection" | "url" | "file" | "clear" | "clear-default";
+    connection?: ConnectionInfo;
+}
+
+async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): Promise<void> {
+    const target = cell ?? activeCell();
+    if (!target) {
+        vscode.window.showWarningMessage("CIMNotebook: no notebook cell is active.");
+        return;
+    }
+
+    const { connections } = await store.forNotebook(target.notebook);
+    const notebookDefault = store.notebookDefault(target.notebook);
+    const items: EndpointPick[] = connections.map((connection) => ({
+        action: "connection",
+        connection,
+        label: `$(plug) ${connection.name}`,
+        description: connection.url,
+        detail: connection.default ? "workspace default connection" : undefined,
+    }));
+    items.push(
+        { action: "url", label: "$(globe) Enter endpoint URL…" },
+        { action: "file", label: "$(file) Enter data file path…" },
+        { action: "clear", label: "$(clear-all) Remove the cell's endpoint directive" },
+    );
+    if (notebookDefault) {
+        items.push({
+            action: "clear-default",
+            label: "$(circle-slash) Clear the notebook default",
+            description: notebookDefault,
+        });
+    }
+
+    const pick = await vscode.window.showQuickPick(items, {
+        title: notebookDefault
+            ? `Where should this cell run? (notebook default: ${notebookDefault})`
+            : "Where should this cell run?",
+        placeHolder: "Connection, URL, or local data file",
+    });
+    if (!pick) {
+        return;
+    }
+    if (pick.action === "clear-default") {
+        await store.setNotebookDefault(target.notebook, undefined);
+        return;
+    }
+
+    let directive: string | null;
+    switch (pick.action) {
+        case "connection":
+            directive = pick.connection?.name ?? null;
+            break;
+        case "url": {
+            const url = await vscode.window.showInputBox({
+                title: "SPARQL endpoint URL",
+                placeHolder: "http://localhost:3030/dataset/query",
+                validateInput: (v) =>
+                    /^https?:\/\/\S+$/i.test(v) ? undefined : "Enter an http(s):// URL",
+            });
+            if (url === undefined) {
+                return;
+            }
+            directive = url;
+            break;
+        }
+        case "file": {
+            const file = await vscode.window.showInputBox({
+                title: "Data file path (relative to the notebook)",
+                placeHolder: "./model.xml",
+            });
+            if (file === undefined || file === "") {
+                return;
+            }
+            directive = file;
+            break;
+        }
+        case "clear":
+            directive = null;
+            break;
+    }
+
+    const scope =
+        directive === null
+            ? "This cell"
+            : await vscode.window.showQuickPick(["This cell", "Notebook default"], {
+                  title: "Apply where?",
+                  placeHolder:
+                      "This cell = write a # [endpoint=…] directive; Notebook default = " +
+                      "remember for all directive-less cells (workspace state, not the file)",
+              });
+    if (scope === undefined) {
+        return;
+    }
+    if (scope === "Notebook default") {
+        await store.setNotebookDefault(target.notebook, directive ?? undefined);
+        return;
+    }
+
+    const newText = applyEndpointDirective(target.document.getText(), directive);
+    if (newText !== target.document.getText()) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(
+            target.document.uri,
+            new vscode.Range(0, 0, target.document.lineCount, 0),
+            newText,
+        );
+        await vscode.workspace.applyEdit(edit);
+    }
+}
+
+function activeCell(): vscode.NotebookCell | undefined {
+    const editor = vscode.window.activeNotebookEditor;
+    if (!editor) {
+        return undefined;
+    }
+    const range = editor.selections[0];
+    if (!range || range.isEmpty) {
+        return undefined;
+    }
+    return editor.notebook.cellAt(range.start);
+}
+
+// ---- credentials ------------------------------------------------------------------------------
+
+async function manageCredentials(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+    mode: "set" | "clear",
+): Promise<void> {
+    const name = await pickConnectionName(store);
+    if (!name) {
+        return;
+    }
+    if (mode === "set") {
+        if (await setCredentials(context.secrets, name)) {
+            vscode.window.showInformationMessage(
+                `CIMNotebook: credentials for "${name}" stored in VS Code secret storage.`,
+            );
+        }
+    } else {
+        await clearCredentials(context.secrets, name);
+        vscode.window.showInformationMessage(`CIMNotebook: credentials for "${name}" cleared.`);
+    }
+}
+
+async function pickConnectionName(store: ConnectionStore): Promise<string | undefined> {
+    const notebook = vscode.window.activeNotebookEditor?.notebook;
+    const connections = notebook ? (await store.forNotebook(notebook)).connections : [];
+    const basicConnections = connections.filter((c) => c.authType?.toLowerCase() === "basic");
+    if (basicConnections.length > 0) {
+        const pick = await vscode.window.showQuickPick(
+            basicConnections.map((c) => ({ label: c.name, description: c.url })),
+            { title: "Connection" },
+        );
+        return pick?.label;
+    }
+    // No notebook open (or no basic-auth connections declared): fall back to free input so
+    // credentials can still be managed.
+    return vscode.window.showInputBox({
+        title: "Connection name",
+        placeHolder: "as declared in opencgmes.jsonc → cimnotebook.connections",
+    });
+}

--- a/cimnotebook/vscode/src/notebook/executor.ts
+++ b/cimnotebook/vscode/src/notebook/executor.ts
@@ -26,17 +26,17 @@
 import * as vscode from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 
-import {
-    EXECUTE_COMMAND,
-    ExecError,
-    ExecuteRequest,
-    ExecuteResponse,
-    resolveTarget,
-} from "./endpoint";
+import { ConnectionStore } from "./connections";
+import { authFor } from "./credentials";
+import { EXECUTE_COMMAND, ExecError, ExecuteRequest, ExecuteResponse } from "./endpoint";
 import { errorSummary, MIME_MARKDOWN, outputItemsFor } from "./outputs";
 
 export class CellExecutor {
-    constructor(private readonly getClient: () => LanguageClient | undefined) {}
+    constructor(
+        private readonly getClient: () => LanguageClient | undefined,
+        private readonly store: ConnectionStore,
+        private readonly secrets: vscode.SecretStorage,
+    ) {}
 
     async execute(
         cell: vscode.NotebookCell,
@@ -77,27 +77,50 @@ export class CellExecutor {
         }
 
         const text = cell.document.getText();
-        const target = resolveTarget(text);
-        if (target.type === "none") {
+        const resolution = await this.store.resolveCell(cell);
+        if (resolution.kind === "none") {
             await replaceMarkdown(
                 execution,
                 "**No endpoint configured.** Add a directive to the cell, e.g.\n\n" +
                     "```\n# [endpoint=http://localhost:3030/dataset/query]\n```\n\n" +
-                    "or point it at a local RDF or CIMXML file:\n\n" +
-                    "```\n# [endpoint=./model.xml]\n```",
+                    "point it at a local RDF or CIMXML file (`# [endpoint=./model.xml]`), " +
+                    "name a connection from `opencgmes.jsonc`, or use the cell's endpoint " +
+                    "status-bar button.",
+            );
+            return false;
+        }
+        if (resolution.kind === "ambiguous-directives") {
+            await replaceMarkdown(
+                execution,
+                "**Conflicting `# [endpoint=…]` directives.** This cell declares " +
+                    resolution.directives.map((d) => `\`${d}\``).join(", ") +
+                    " — a cell runs against one endpoint. Keep a single URL or connection name " +
+                    "(several *file* paths are allowed: they are queried as one union).",
+            );
+            return false;
+        }
+        if (resolution.kind === "unknown-connection") {
+            const known =
+                resolution.known.length > 0
+                    ? `Known connections: ${resolution.known.map((n) => `\`${n}\``).join(", ")}.`
+                    : "The applicable `opencgmes.jsonc` declares no connections.";
+            await replaceMarkdown(
+                execution,
+                `**Unknown connection \`${resolution.name}\`.** ${known}`,
             );
             return false;
         }
 
+        const target = resolution.target;
+        if (resolution.authConnection) {
+            target.auth = await authFor(this.secrets, resolution.authConnection, true);
+        }
         const request: ExecuteRequest = {
             cellUri: cell.document.uri.toString(),
             notebookUri: cell.notebook.uri.toString(),
             languageId: cell.document.languageId,
             text,
-            target:
-                target.type === "http"
-                    ? { type: "http", url: target.url, updateUrl: target.updateUrl }
-                    : { type: "files", files: target.files },
+            target,
         };
         const response = await client.sendRequest<ExecuteResponse>(
             "workspace/executeCommand",

--- a/cimnotebook/vscode/src/notebook/statusBar.ts
+++ b/cimnotebook/vscode/src/notebook/statusBar.ts
@@ -1,0 +1,68 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Per-cell status bar item showing where the cell will run — connection, URL, files, or
+ * a warning when nothing is configured. Clicking it opens the *Set Cell Endpoint*
+ * command for that cell.
+ */
+
+import * as vscode from "vscode";
+
+import { ConnectionStore } from "./connections";
+import { statusBarText } from "./endpoint";
+import { NOTEBOOK_TYPES } from "./serializers";
+import { SET_ENDPOINT_COMMAND } from "./endpointCommands";
+
+export function registerCellStatusBar(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+): void {
+    const changeEmitter = new vscode.EventEmitter<void>();
+    context.subscriptions.push(changeEmitter);
+    // Re-resolve labels when the config or a notebook default changes; cell edits
+    // already re-trigger the provider through VS Code itself.
+    context.subscriptions.push(store.onDidChange(() => changeEmitter.fire()));
+
+    const provider: vscode.NotebookCellStatusBarItemProvider = {
+        onDidChangeCellStatusBarItems: changeEmitter.event,
+        async provideCellStatusBarItems(cell) {
+            if (cell.kind !== vscode.NotebookCellKind.Code) {
+                return [];
+            }
+            const resolution = await store.resolveCell(cell);
+            const item = new vscode.NotebookCellStatusBarItem(
+                statusBarText(resolution),
+                vscode.NotebookCellStatusBarAlignment.Right,
+            );
+            item.tooltip = "Set the endpoint this cell runs against";
+            item.command = {
+                title: "Set Cell Endpoint",
+                command: SET_ENDPOINT_COMMAND,
+                arguments: [cell],
+            };
+            return [item];
+        },
+    };
+
+    for (const notebookType of NOTEBOOK_TYPES) {
+        context.subscriptions.push(
+            vscode.notebooks.registerNotebookCellStatusBarItemProvider(notebookType, provider),
+        );
+    }
+}

--- a/cimvocabcheck/core/src/main/java/de/soptim/opencgmes/cimvocabcheck/core/ConfigTemplate.java
+++ b/cimvocabcheck/core/src/main/java/de/soptim/opencgmes/cimvocabcheck/core/ConfigTemplate.java
@@ -71,6 +71,19 @@ public final class ConfigTemplate {
           // their ontology conventions: "cim16" (CGMES 2.4.15), "cim17"/"cim18" (CGMES 3.0+).
           // "cimNamespaces": { "http://example.org/CIM-Custom#": "cim17" }
         }
+
+        // CIM Notebooks (VS Code) read the "cimnotebook" section: named connections that
+        // cells reference with "# [endpoint=<name>]", plus execution defaults. Passwords
+        // NEVER belong in this file — declare "authType": "basic" and CIMNotebook keeps
+        // the credentials in VS Code secret storage.
+        // "cimnotebook": {
+        //   "connections": [
+        //     { "name": "local-fuseki", "url": "http://localhost:3030/cgmes/query", "default": true },
+        //     { "name": "prod", "url": "https://sparql.example.org/query", "authType": "basic" }
+        //   ],
+        //   "queryTimeoutSeconds": 30,
+        //   "maxRows": 10000
+        // }
       }
       """;
 

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/DocumentUris.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/DocumentUris.java
@@ -1,0 +1,77 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Reduces a document URI to the file it denotes.
+ *
+ * <p>Ordinary documents arrive as {@code file:} URIs, notebook cells as {@code
+ * vscode-notebook-cell:/path/to/notebook.cimnb.md#<cell-id>} — the notebook's path plus a cell-id
+ * fragment. Both forms are mapped to the same plain filesystem path, which is what config
+ * discovery, relative {@code # [endpoint=...]} resolution, and {@link NotebookDefaults} key on.
+ */
+final class DocumentUris {
+
+  private static final String CELL_SCHEME = "vscode-notebook-cell:";
+
+  private DocumentUris() {}
+
+  /** Whether {@code uri} is a notebook cell rather than a document on disk. */
+  static boolean isNotebookCell(String uri) {
+    return uri != null && uri.toLowerCase(Locale.ROOT).startsWith(CELL_SCHEME);
+  }
+
+  /**
+   * The file a document URI denotes — for a cell, the notebook file itself — or {@code null} when
+   * the URI names no file (an unsaved {@code untitled:} document, an unparseable URI).
+   */
+  static Path path(String uri) {
+    if (uri == null) {
+      return null;
+    }
+    try {
+      int hash = uri.indexOf('#');
+      URI parsed = URI.create(hash >= 0 ? uri.substring(0, hash) : uri);
+      if ("file".equalsIgnoreCase(parsed.getScheme())) {
+        return Path.of(parsed);
+      }
+      String p = parsed.getPath();
+      if (p == null || p.isBlank()) {
+        return null;
+      }
+      // On Windows the cell URI path is "/C:/Users/…"; Path.of rejects the leading slash.
+      if (p.length() >= 3 && p.charAt(0) == '/' && p.charAt(2) == ':') {
+        p = p.substring(1);
+      }
+      return Path.of(p);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /** The directory containing a document URI's file, or {@code null} when it has none. */
+  static Path dir(String uri) {
+    Path path = path(uri);
+    return path == null ? null : path.getParent();
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaults.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaults.java
@@ -1,0 +1,145 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The per-notebook default endpoint: the {@code # [endpoint=...]} value a notebook's directive-less
+ * cells run — and validate — against.
+ *
+ * <p>The default is a client-side choice (VS Code's <em>Set Cell Endpoint → Notebook default</em>,
+ * remembered in workspace state rather than written into the notebook file), so the server can only
+ * learn about it by being told: the client pushes every change, and re-pushes on startup, through
+ * the {@value SparqlWorkspaceService#CMD_SET_DEFAULT_ENDPOINT} command. Without that, a cell with
+ * no directive of its own has no schema source and falls back to syntax-only validation.
+ *
+ * <p>Entries are keyed by the notebook's own path, which a cell URI carries too — see {@link
+ * DocumentUris} — so a cell can look up the notebook it belongs to.
+ */
+final class NotebookDefaults {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookDefaults.class);
+  private static final Gson GSON = new Gson();
+
+  private final Map<String, String> endpoints = new ConcurrentHashMap<>();
+  private final List<Runnable> onChangeCallbacks = new CopyOnWriteArrayList<>();
+
+  /** Registers a callback invoked after each change (typically: revalidate open documents). */
+  void addOnChangeCallback(Runnable callback) {
+    onChangeCallbacks.add(callback);
+  }
+
+  /**
+   * Applies one {@value SparqlWorkspaceService#CMD_SET_DEFAULT_ENDPOINT} invocation. Its single
+   * argument is {@code {"notebookUri": "...", "endpoint": "..."}}; a {@code null}/absent endpoint
+   * clears the notebook's default. Over JSON-RPC lsp4j delivers arguments as Gson {@link
+   * JsonElement}s, while an in-process call may pass a JSON {@link String} — both are accepted, as
+   * in {@code NotebookCommandHandler}.
+   */
+  void apply(List<Object> arguments) {
+    if (arguments == null || arguments.isEmpty() || arguments.get(0) == null) {
+      LOG.warn("Ignoring setDefaultEndpoint without an argument");
+      return;
+    }
+    try {
+      Object first = arguments.get(0);
+      JsonElement el =
+          first instanceof JsonElement je ? je : GSON.fromJson(first.toString(), JsonElement.class);
+      if (el == null || !el.isJsonObject()) {
+        LOG.warn("Ignoring malformed setDefaultEndpoint argument: {}", first);
+        return;
+      }
+      JsonObject obj = el.getAsJsonObject();
+      set(stringField(obj, "notebookUri"), stringField(obj, "endpoint"));
+    } catch (RuntimeException e) {
+      LOG.warn("Ignoring malformed setDefaultEndpoint argument: {}", e.getMessage());
+    }
+  }
+
+  /** Sets a notebook's default endpoint, or clears it when {@code endpoint} is null/blank. */
+  void set(String notebookUri, String endpoint) {
+    String key = key(notebookUri);
+    if (key == null) {
+      LOG.debug("Ignoring notebook default for unusable URI {}", notebookUri);
+      return;
+    }
+    if (endpoint == null || endpoint.isBlank()) {
+      endpoints.remove(key);
+    } else {
+      endpoints.put(key, endpoint.trim());
+    }
+    LOG.debug("Notebook default for {} is now {}", key, endpoints.get(key));
+    fireOnChange();
+  }
+
+  /**
+   * The default endpoint of the notebook owning {@code cellUri}, or {@code null} if none is set.
+   */
+  String forCell(String cellUri) {
+    String key = key(cellUri);
+    return key == null ? null : endpoints.get(key);
+  }
+
+  /**
+   * The map key a notebook URI and its cell URIs agree on: the notebook's path. Unsaved notebooks
+   * have none, so their opaque URI body ({@code untitled:Untitled-1} and {@code
+   * vscode-notebook-cell:Untitled-1#…} alike) is used instead.
+   */
+  private static String key(String uri) {
+    Path path = DocumentUris.path(uri);
+    if (path != null) {
+      return path.normalize().toString();
+    }
+    if (uri == null || uri.isBlank()) {
+      return null;
+    }
+    try {
+      String body = URI.create(uri.split("#", 2)[0]).getSchemeSpecificPart();
+      return body == null || body.isBlank() ? null : body;
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  private static String stringField(JsonObject obj, String name) {
+    JsonElement value = obj.get(name);
+    return value == null || value.isJsonNull() ? null : value.getAsString();
+  }
+
+  private void fireOnChange() {
+    for (Runnable callback : onChangeCallbacks) {
+      try {
+        callback.run();
+      } catch (Exception e) {
+        LOG.error("Notebook-default change callback failed: {}", e.getMessage(), e);
+      }
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManager.java
@@ -28,6 +28,8 @@ import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.EndpointSchema;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.EndpointSchemaLoader;
 import de.soptim.opencgmes.cimvocabcheck.core.schema.RdfsSchemaIndex;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConfigLoader;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConnection;
 import de.soptim.opencgmes.cimvocabcheck.lsp.schema.SchemaLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -199,33 +201,78 @@ final class SchemaManager {
   }
 
   /**
-   * Resolves the schema a document should be validated against.
-   *
-   * <p>When {@code endpoint} is {@code null}/blank, the document's workspace schema is used: the
-   * nearest {@code opencgmes.jsonc} above the document. When none is found (or it declares no
-   * schemas) the result is empty and the caller validates syntax-only. Otherwise the schema is
-   * loaded from the endpoint — a local {@code .ttl}/{@code .rdf}/{@code .owl} file or a remote
-   * SPARQL endpoint — and cached by resolved source.
+   * Resolves the schema a document should be validated against — {@link #schemaSourceOf} followed
+   * by {@link #resolveFrom}. Callers that also need to know <em>whether</em> the endpoint is a
+   * schema source (to tell a failed endpoint apart from one that never was one) should call the two
+   * separately.
    *
    * @param endpoint the {@code # [endpoint=...]} value, or {@code null} for the workspace schema
    * @param docDir the document's own directory, used for config discovery and relative endpoints
    */
   Optional<ResolvedSchema> resolveSchema(String endpoint, Path docDir) {
+    return resolveFrom(schemaSourceOf(endpoint, docDir), docDir);
+  }
+
+  /**
+   * The source an endpoint directive loads its schema from — a remote SPARQL endpoint URL or a
+   * local {@code .ttl}/{@code .rdf}/{@code .owl} file — or {@code null} when the directive names no
+   * schema at all and the document's workspace schema applies instead. That is the case for a blank
+   * directive, and for two notebook-specific ones:
+   *
+   * <ul>
+   *   <li><b>Instance data.</b> The same directive is also the cell's execution target, which may
+   *       be a CIMXML model or an {@code .nt}/{@code .nq}/{@code .trig} dump. Loading data as a
+   *       schema would turn every term in the cell into a false diagnostic.
+   *   <li><b>An unresolvable connection name.</b> Names with no matching {@code "cimnotebook"}
+   *       connection, or whose connection declares no remote URL, have no schema to offer.
+   * </ul>
+   */
+  String schemaSourceOf(String endpoint, Path docDir) {
     if (endpoint == null || endpoint.isBlank()) {
-      return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
+      return null;
     }
     if (isRemote(endpoint)) {
-      return resolveRemote(endpoint);
+      return endpoint;
+    }
+    if (looksLikeConnectionName(endpoint)) {
+      // Notebook cells may name a connection from the "cimnotebook" config section instead of a
+      // URL or file. Resolving it here keeps validation and execution agreeing on what the
+      // directive means: the schema loads from the connection's endpoint.
+      NotebookConnection connection =
+          NotebookConfigLoader.forDirectory(docDir).config().byName(endpoint);
+      return connection != null && connection.url() != null && isRemote(connection.url())
+          ? connection.url()
+          : null;
     }
     Path file = resolveLocalEndpoint(endpoint, docDir);
     if (!isSchemaFile(file)) {
-      // The same # [endpoint=...] directive is also the notebook execution target, which may be
-      // instance data (a CIMXML model, an .nt/.nq/.trig dump). Loading that as a schema would
-      // produce misleading diagnostics, so validation quietly keeps the workspace schema instead.
       LOG.debug("Endpoint directive {} is not a schema file; using the workspace schema", file);
+      return null;
+    }
+    return file.toString();
+  }
+
+  /**
+   * Loads the schema from a {@link #schemaSourceOf} result, caching it by source; {@code null} —
+   * i.e. no schema source — falls back to the document's workspace schema (the nearest {@code
+   * opencgmes.jsonc} above it). Empty when nothing applies: no config, a config without schemas, or
+   * an endpoint that is still loading or failed — the caller then validates syntax-only.
+   */
+  Optional<ResolvedSchema> resolveFrom(String source, Path docDir) {
+    if (source == null) {
       return workspaceSchemaFor(docDir).map(WorkspaceSchema::toResolvedSchema);
     }
-    return resolveLocal(file);
+    return isRemote(source) ? resolveRemote(source) : resolveLocal(Path.of(source));
+  }
+
+  /**
+   * Whether a directive could be a named connection: no path separators, no extension dot. Only
+   * such directives pay for a config lookup; files virtually always have an extension, so
+   * "model.xml" never does, while "local-fuseki" does. (A connection whose name contains a dot or
+   * slash is not resolvable from a directive — documented limitation.)
+   */
+  private static boolean looksLikeConnectionName(String endpoint) {
+    return !endpoint.contains("/") && !endpoint.contains("\\") && !endpoint.contains(".");
   }
 
   /** Whether a local endpoint directive names a schema file (vs instance data — see above). */

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlLanguageServer.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlLanguageServer.java
@@ -74,11 +74,16 @@ public final class SparqlLanguageServer implements LanguageServer, LanguageClien
   /** Creates the server and wires up its document, workspace, and schema services. */
   public SparqlLanguageServer() {
     schemaManager = new SchemaManager();
-    textDocumentService = new SparqlTextDocumentService(schemaManager);
+    NotebookDefaults notebookDefaults = new NotebookDefaults();
+    textDocumentService = new SparqlTextDocumentService(schemaManager, notebookDefaults);
     notebookCommandHandler = new NotebookCommandHandler();
-    workspaceService = new SparqlWorkspaceService(schemaManager, notebookCommandHandler);
+    workspaceService =
+        new SparqlWorkspaceService(schemaManager, notebookCommandHandler, notebookDefaults);
     // After each successful schema load, revalidate all open documents.
     schemaManager.addOnLoadedCallback(textDocumentService::revalidateAll);
+    // Likewise when a notebook's default endpoint changes: its directive-less cells now validate
+    // against a different schema.
+    notebookDefaults.addOnChangeCallback(textDocumentService::revalidateAll);
   }
 
   // ---- LanguageClientAware ---------------------------------------------------------------

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlTextDocumentService.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlTextDocumentService.java
@@ -31,7 +31,8 @@ import de.soptim.opencgmes.cimvocabcheck.core.schema.SchemaIndex;
 import de.soptim.opencgmes.cimvocabcheck.core.shacl.EmbeddedSourceMapper;
 import de.soptim.opencgmes.cimvocabcheck.core.shacl.EmbeddedSparql;
 import de.soptim.opencgmes.cimvocabcheck.core.shacl.ShaclValidationResult;
-import java.net.URI;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConfigLoader;
+import de.soptim.opencgmes.cimvocabcheck.lsp.notebook.NotebookConnection;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -96,6 +97,7 @@ final class SparqlTextDocumentService implements TextDocumentService {
   private static final long DEBOUNCE_MS = 300;
 
   private final SchemaManager schemaManager;
+  private final NotebookDefaults notebookDefaults;
   private final AtomicReference<LanguageClient> client = new AtomicReference<>();
 
   /** Whether a document is validated as SPARQL or as SHACL/Turtle. */
@@ -128,8 +130,9 @@ final class SparqlTextDocumentService implements TextDocumentService {
   private final EndpointDefinitionPeek endpointPeek =
       new EndpointDefinitionPeek(Duration.ofSeconds(15));
 
-  SparqlTextDocumentService(SchemaManager schemaManager) {
+  SparqlTextDocumentService(SchemaManager schemaManager, NotebookDefaults notebookDefaults) {
     this.schemaManager = schemaManager;
+    this.notebookDefaults = notebookDefaults;
   }
 
   void setClient(LanguageClient client) {
@@ -218,9 +221,10 @@ final class SparqlTextDocumentService implements TextDocumentService {
       // files. A local-file endpoint has a real source file to jump to, via the same
       // DefinitionIndex mechanism as a workspace schema; a remote SPARQL endpoint has none, so
       // the term's triples are fetched and opened as a generated read-only Turtle "peek" instead.
-      String endpoint = EndpointDirective.parse(text).orElse(null);
-      if (endpoint != null) {
-        var rsOpt = schemaManager.resolveSchema(endpoint, documentDir(uri));
+      Path docDir = documentDir(uri);
+      String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+      if (source != null) {
+        var rsOpt = schemaManager.resolveFrom(source, docDir);
         if (rsOpt.isEmpty() || !termKnown(rsOpt.get().api().schemaIndex(), term)) {
           return noDefinition();
         }
@@ -232,13 +236,13 @@ final class SparqlTextDocumentService implements TextDocumentService {
               .orElseGet(SparqlTextDocumentService::noDefinition);
         }
         return endpointPeek
-            .locationFor(endpoint, term.getURI())
+            .locationFor(source, term.getURI())
             .map(SparqlTextDocumentService::definitionAt)
             .orElseGet(SparqlTextDocumentService::noDefinition);
       }
 
       // Workspace document: jump into the local RDFS source file.
-      var wsOpt = schemaManager.workspaceSchemaFor(documentDir(uri));
+      var wsOpt = schemaManager.workspaceSchemaFor(docDir);
       if (wsOpt.isEmpty() || wsOpt.get().definitionIndex() == null) {
         return noDefinition();
       }
@@ -333,17 +337,46 @@ final class SparqlTextDocumentService implements TextDocumentService {
 
   /**
    * The schema index a document's IDE features (hover, completion, definition) should consult: the
-   * {@code # [endpoint=...]} schema when the document declares one and it has resolved, otherwise
-   * the document's workspace schema (nearest {@code opencgmes.jsonc}). Returns empty when no schema
-   * applies — no config / config without schemas, or an endpoint not yet available (still loading,
-   * or the load failed) — so the editor never shows information from the wrong (workspace) schema
-   * for an endpoint document.
+   * {@link #effectiveEndpoint} schema when one applies and has resolved, otherwise the document's
+   * workspace schema (nearest {@code opencgmes.jsonc}). Returns empty when no schema applies — no
+   * config / config without schemas, or an endpoint not yet available (still loading, or the load
+   * failed) — so the editor never shows information from the wrong (workspace) schema for an
+   * endpoint document.
    */
   private Optional<SchemaIndex> documentSchemaIndex(String uri, String text) {
-    String endpoint = EndpointDirective.parse(text).orElse(null);
     return schemaManager
-        .resolveSchema(endpoint, documentDir(uri))
+        .resolveSchema(effectiveEndpoint(uri, text), documentDir(uri))
         .map(rs -> rs.api().schemaIndex());
+  }
+
+  /**
+   * The endpoint a document's schema comes from.
+   *
+   * <p>The precedence mirrors the one the VS Code client uses to pick a cell's <em>execution</em>
+   * target, so a cell validates against what it runs against:
+   *
+   * <ol>
+   *   <li>the document's own {@code # [endpoint=...]} directive;
+   *   <li>for notebook cells, the {@link NotebookDefaults notebook default} the client set;
+   *   <li>for notebook cells, the {@code "cimnotebook"} connection marked {@code "default": true}.
+   * </ol>
+   *
+   * <p>Returns {@code null} when none applies — the document then uses its workspace schema. Only
+   * cells consult the notebook fallbacks: a stand-alone {@code .rq}/{@code .ttl} file is not part
+   * of a notebook and keeps its workspace schema.
+   */
+  private String effectiveEndpoint(String uri, String text) {
+    String directive = EndpointDirective.parse(text).orElse(null);
+    if (directive != null || !DocumentUris.isNotebookCell(uri)) {
+      return directive;
+    }
+    String notebookDefault = notebookDefaults.forCell(uri);
+    if (notebookDefault != null) {
+      return notebookDefault;
+    }
+    NotebookConnection defaultConnection =
+        NotebookConfigLoader.forDirectory(documentDir(uri)).config().defaultConnection();
+    return defaultConnection != null ? defaultConnection.url() : null;
   }
 
   // ---- Internal API ----------------------------------------------------------------------
@@ -383,16 +416,18 @@ final class SparqlTextDocumentService implements TextDocumentService {
       return;
     }
 
-    // A SPARQL Notebook cell may declare its schema source via "# [endpoint=...]"; otherwise the
-    // document's workspace schema (nearest opencgmes.jsonc) is used. With neither, validation is
-    // syntax-only — there is no bundled default schema.
-    String endpoint = EndpointDirective.parse(text).orElse(null);
-    var schemaOpt = schemaManager.resolveSchema(endpoint, documentDir(uri));
+    // A notebook cell may declare its schema source via "# [endpoint=...]" (or inherit one from the
+    // notebook default / the default connection); otherwise the document's workspace schema
+    // (nearest opencgmes.jsonc) is used. With neither, validation is syntax-only — there is no
+    // bundled default schema.
+    Path docDir = documentDir(uri);
+    String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+    var schemaOpt = schemaManager.resolveFrom(source, docDir);
     if (schemaOpt.isEmpty()) {
       // No schema resolved: an endpoint that failed / is still loading, or no config + no
       // endpoint. Fall back to a schema-independent syntax check so broken SPARQL still gets
       // squiggles; flag the endpoint case as an error (the others are the normal no-config state).
-      publishSyntaxOnly(uri, text, endpoint != null);
+      publishSyntaxOnly(uri, text, source != null);
       return;
     }
 
@@ -598,13 +633,14 @@ final class SparqlTextDocumentService implements TextDocumentService {
       return;
     }
 
-    String endpoint = EndpointDirective.parse(text).orElse(null);
-    var schemaOpt = schemaManager.resolveSchema(endpoint, documentDir(uri));
+    Path docDir = documentDir(uri);
+    String source = schemaManager.schemaSourceOf(effectiveEndpoint(uri, text), docDir);
+    var schemaOpt = schemaManager.resolveFrom(source, docDir);
     if (schemaOpt.isEmpty()) {
       // No schema resolved: an endpoint that failed / is still loading, or no config + no
       // endpoint. Fall back to a schema-independent check (Turtle parse, embedded-SPARQL
       // syntax, vocabulary typos); flag the endpoint case as an error.
-      publishShaclSyntaxOnly(uri, text, endpoint != null);
+      publishShaclSyntaxOnly(uri, text, source != null);
       return;
     }
     ResolvedSchema schema = schemaOpt.get();
@@ -970,31 +1006,12 @@ final class SparqlTextDocumentService implements TextDocumentService {
   }
 
   /**
-   * Best-effort parent directory of a document URI, used to resolve relative endpoint paths.
-   *
-   * <p>Handles both {@code file://} URIs and notebook cell URIs such as {@code
-   * vscode-notebook-cell:/path/to/notebook.sparqlbook#<cell-id>} — the fragment (cell id) is
-   * stripped so the notebook file's directory is returned.
+   * Best-effort parent directory of a document URI, used for config discovery and to resolve
+   * relative endpoint paths. Notebook cells resolve against the notebook file's directory — see
+   * {@link DocumentUris}.
    */
   static Path documentDir(String uri) {
-    try {
-      int hash = uri.indexOf('#');
-      String noFragment = hash >= 0 ? uri.substring(0, hash) : uri;
-      URI parsed = URI.create(noFragment);
-      if ("file".equalsIgnoreCase(parsed.getScheme())) {
-        return Path.of(parsed).getParent();
-      }
-      String p = parsed.getPath();
-      if (p == null || p.isBlank()) {
-        return null;
-      }
-      if (p.length() >= 3 && p.charAt(0) == '/' && p.charAt(2) == ':') {
-        p = p.substring(1);
-      }
-      return Path.of(p).getParent();
-    } catch (Exception e) {
-      return null;
-    }
+    return DocumentUris.dir(uri);
   }
 
   private static boolean isSparqlFile(String uri) {

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlWorkspaceService.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/SparqlWorkspaceService.java
@@ -58,13 +58,24 @@ final class SparqlWorkspaceService implements WorkspaceService {
    */
   static final String CMD_CREATE_CONFIG = "cimvocabcheck.createConfig";
 
+  /**
+   * Command id for the per-notebook default endpoint (see {@link NotebookDefaults}). The client
+   * sends {@code {"notebookUri": "...", "endpoint": "..."}} whenever the user picks a notebook
+   * default, and re-sends the notebook defaults it remembers when the server starts.
+   */
+  static final String CMD_SET_DEFAULT_ENDPOINT = "cimvocabcheck.notebook.setDefaultEndpoint";
+
   private final SchemaManager schemaManager;
   private final NotebookCommandHandler notebookCommandHandler;
+  private final NotebookDefaults notebookDefaults;
 
   SparqlWorkspaceService(
-      SchemaManager schemaManager, NotebookCommandHandler notebookCommandHandler) {
+      SchemaManager schemaManager,
+      NotebookCommandHandler notebookCommandHandler,
+      NotebookDefaults notebookDefaults) {
     this.schemaManager = schemaManager;
     this.notebookCommandHandler = notebookCommandHandler;
+    this.notebookDefaults = notebookDefaults;
   }
 
   @Override
@@ -98,6 +109,13 @@ final class SparqlWorkspaceService implements WorkspaceService {
     }
     if (NotebookCommandHandler.CMD_EXECUTE.equals(params.getCommand())) {
       return notebookCommandHandler.executeCommand(params.getArguments());
+    }
+    if (NotebookCommandHandler.CMD_LIST_CONNECTIONS.equals(params.getCommand())) {
+      return notebookCommandHandler.listConnections(params.getArguments());
+    }
+    if (CMD_SET_DEFAULT_ENDPOINT.equals(params.getCommand())) {
+      notebookDefaults.apply(params.getArguments());
+      return CompletableFuture.completedFuture(null);
     }
     if (!CMD_EXPLAIN_QUERY.equals(params.getCommand())) {
       LOG.warn("Unknown command: {}", params.getCommand());

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecAuth.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecAuth.java
@@ -1,0 +1,41 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+/**
+ * Credentials for an HTTP target, attached by the client per execute request. This is the
+ * <b>only</b> place credentials ever travel: the client keeps them in VS Code SecretStorage (never
+ * in {@code opencgmes.jsonc}), and the server uses them solely to build the request's {@code
+ * Authorization} header — they are never logged, cached, or echoed back in responses.
+ *
+ * @param type the scheme; only {@code "basic"} is understood.
+ * @param username the user name.
+ * @param password the password; may be empty.
+ */
+record ExecAuth(String type, String username, String password) {
+
+  /** The only {@link #type()} understood. */
+  static final String TYPE_BASIC = "basic";
+
+  /** Redacts credentials wherever a record accidentally ends up in a log or error message. */
+  @Override
+  public String toString() {
+    return "ExecAuth[type=" + type + ", username=***, password=***]";
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecSupport.java
@@ -18,6 +18,8 @@
 
 package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -161,5 +163,21 @@ final class ExecSupport {
 
   static boolean isBlank(String s) {
     return s == null || s.isBlank();
+  }
+
+  /**
+   * The value for a preemptive {@code Authorization} header, or {@code null} when the target has no
+   * usable basic-auth credentials. Sent preemptively (rather than via a 401 challenge dance) so it
+   * also works with services that answer 400/404 instead of challenging.
+   */
+  static String basicAuthHeader(ExecAuth auth) {
+    if (auth == null
+        || !ExecAuth.TYPE_BASIC.equalsIgnoreCase(auth.type())
+        || auth.username() == null) {
+      return null;
+    }
+    String credentials = auth.username() + ":" + (auth.password() != null ? auth.password() : "");
+    return "Basic "
+        + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ExecuteTarget.java
@@ -38,9 +38,11 @@ import java.util.List;
  *     targets only). Relative paths are resolved server-side against the directory of {@link
  *     ExecuteRequest#notebookUri()}; multiple files are queried as one union store. Local files are
  *     read-only — updates are rejected with {@link ErrorCode#UPDATE_NOT_ALLOWED}.
+ * @param auth optional credentials for {@code "http"} targets — see {@link ExecAuth} for the
+ *     handling guarantees; {@code null} for anonymous access.
  */
 record ExecuteTarget(
-    String type, String url, String updateUrl, String shaclUrl, List<String> files) {
+    String type, String url, String updateUrl, String shaclUrl, List<String> files, ExecAuth auth) {
 
   /** Target {@link #type()}: a remote SPARQL endpoint. */
   static final String TYPE_HTTP = "http";

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutor.java
@@ -26,7 +26,9 @@ import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
 import org.apache.jena.sparql.exec.http.UpdateExecutionHTTP;
+import org.apache.jena.sparql.exec.http.UpdateExecutionHTTPBuilder;
 import org.apache.jena.update.UpdateExecution;
 import org.apache.jena.update.UpdateRequest;
 import org.slf4j.Logger;
@@ -63,11 +65,15 @@ final class HttpQueryExecutor {
 
     String url = target.url();
     int maxRows = ExecSupport.maxRows(options);
-    QueryExecution qe =
+    QueryExecutionHTTPBuilder builder =
         QueryExecutionHTTP.service(url)
             .query(query)
-            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS)
-            .build();
+            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS);
+    String authHeader = ExecSupport.basicAuthHeader(target.auth());
+    if (authHeader != null) {
+      builder.httpHeader("Authorization", authHeader);
+    }
+    QueryExecution qe = builder.build();
     return ExecSupport.runCancellable(
         ctx,
         qe::abort,
@@ -96,11 +102,15 @@ final class HttpQueryExecutor {
               null));
     }
 
-    UpdateExecution ue =
+    UpdateExecutionHTTPBuilder builder =
         UpdateExecutionHTTP.service(updateUrl)
             .update(update)
-            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS)
-            .build();
+            .timeout(ExecSupport.timeoutMs(options), TimeUnit.MILLISECONDS);
+    String authHeader = ExecSupport.basicAuthHeader(target.auth());
+    if (authHeader != null) {
+      builder.httpHeader("Authorization", authHeader);
+    }
+    UpdateExecution ue = builder.build();
     return ExecSupport.runCancellable(ctx, ue::abort, () -> runUpdate(ue, updateUrl));
   }
 

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpShaclClient.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpShaclClient.java
@@ -74,13 +74,17 @@ final class HttpShaclClient {
 
     HttpRequest request;
     try {
-      request =
+      HttpRequest.Builder builder =
           HttpRequest.newBuilder(URI.create(shaclUrl))
               .timeout(Duration.ofMillis(ExecSupport.timeoutMs(options)))
               .header("Content-Type", TEXT_TURTLE)
               .header("Accept", TEXT_TURTLE)
-              .POST(HttpRequest.BodyPublishers.ofString(shapesTurtle))
-              .build();
+              .POST(HttpRequest.BodyPublishers.ofString(shapesTurtle));
+      String authHeader = ExecSupport.basicAuthHeader(target.auth());
+      if (authHeader != null) {
+        builder.header("Authorization", authHeader);
+      }
+      request = builder.build();
     } catch (IllegalArgumentException e) {
       return ExecuteResponse.failed(
           new ExecError(

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ListConnectionsResponse.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ListConnectionsResponse.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.util.List;
+
+/**
+ * Result of the {@code cimvocabcheck.notebook.listConnections} workspace command: the notebook's
+ * applicable {@code "cimnotebook"} config, resolved with nearest-config discovery. Contains no
+ * secrets by construction (see {@link NotebookConnection}).
+ *
+ * @param configPath the config file the connections came from, or {@code null} when no {@code
+ *     opencgmes.jsonc} applies to the notebook.
+ * @param connections the declared connections; empty when there are none.
+ * @param queryTimeoutSeconds workspace default execution timeout, or {@code null}.
+ * @param maxRows workspace default result cap, or {@code null}.
+ */
+record ListConnectionsResponse(
+    String configPath,
+    List<NotebookConnection> connections,
+    Integer queryTimeoutSeconds,
+    Integer maxRows) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandler.java
@@ -53,6 +53,9 @@ public final class NotebookCommandHandler {
   /** Command id for cell execution (see {@link #executeCommand}). */
   public static final String CMD_EXECUTE = "cimvocabcheck.notebook.execute";
 
+  /** Command id for listing a notebook's configured connections (see {@link #listConnections}). */
+  public static final String CMD_LIST_CONNECTIONS = "cimvocabcheck.notebook.listConnections";
+
   /**
    * Pool the blocking Jena call runs on. Must stay unbounded (cached, not fixed): the executors'
    * {@link ExecSupport#runCancellable} racing submits its own nested task to this same pool and
@@ -88,6 +91,36 @@ public final class NotebookCommandHandler {
         executionPool, cancelChecker -> doExecute(request, cancelChecker));
   }
 
+  /**
+   * Handles one {@value #CMD_LIST_CONNECTIONS} invocation: answers the {@code "cimnotebook"} config
+   * that applies to the notebook named by the single argument's {@code notebookUri} field
+   * (nearest-config discovery; empty result when none applies). Never returns secrets — the config
+   * only ever declares an {@code authType}.
+   */
+  public CompletableFuture<Object> listConnections(List<Object> arguments) {
+    String notebookUri = null;
+    if (arguments != null && !arguments.isEmpty() && arguments.get(0) != null) {
+      Object first = arguments.get(0);
+      JsonElement el =
+          first instanceof JsonElement je ? je : GSON.fromJson(first.toString(), JsonElement.class);
+      if (el != null && el.isJsonObject() && el.getAsJsonObject().has("notebookUri")) {
+        notebookUri = el.getAsJsonObject().get("notebookUri").getAsString();
+      }
+    }
+    final String uri = notebookUri;
+    return CompletableFuture.supplyAsync(
+        () -> {
+          NotebookConfigLoader.Located located = NotebookConfigLoader.forNotebook(uri);
+          NotebookConfig config = located.config();
+          return new ListConnectionsResponse(
+              located.configPath() != null ? located.configPath().toString() : null,
+              config.connections(),
+              config.queryTimeoutSeconds(),
+              config.maxRows());
+        },
+        executionPool);
+  }
+
   /** Releases the thread pools. Safe to call once during server shutdown. */
   public void shutdown() {
     executionPool.shutdown();
@@ -106,9 +139,10 @@ public final class NotebookCommandHandler {
     }
   }
 
-  private Object doExecute(ExecuteRequest request, CancelChecker cancelChecker) {
-    LOG.debug("Executing {} cell {}", request.languageId(), request.cellUri());
+  private Object doExecute(ExecuteRequest rawRequest, CancelChecker cancelChecker) {
+    LOG.debug("Executing {} cell {}", rawRequest.languageId(), rawRequest.cellUri());
     try {
+      ExecuteRequest request = withConfigDefaults(rawRequest);
       var ctx = new ExecContext(executionPool, watchdogScheduler, cancelChecker);
       if ("shacl".equalsIgnoreCase(request.languageId())) {
         // SHACL cells are Turtle shapes, not SPARQL — never route them through the query parser.
@@ -142,6 +176,36 @@ public final class NotebookCommandHandler {
       return ExecuteResponse.failed(
           new ExecError(ErrorCode.INTERNAL, "Internal error: " + e.getMessage(), null, null, null));
     }
+  }
+
+  /**
+   * Fills unset execution options from the notebook's {@code "cimnotebook"} config
+   * (queryTimeoutSeconds/maxRows), so workspace-wide defaults apply without the client having to
+   * read the config itself. Explicit per-request options always win.
+   */
+  private static ExecuteRequest withConfigDefaults(ExecuteRequest request) {
+    ExecuteOptions options = request.options();
+    boolean needsTimeout = options == null || options.timeoutMs() == null;
+    boolean needsMaxRows = options == null || options.maxRows() == null;
+    if (!needsTimeout && !needsMaxRows) {
+      return request;
+    }
+    NotebookConfig config = NotebookConfigLoader.forNotebook(request.notebookUri()).config();
+    if (config.queryTimeoutSeconds() == null && config.maxRows() == null) {
+      return request;
+    }
+    Integer timeoutMs =
+        !needsTimeout
+            ? options.timeoutMs()
+            : config.queryTimeoutSeconds() != null ? config.queryTimeoutSeconds() * 1_000 : null;
+    Integer maxRows = !needsMaxRows ? options.maxRows() : config.maxRows();
+    return new ExecuteRequest(
+        request.cellUri(),
+        request.notebookUri(),
+        request.languageId(),
+        request.text(),
+        request.target(),
+        new ExecuteOptions(timeoutMs, maxRows));
   }
 
   /**

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfig.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfig.java
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import java.util.List;
+
+/**
+ * The {@code "cimnotebook"} section of {@code opencgmes.jsonc} — a sibling of the {@code
+ * "cimvocabcheck"} section the validator reads, parsed by {@link NotebookConfigLoader}.
+ *
+ * @param connections named endpoint connections; never {@code null} after loading.
+ * @param queryTimeoutSeconds workspace default for the execution timeout; {@code null} keeps the
+ *     built-in default ({@link ExecSupport#DEFAULT_TIMEOUT_MS}).
+ * @param maxRows workspace default for the result row/triple cap; {@code null} keeps the built-in
+ *     default ({@link ExecSupport#DEFAULT_MAX_ROWS}).
+ */
+public record NotebookConfig(
+    List<NotebookConnection> connections, Integer queryTimeoutSeconds, Integer maxRows) {
+
+  static final NotebookConfig EMPTY = new NotebookConfig(List.of(), null, null);
+
+  /** Normalizes an absent {@code connections} array to an immutable empty list. */
+  public NotebookConfig {
+    connections = connections == null ? List.of() : List.copyOf(connections);
+  }
+
+  /** The connection marked {@code "default": true}, or {@code null} if none is. */
+  public NotebookConnection defaultConnection() {
+    return connections.stream().filter(NotebookConnection::isDefault).findFirst().orElse(null);
+  }
+
+  /** The connection with the given name (exact match), or {@code null}. */
+  public NotebookConnection byName(String name) {
+    return connections.stream()
+        .filter(c -> name != null && name.equals(c.name()))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfigLoader.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfigLoader.java
@@ -1,0 +1,135 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.soptim.opencgmes.cimvocabcheck.core.config.ConfigLoader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reads the {@code "cimnotebook"} section from the nearest {@code opencgmes.jsonc} — the same
+ * git-style nearest-config discovery and lenient JSONC parsing (comments, trailing commas) as the
+ * validator's {@link ConfigLoader}, which owns the {@code "cimvocabcheck"} sibling section and is
+ * untouched by this loader.
+ *
+ * <p>Reads are deliberately forgiving: a missing file, missing section, or unparseable file all
+ * yield {@link NotebookConfig#EMPTY} (with a log line for the parse failure) — the validator
+ * already surfaces config syntax problems to the user, notebooks don't need to pile on.
+ *
+ * <p><b>Caching.</b> Parsed configs are cached per file and invalidated when its modification time
+ * or size changes, because this sits on the interactive path: a notebook cell without its own
+ * {@code # [endpoint=...]} directive resolves its schema through here on every completion, hover,
+ * and validation — i.e. on every keystroke. Only the parse is cached; the nearest-config discovery
+ * still runs each time (a handful of {@code stat} calls), so a newly created {@code
+ * opencgmes.jsonc} takes effect immediately.
+ */
+public final class NotebookConfigLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookConfigLoader.class);
+
+  private static final String SECTION = "cimnotebook";
+
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .configure(JsonReadFeature.ALLOW_JAVA_COMMENTS.mappedFeature(), true)
+          .configure(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature(), true);
+
+  /** A cached parse: the file's attributes at parse time, used to detect staleness on access. */
+  private record CachedConfig(FileTime mtime, long size, NotebookConfig config) {}
+
+  private static final Map<Path, CachedConfig> CACHE = new ConcurrentHashMap<>();
+
+  private NotebookConfigLoader() {}
+
+  /** A loaded config together with the file it came from ({@code null} when none was found). */
+  public record Located(NotebookConfig config, Path configPath) {
+
+    static final Located NONE = new Located(NotebookConfig.EMPTY, null);
+  }
+
+  /** Loads the config that applies to a notebook, via its directory. */
+  static Located forNotebook(String notebookUri) {
+    return forDirectory(NotebookPaths.notebookDir(notebookUri));
+  }
+
+  /** Loads the config that applies to documents in {@code dir} ({@code null} → none). */
+  public static Located forDirectory(Path dir) {
+    if (dir == null) {
+      return Located.NONE;
+    }
+    Optional<Path> configFile = ConfigLoader.discoverFile(dir);
+    return configFile.map(f -> new Located(load(f), f)).orElse(Located.NONE);
+  }
+
+  /**
+   * The config file's {@code "cimnotebook"} section, from the cache when the file is unchanged
+   * since it was last parsed. Forgiving as documented above.
+   */
+  static NotebookConfig load(Path configFile) {
+    BasicFileAttributes attrs = readAttributes(configFile);
+    if (attrs == null) {
+      CACHE.remove(configFile);
+      return NotebookConfig.EMPTY;
+    }
+    CachedConfig cached = CACHE.get(configFile);
+    if (cached != null
+        && cached.mtime().equals(attrs.lastModifiedTime())
+        && cached.size() == attrs.size()) {
+      return cached.config();
+    }
+    NotebookConfig config = parse(configFile);
+    CACHE.put(configFile, new CachedConfig(attrs.lastModifiedTime(), attrs.size(), config));
+    return config;
+  }
+
+  private static NotebookConfig parse(Path configFile) {
+    try {
+      JsonNode root = MAPPER.readTree(configFile.toFile());
+      JsonNode section = root == null ? null : root.get(SECTION);
+      if (section == null || section.isNull()) {
+        return NotebookConfig.EMPTY;
+      }
+      return MAPPER.treeToValue(section, NotebookConfig.class);
+    } catch (IOException | RuntimeException e) {
+      LOG.warn("Ignoring unreadable {} section in {}: {}", SECTION, configFile, e.getMessage());
+      return NotebookConfig.EMPTY;
+    }
+  }
+
+  private static BasicFileAttributes readAttributes(Path configFile) {
+    try {
+      return Files.readAttributes(configFile, BasicFileAttributes.class);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConnection.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConnection.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * One named connection from the {@code "cimnotebook"} section of {@code opencgmes.jsonc}, read by
+ * {@link NotebookConfigLoader} (Jackson) and answered to the client by the {@code
+ * cimvocabcheck.notebook.listConnections} command (lsp4j's Gson) — hence the double annotations on
+ * {@code isDefault}, whose JSON name {@code default} is a Java keyword.
+ *
+ * <p>Deliberately carries <b>no credentials</b>: the config file only declares the {@code
+ * authType}, and the client keeps secrets in VS Code SecretStorage — passwords never live in {@code
+ * opencgmes.jsonc} and never leave the client except inside an execute request.
+ *
+ * @param name the connection's name, referenced by {@code # [endpoint=<name>]} directives.
+ * @param url the SPARQL query endpoint URL.
+ * @param updateUrl optional SPARQL Update endpoint; {@code null} lets the client derive it.
+ * @param shaclUrl optional SHACL service endpoint; {@code null} lets the client derive it.
+ * @param authType {@code "basic"} when the endpoint needs credentials, else {@code null}/"none".
+ * @param isDefault whether cells without a directive use this connection ({@code "default"} in
+ *     JSON).
+ */
+public record NotebookConnection(
+    String name,
+    String url,
+    String updateUrl,
+    String shaclUrl,
+    String authType,
+    @JsonProperty("default") @SerializedName("default") boolean isDefault) {}

--- a/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
+++ b/cimvocabcheck/lsp/src/main/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookPaths.java
@@ -73,7 +73,7 @@ final class NotebookPaths {
   }
 
   /** The notebook's directory, or {@code null} when the notebook has no on-disk location. */
-  private static Path notebookDir(String notebookUri) {
+  static Path notebookDir(String notebookUri) {
     if (notebookUri == null || notebookUri.isBlank()) {
       return null;
     }

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaultEndpointTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaultEndpointTest.java
@@ -1,0 +1,280 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BooleanSupplier;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the schema source of a notebook cell that carries <em>no</em> {@code # [endpoint=...]}
+ * directive of its own.
+ *
+ * <p>Such a cell still has a target: the notebook default the client remembers (its <em>Set Cell
+ * Endpoint → Notebook default</em> scope), or the {@code "cimnotebook"} connection marked {@code
+ * "default": true}. Both are how the cell is <em>executed</em>, so both must also be how it is
+ * <em>validated</em> — otherwise the cell runs fine but the editor shows syntax-only diagnostics,
+ * no completion and no go-to-definition, because the server only ever saw the cell text.
+ */
+public class NotebookDefaultEndpointTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private static final String CIM16 = "http://iec.ch/TC57/2013/CIM-schema-cim16#";
+  private static final long TIMEOUT_MS = 10_000;
+
+  /** Minimal CIM 16 RDFS that passes profile detection, plus one real class declaration. */
+  private static final String SCHEMA_RDF =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+               xmlns:cims="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#"
+               xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+               xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#">
+        <rdf:Description rdf:about="http://entsoe.eu/TestExt#TestVersion.shortName">
+          <rdfs:domain rdf:resource="http://entsoe.eu/TestExt#TestVersion"/>
+          <cims:isFixed rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TST</cims:isFixed>
+        </rdf:Description>
+        <rdf:Description rdf:about="http://entsoe.eu/TestExt#TestVersion.entsoeURI">
+          <rdfs:domain rdf:resource="http://entsoe.eu/TestExt#TestVersion"/>
+          <cims:isFixed rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://example.org/TestProfile/1</cims:isFixed>
+        </rdf:Description>
+        <rdfs:Class rdf:about="http://iec.ch/TC57/2013/CIM-schema-cim16#TestClass">
+          <rdfs:label>TestClass</rdfs:label>
+        </rdfs:Class>
+      </rdf:RDF>
+      """;
+
+  /** A cell whose only schema-dependent finding is the unknown class — no syntax errors. */
+  private static final String CELL_WITH_UNKNOWN_CLASS =
+      "PREFIX cim: <" + CIM16 + ">\nSELECT * WHERE { ?s a cim:NoSuchClass }";
+
+  /** The same notebook, mid-completion: the cursor sits right after the "cim:" prefix. */
+  private static final String CELL_MID_COMPLETION =
+      "PREFIX cim: <" + CIM16 + ">\nSELECT * WHERE { ?s a cim: }";
+
+  private final List<PublishDiagnosticsParams> published = new CopyOnWriteArrayList<>();
+  private final List<MessageParams> messages = new CopyOnWriteArrayList<>();
+
+  private SchemaManager schemaManager;
+  private SparqlTextDocumentService service;
+  private NotebookDefaults notebookDefaults;
+
+  private void startServer() {
+    schemaManager = new SchemaManager();
+    notebookDefaults = new NotebookDefaults();
+    service = new SparqlTextDocumentService(schemaManager, notebookDefaults);
+    // The same wiring SparqlLanguageServer does: a changed default revalidates the open cells.
+    notebookDefaults.addOnChangeCallback(service::revalidateAll);
+    LanguageClient client = recordingClient();
+    schemaManager.setClient(client);
+    service.setClient(client);
+  }
+
+  @After
+  public void tearDown() {
+    if (service != null) {
+      service.shutdown();
+    }
+    if (schemaManager != null) {
+      schemaManager.shutdown();
+    }
+  }
+
+  @Test
+  public void notebookDefaultGivesDirectivelessCellsTheirSchema() throws Exception {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("schema.rdf"), SCHEMA_RDF);
+    Path notebook = dir.resolve("analysis.cimnb.md");
+    startServer();
+
+    String queryCell = cellUri(notebook, "c1");
+    String completionCell = cellUri(notebook, "c2");
+    open(queryCell, CELL_WITH_UNKNOWN_CLASS);
+    open(completionCell, CELL_MID_COMPLETION);
+
+    // Before: the cell has no directive and there is no config, so nothing but syntax is checked.
+    awaitTrue("a first (syntax-only) publish", () -> lastDiagnostics(queryCell) != null);
+    assertEquals(
+        "without a schema the cell is syntax-only — no semantic findings",
+        List.of(),
+        lastDiagnostics(queryCell));
+    assertEquals("and no completion is offered", List.of(), completeAfterPrefix(completionCell));
+
+    // The user picks "Notebook default" in *Set Cell Endpoint*; the client pushes it to us.
+    notebookDefaults.set(notebook.toUri().toString(), "./schema.rdf");
+
+    awaitTrue(
+        "the unknown class must be reported once the notebook default supplies a schema",
+        () -> diagnosticsMention(queryCell, "NoSuchClass"));
+    List<CompletionItem> items = completeAfterPrefix(completionCell);
+    assertTrue(
+        "completion must now offer the schema's terms, got: " + labels(items),
+        labels(items).contains("cim:TestClass"));
+  }
+
+  @Test
+  public void defaultConnectionGivesDirectivelessCellsTheirSchema() throws Exception {
+    Path dir = tmp.getRoot().toPath();
+    // Deliberately unreachable: what matters is that the cell's schema is fetched from the default
+    // connection's endpoint at all — observable through the "loading schema from endpoint" notice.
+    String url = "http://localhost:9/none/query";
+    Files.writeString(
+        dir.resolve("opencgmes.jsonc"),
+        """
+        { "cimnotebook": { "connections": [
+            { "name": "local-fuseki", "url": "%s", "default": true }
+        ] } }
+        """
+            .formatted(url));
+    startServer();
+
+    open(cellUri(dir.resolve("analysis.cimnb.md"), "c1"), CELL_WITH_UNKNOWN_CLASS);
+
+    awaitTrue(
+        "a directive-less cell must validate against the default connection's endpoint",
+        () -> messages.stream().anyMatch(m -> m.getMessage().contains(url)));
+  }
+
+  @Test
+  public void plainFilesIgnoreTheNotebookFallbacks() throws Exception {
+    Path dir = tmp.getRoot().toPath();
+    String url = "http://localhost:9/none/query";
+    Files.writeString(
+        dir.resolve("opencgmes.jsonc"),
+        """
+        { "cimnotebook": { "connections": [
+            { "name": "local-fuseki", "url": "%s", "default": true }
+        ] } }
+        """
+            .formatted(url));
+    startServer();
+
+    // A stand-alone query file is not part of any notebook: it keeps its workspace schema (here:
+    // none) rather than borrowing the notebook connection's endpoint.
+    String fileUri = dir.resolve("query.rq").toUri().toString();
+    open(fileUri, CELL_WITH_UNKNOWN_CLASS);
+
+    awaitTrue("a publish for the file", () -> lastDiagnostics(fileUri) != null);
+    assertFalse(
+        "a plain .rq file must not load the notebook default connection's schema: " + messages,
+        messages.stream().anyMatch(m -> m.getMessage().contains(url)));
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------
+
+  /** The URI VS Code gives a cell: the notebook's path plus a cell-id fragment. */
+  private static String cellUri(Path notebook, String cellId) {
+    return "vscode-notebook-cell:" + notebook + "#" + cellId;
+  }
+
+  private void open(String uri, String text) {
+    service.didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, "sparql", 1, text)));
+  }
+
+  /** Completions offered with the cursor right behind the {@code cim:} prefix of line 1. */
+  private List<CompletionItem> completeAfterPrefix(String uri) throws Exception {
+    String line = CELL_MID_COMPLETION.split("\n")[1];
+    Position cursor = new Position(1, line.indexOf("cim:") + "cim:".length());
+    return service
+        .completion(new CompletionParams(new TextDocumentIdentifier(uri), cursor))
+        .get()
+        .getLeft();
+  }
+
+  private static List<String> labels(List<CompletionItem> items) {
+    return items.stream().map(CompletionItem::getLabel).toList();
+  }
+
+  /** The diagnostics of the most recent publish for {@code uri}, or {@code null} if none yet. */
+  private List<Diagnostic> lastDiagnostics(String uri) {
+    return published.stream()
+        .filter(p -> p.getUri().equals(uri))
+        .reduce((first, second) -> second)
+        .map(PublishDiagnosticsParams::getDiagnostics)
+        .orElse(null);
+  }
+
+  private boolean diagnosticsMention(String uri, String term) {
+    List<Diagnostic> diagnostics = lastDiagnostics(uri);
+    return diagnostics != null
+        && diagnostics.stream().anyMatch(d -> d.getMessage().getLeft().contains(term));
+  }
+
+  /** Waits for a debounced (and, for endpoints, asynchronous) result to appear. */
+  private static void awaitTrue(String what, BooleanSupplier condition) throws Exception {
+    long deadline = System.nanoTime() + TIMEOUT_MS * 1_000_000L;
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(25);
+    }
+    throw new AssertionError("Timed out waiting for " + what);
+  }
+
+  private LanguageClient recordingClient() {
+    return new LanguageClient() {
+      @Override
+      public void telemetryEvent(Object object) {}
+
+      @Override
+      public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+        published.add(diagnostics);
+      }
+
+      @Override
+      public void showMessage(MessageParams messageParams) {
+        messages.add(messageParams);
+      }
+
+      @Override
+      public CompletableFuture<MessageActionItem> showMessageRequest(
+          ShowMessageRequestParams requestParams) {
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      public void logMessage(MessageParams message) {}
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaultsTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/NotebookDefaultsTest.java
@@ -1,0 +1,112 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.gson.JsonParser;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/**
+ * Covers {@link NotebookDefaults}: the client sets a default on the <em>notebook</em> URI, while
+ * every lookup comes from a <em>cell</em> URI — the two must agree on a key, or a notebook's
+ * directive-less cells silently fall back to syntax-only validation.
+ */
+public class NotebookDefaultsTest {
+
+  private static final String NOTEBOOK_URI = "file:///home/u/proj/analysis.cimnb.md";
+  private static final String CELL_URI = "vscode-notebook-cell:/home/u/proj/analysis.cimnb.md#W0s";
+  private static final String OTHER_CELL_URI = "vscode-notebook-cell:/home/u/proj/other.cimnb.md#A";
+
+  @Test
+  public void cellsOfTheNotebookSeeItsDefault() {
+    NotebookDefaults defaults = new NotebookDefaults();
+
+    defaults.set(NOTEBOOK_URI, "./schema.ttl");
+
+    assertEquals("./schema.ttl", defaults.forCell(CELL_URI));
+    assertNull("a cell of another notebook is unaffected", defaults.forCell(OTHER_CELL_URI));
+  }
+
+  @Test
+  public void blankEndpointClearsTheDefault() {
+    NotebookDefaults defaults = new NotebookDefaults();
+    defaults.set(NOTEBOOK_URI, "http://localhost:3030/ds/query");
+
+    defaults.set(NOTEBOOK_URI, null);
+
+    assertNull(defaults.forCell(CELL_URI));
+  }
+
+  @Test
+  public void unsavedNotebooksKeyOnTheirOpaqueUri() {
+    NotebookDefaults defaults = new NotebookDefaults();
+
+    defaults.set("untitled:Untitled-1", "http://localhost:3030/ds/query");
+
+    assertEquals(
+        "http://localhost:3030/ds/query",
+        defaults.forCell("vscode-notebook-cell:Untitled-1#W0sZmlsZQ"));
+  }
+
+  @Test
+  public void applyParsesTheCommandArgumentAndNotifies() {
+    NotebookDefaults defaults = new NotebookDefaults();
+    AtomicInteger changes = new AtomicInteger();
+    defaults.addOnChangeCallback(changes::incrementAndGet);
+
+    defaults.apply(
+        List.of(
+            JsonParser.parseString(
+                """
+                { "notebookUri": "%s", "endpoint": "local-fuseki" }
+                """
+                    .formatted(NOTEBOOK_URI))));
+
+    assertEquals("local-fuseki", defaults.forCell(CELL_URI));
+    assertEquals("open cells must be revalidated against the new default", 1, changes.get());
+
+    // A null endpoint is how the client clears a default.
+    defaults.apply(
+        List.of(
+            JsonParser.parseString(
+                """
+                { "notebookUri": "%s", "endpoint": null }
+                """
+                    .formatted(NOTEBOOK_URI))));
+
+    assertNull(defaults.forCell(CELL_URI));
+    assertEquals(2, changes.get());
+  }
+
+  @Test
+  public void malformedArgumentsAreIgnored() {
+    NotebookDefaults defaults = new NotebookDefaults();
+
+    defaults.apply(null);
+    defaults.apply(List.of());
+    defaults.apply(List.of(JsonParser.parseString("\"not-an-object\"")));
+    defaults.apply(List.of(JsonParser.parseString("{ \"endpoint\": \"http://x/query\" }")));
+
+    assertNull(defaults.forCell(CELL_URI));
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerConnectionNameTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/SchemaManagerConnectionNameTest.java
@@ -1,0 +1,116 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the connection-name coherence in {@link SchemaManager#resolveSchema}: a {@code #
+ * [endpoint=<name>]} directive naming a {@code "cimnotebook"} connection must resolve the schema
+ * from that connection's URL (the remote-endpoint path), so validation and notebook execution agree
+ * on what the directive means. An unknown name falls through to the old behavior (and, with no
+ * extension, ends in the quiet workspace-schema fallback).
+ */
+public class SchemaManagerConnectionNameTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  @Test
+  public void connectionNameDirectiveResolvesTheSchemaFromTheConnectionUrl() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    // Deliberately unreachable URL: what matters is that the remote-schema path is entered for
+    // the connection's URL, observable through the synchronous "loading schema from endpoint"
+    // notification. The async load then fails quietly (negative-cached), which is fine here.
+    String url = "http://localhost:9/none/query";
+    Files.writeString(
+        docDir.resolve("opencgmes.jsonc"),
+        """
+        { "cimnotebook": { "connections": [ { "name": "local-fuseki", "url": "%s" } ] } }
+        """
+            .formatted(url));
+
+    List<MessageParams> messages = new CopyOnWriteArrayList<>();
+    SchemaManager manager = new SchemaManager();
+    manager.setClient(recordingClient(messages));
+    try {
+      var resolved = manager.resolveSchema("local-fuseki", docDir);
+
+      assertTrue("remote loads are async — nothing is resolved yet", resolved.isEmpty());
+      assertTrue(
+          "the remote-schema path must be entered for the connection's URL; messages: " + messages,
+          messages.stream().anyMatch(m -> m.getMessage().contains(url)));
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  @Test
+  public void unknownNameFallsBackQuietlyToTheWorkspaceSchema() throws Exception {
+    Path docDir = tmp.getRoot().toPath();
+    Files.writeString(docDir.resolve("opencgmes.jsonc"), "{ \"cimnotebook\": {} }");
+
+    List<MessageParams> messages = new CopyOnWriteArrayList<>();
+    SchemaManager manager = new SchemaManager();
+    manager.setClient(recordingClient(messages));
+    try {
+      assertTrue(manager.resolveSchema("no-such-connection", docDir).isEmpty());
+      assertTrue("no user-facing noise for an unknown name: " + messages, messages.isEmpty());
+    } finally {
+      manager.shutdown();
+    }
+  }
+
+  private static LanguageClient recordingClient(List<MessageParams> messages) {
+    return new LanguageClient() {
+      @Override
+      public void telemetryEvent(Object object) {}
+
+      @Override
+      public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {}
+
+      @Override
+      public void showMessage(MessageParams messageParams) {
+        messages.add(messageParams);
+      }
+
+      @Override
+      public CompletableFuture<MessageActionItem> showMessageRequest(
+          ShowMessageRequestParams requestParams) {
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      public void logMessage(MessageParams message) {}
+    };
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/BasicAuthTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/BasicAuthTest.java
@@ -1,0 +1,187 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pins the preemptive basic-auth behavior across all three HTTP paths (query, update, SHACL): the
+ * exact {@code Authorization} header the endpoint receives, and its absence for anonymous targets.
+ * Uses a header-capturing JDK HttpServer rather than a secured Fuseki — what matters is the request
+ * we send, not any particular server's challenge dance.
+ */
+public class BasicAuthTest {
+
+  /** {@code Basic base64("alice:secret")}. */
+  private static final String EXPECTED_HEADER = "Basic YWxpY2U6c2VjcmV0";
+
+  private static final ExecAuth AUTH = new ExecAuth("basic", "alice", "secret");
+
+  private static final CancelChecker NEVER_CANCELLED =
+      new CancelChecker() {
+        @Override
+        public void checkCanceled() {}
+
+        @Override
+        public boolean isCanceled() {
+          return false;
+        }
+      };
+
+  private ExecutorService executionPool;
+  private ScheduledExecutorService watchdogScheduler;
+  private HttpServer server;
+  private final AtomicReference<String> seenAuthorization = new AtomicReference<>();
+
+  @Before
+  public void setUp() throws IOException {
+    executionPool = Executors.newCachedThreadPool();
+    watchdogScheduler = Executors.newSingleThreadScheduledExecutor();
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext(
+        "/",
+        exchange -> {
+          seenAuthorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+          byte[] body;
+          String contentType;
+          if (exchange.getRequestURI().getPath().contains("shacl")) {
+            body =
+                """
+                PREFIX sh: <http://www.w3.org/ns/shacl#>
+                [] a sh:ValidationReport ; sh:conforms true .
+                """
+                    .getBytes(StandardCharsets.UTF_8);
+            contentType = "text/turtle";
+          } else {
+            body = "{\"head\":{},\"boolean\":true}".getBytes(StandardCharsets.UTF_8);
+            contentType = "application/sparql-results+json";
+          }
+          exchange.getResponseHeaders().set("Content-Type", contentType);
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+    server.start();
+  }
+
+  @After
+  public void tearDown() {
+    server.stop(0);
+    executionPool.shutdownNow();
+    watchdogScheduler.shutdownNow();
+  }
+
+  @Test
+  public void queryCarriesThePreemptiveBasicAuthHeader() {
+    ExecuteResponse response =
+        HttpQueryExecutor.executeQuery(
+            QueryFactory.create("ASK {}"), QueryKind.ASK, target(url("/query"), AUTH), null, ctx());
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(EXPECTED_HEADER, seenAuthorization.get());
+  }
+
+  @Test
+  public void queryWithoutCredentialsSendsNoAuthorizationHeader() {
+    HttpQueryExecutor.executeQuery(
+        QueryFactory.create("ASK {}"), QueryKind.ASK, target(url("/query"), null), null, ctx());
+
+    assertNull(seenAuthorization.get());
+  }
+
+  @Test
+  public void updateCarriesThePreemptiveBasicAuthHeader() {
+    HttpQueryExecutor.executeUpdate(
+        UpdateFactory.create("INSERT DATA { <urn:s> <urn:p> 1 }"),
+        new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url("/query"), url("/update"), null, null, AUTH),
+        null,
+        ctx());
+
+    assertEquals(EXPECTED_HEADER, seenAuthorization.get());
+  }
+
+  @Test
+  public void shaclValidationCarriesThePreemptiveBasicAuthHeader() {
+    ExecuteResponse response =
+        HttpShaclClient.validate(
+            "PREFIX sh: <http://www.w3.org/ns/shacl#>",
+            new ExecuteTarget(
+                ExecuteTarget.TYPE_HTTP,
+                url("/query"),
+                null,
+                url("/shacl?graph=default"),
+                null,
+                AUTH),
+            null,
+            ctx());
+
+    assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+    assertEquals(EXPECTED_HEADER, seenAuthorization.get());
+  }
+
+  @Test
+  public void basicAuthHeaderIsNullForUnusableCredentials() {
+    assertNull(ExecSupport.basicAuthHeader(null));
+    assertNull(ExecSupport.basicAuthHeader(new ExecAuth("bearer", "alice", "secret")));
+    assertNull(ExecSupport.basicAuthHeader(new ExecAuth("basic", null, "secret")));
+    assertEquals(
+        "an empty password must still authenticate as user:",
+        "Basic YWxpY2U6",
+        ExecSupport.basicAuthHeader(new ExecAuth("basic", "alice", null)));
+  }
+
+  @Test
+  public void toStringNeverLeaksCredentials() {
+    String s = AUTH.toString();
+    assertEquals(-1, s.indexOf("alice"));
+    assertEquals(-1, s.indexOf("secret"));
+  }
+
+  // ---- helpers -------------------------------------------------------------------------------
+
+  private String url(String pathAndQuery) {
+    return "http://localhost:" + server.getAddress().getPort() + pathAndQuery;
+  }
+
+  private static ExecuteTarget target(String url, ExecAuth auth) {
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, null, null, null, auth);
+  }
+
+  private ExecContext ctx() {
+    return new ExecContext(executionPool, watchdogScheduler, NEVER_CANCELLED);
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/HttpQueryExecutorTest.java
@@ -426,7 +426,7 @@ public class HttpQueryExecutorTest {
   }
 
   private static ExecuteTarget target(String url, String updateUrl) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null, null);
+    return new ExecuteTarget(ExecuteTarget.TYPE_HTTP, url, updateUrl, null, null, null);
   }
 
   private static String uniqueSubject() {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/LocalQueryExecutorTest.java
@@ -318,7 +318,7 @@ public class LocalQueryExecutorTest {
   }
 
   private static ExecuteTarget filesTarget(String... files) {
-    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files));
+    return new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files), null);
   }
 
   private Path dataFile(String name, String content) throws IOException {

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookCommandHandlerTest.java
@@ -245,6 +245,86 @@ public class NotebookCommandHandlerTest {
     }
   }
 
+  // ---- connections and config defaults ---------------------------------------------------------
+
+  @Test
+  public void listConnectionsAnswersTheNotebookConfigAndPinsTheWireShape() throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-conn");
+    try {
+      Files.writeString(
+          dir.resolve("opencgmes.jsonc"),
+          """
+          {
+            "cimnotebook": {
+              "queryTimeoutSeconds": 7,
+              "connections": [
+                { "name": "local-fuseki", "url": "http://localhost:3030/ds/query",
+                  "authType": "basic", "default": true,
+                  "password": "must-never-be-echoed" }
+              ]
+            }
+          }
+          """);
+      JsonObject arg = new JsonObject();
+      arg.addProperty("notebookUri", dir.resolve("demo.cimnb.md").toUri().toString());
+
+      Object result = handler.listConnections(List.of(arg)).get();
+
+      Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
+      JsonObject json = wireGson.toJsonTree(result).getAsJsonObject();
+      assertTrue(json.get("configPath").getAsString().endsWith("opencgmes.jsonc"));
+      assertEquals(7, json.get("queryTimeoutSeconds").getAsInt());
+      JsonObject connection = json.getAsJsonArray("connections").get(0).getAsJsonObject();
+      assertEquals("local-fuseki", connection.get("name").getAsString());
+      assertEquals("basic", connection.get("authType").getAsString());
+      assertTrue(
+          "the keyword-named flag must serialize as 'default'",
+          connection.get("default").getAsBoolean());
+      assertFalse(
+          "secrets in the config must never be echoed back", json.toString().contains("password"));
+    } finally {
+      try (var paths = Files.walk(dir)) {
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
+  @Test
+  public void listConnectionsWithoutAConfigAnswersEmpty() throws Exception {
+    JsonObject arg = new JsonObject();
+    arg.addProperty("notebookUri", "untitled:Untitled-1");
+
+    Gson wireGson = new MessageJsonHandler(Map.of()).getGson();
+    JsonObject json =
+        wireGson.toJsonTree(handler.listConnections(List.of(arg)).get()).getAsJsonObject();
+
+    assertFalse(json.has("configPath"));
+    assertEquals(0, json.getAsJsonArray("connections").size());
+  }
+
+  @Test
+  public void executeAppliesTheConfigMaxRowsWhenTheRequestHasNoOptions() throws Exception {
+    Path dir = Files.createTempDirectory("cimnb-clamp");
+    try {
+      Files.writeString(dir.resolve("opencgmes.jsonc"), "{ \"cimnotebook\": { \"maxRows\": 1 } }");
+      Files.writeString(
+          dir.resolve("data.ttl"),
+          "<http://example.org/a> <http://example.org/p> 1 . "
+              + "<http://example.org/b> <http://example.org/p> 2 .");
+      JsonObject arg = filesRequestJson("SELECT ?s WHERE { ?s ?p ?o }", dir, "./data.ttl");
+
+      ExecuteResponse response = getResponse(handler.executeCommand(List.of(arg)));
+
+      assertEquals(ExecutionStatus.SUCCESS.name(), response.status());
+      assertEquals(Integer.valueOf(1), response.stats().rowCount());
+      assertTrue("the config cap must truncate the result", response.stats().truncated());
+    } finally {
+      try (var paths = Files.walk(dir)) {
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
   // ---- wire shape ----------------------------------------------------------------------------
 
   /**

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfigLoaderTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/NotebookConfigLoaderTest.java
@@ -1,0 +1,174 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.soptim.opencgmes.cimvocabcheck.lsp.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises {@link NotebookConfigLoader}: the lenient JSONC parsing of the {@code "cimnotebook"}
+ * section (comments, trailing commas, the {@code "default"} keyword-named flag), git-style
+ * nearest-config discovery, and the deliberately forgiving failure modes.
+ */
+public class NotebookConfigLoaderTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  private static final String CONFIG_JSONC =
+      """
+      {
+        // validator settings live in a sibling section and are irrelevant here
+        "cimvocabcheck": { "strictness": "strict" },
+        "cimnotebook": {
+          "queryTimeoutSeconds": 5,
+          "maxRows": 100,
+          "connections": [
+            {
+              "name": "local-fuseki",
+              "url": "http://localhost:3030/cgmes/query",
+              "updateUrl": "http://localhost:3030/cgmes/update",
+              "authType": "basic",
+              "default": true,
+            },
+            { "name": "prod", "url": "https://sparql.example.org/query" },
+          ],
+        },
+      }
+      """;
+
+  @Test
+  public void readsConnectionsTimeoutsAndTheDefaultFlag() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("opencgmes.jsonc"), CONFIG_JSONC);
+
+    NotebookConfigLoader.Located located = NotebookConfigLoader.forDirectory(dir);
+
+    assertEquals(dir.resolve("opencgmes.jsonc"), located.configPath());
+    NotebookConfig config = located.config();
+    assertEquals(Integer.valueOf(5), config.queryTimeoutSeconds());
+    assertEquals(Integer.valueOf(100), config.maxRows());
+    assertEquals(2, config.connections().size());
+
+    NotebookConnection fuseki = config.byName("local-fuseki");
+    assertEquals("http://localhost:3030/cgmes/query", fuseki.url());
+    assertEquals("http://localhost:3030/cgmes/update", fuseki.updateUrl());
+    assertNull(fuseki.shaclUrl());
+    assertEquals("basic", fuseki.authType());
+    assertTrue(fuseki.isDefault());
+    assertEquals(fuseki, config.defaultConnection());
+
+    NotebookConnection prod = config.byName("prod");
+    assertTrue(!prod.isDefault());
+    assertNull(config.byName("nope"));
+  }
+
+  @Test
+  public void discoveryWalksUpToTheNearestConfig() throws IOException {
+    Path root = tmp.getRoot().toPath();
+    Files.writeString(root.resolve("opencgmes.jsonc"), CONFIG_JSONC);
+    Path nested = Files.createDirectories(root.resolve("reports/2026"));
+
+    NotebookConfigLoader.Located located = NotebookConfigLoader.forDirectory(nested);
+
+    assertEquals(root.resolve("opencgmes.jsonc"), located.configPath());
+    assertEquals(2, located.config().connections().size());
+  }
+
+  @Test
+  public void missingSectionYieldsTheEmptyConfig() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("opencgmes.jsonc"), "{ \"cimvocabcheck\": {} }");
+
+    NotebookConfigLoader.Located located = NotebookConfigLoader.forDirectory(dir);
+
+    assertEquals(dir.resolve("opencgmes.jsonc"), located.configPath());
+    assertTrue(located.config().connections().isEmpty());
+    assertNull(located.config().queryTimeoutSeconds());
+    assertNull(located.config().defaultConnection());
+  }
+
+  @Test
+  public void missingConfigFileYieldsNone() {
+    NotebookConfigLoader.Located located =
+        NotebookConfigLoader.forDirectory(tmp.getRoot().toPath());
+
+    assertNull(located.configPath());
+    assertTrue(located.config().connections().isEmpty());
+  }
+
+  @Test
+  public void unparseableFileIsForgivinglyTreatedAsEmpty() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("opencgmes.jsonc"), "{ this is not json !!");
+
+    NotebookConfigLoader.Located located = NotebookConfigLoader.forDirectory(dir);
+
+    assertTrue(located.config().connections().isEmpty());
+  }
+
+  /**
+   * The parse is cached (it sits on the completion path), so an edit must still be seen. The mtime
+   * is set explicitly: two writes within the filesystem's timestamp granularity would otherwise be
+   * indistinguishable, which is a test-timing artefact rather than the behaviour under test.
+   */
+  @Test
+  public void anEditedConfigIsReParsedRatherThanServedFromTheCache() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Path configFile = dir.resolve("opencgmes.jsonc");
+    Files.writeString(configFile, CONFIG_JSONC);
+
+    assertEquals(2, NotebookConfigLoader.forDirectory(dir).config().connections().size());
+
+    Files.writeString(
+        configFile,
+        """
+        {
+          "cimnotebook": {
+            "connections": [{ "name": "only-one", "url": "http://localhost:3030/ds/query" }]
+          }
+        }
+        """);
+    Files.setLastModifiedTime(configFile, FileTime.fromMillis(System.currentTimeMillis() + 1_000));
+
+    NotebookConfig reloaded = NotebookConfigLoader.forDirectory(dir).config();
+    assertEquals(1, reloaded.connections().size());
+    assertEquals("only-one", reloaded.connections().get(0).name());
+  }
+
+  @Test
+  public void notebookUriResolvesViaTheNotebookDirectory() throws IOException {
+    Path dir = tmp.getRoot().toPath();
+    Files.writeString(dir.resolve("opencgmes.jsonc"), CONFIG_JSONC);
+    String notebookUri = dir.resolve("demo.cimnb.md").toUri().toString();
+
+    assertEquals(2, NotebookConfigLoader.forNotebook(notebookUri).config().connections().size());
+    assertTrue(NotebookConfigLoader.forNotebook(null).config().connections().isEmpty());
+    assertTrue(
+        NotebookConfigLoader.forNotebook("untitled:Untitled-1").config().connections().isEmpty());
+  }
+}

--- a/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutorTest.java
+++ b/cimvocabcheck/lsp/src/test/java/de/soptim/opencgmes/cimvocabcheck/lsp/notebook/ShaclExecutorTest.java
@@ -327,14 +327,14 @@ public class ShaclExecutorTest {
 
   private ExecuteResponse executeLocal(String shapes, String... files) {
     ExecuteTarget target =
-        new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files));
+        new ExecuteTarget(ExecuteTarget.TYPE_FILES, null, null, null, List.of(files), null);
     return ShaclExecutor.execute(request(shapes, target), stores, ctx(NEVER_CANCELLED));
   }
 
   private ExecuteResponse executeRemote(String shapes, String shaclServiceUrl) {
     ExecuteTarget target =
         new ExecuteTarget(
-            ExecuteTarget.TYPE_HTTP, fuseki.serverURL() + "ds", null, shaclServiceUrl, null);
+            ExecuteTarget.TYPE_HTTP, fuseki.serverURL() + "ds", null, shaclServiceUrl, null, null);
     return ShaclExecutor.execute(request(shapes, target), stores, ctx(NEVER_CANCELLED));
   }
 

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -146,6 +146,11 @@ Parsed files are cached in the language server and re-parsed automatically when 
 changes on disk, so _edit model → re-run cell_ just works. Local files are **read-only**:
 a SPARQL Update against a file target is rejected — updates need an HTTP endpoint.
 
+Multiple **file** directives are the only repetition that means something. A cell runs
+against exactly one endpoint, so mixing kinds (a file and a URL, a file and a connection
+name) or repeating a URL or a connection name is reported as an error rather than
+silently resolved to one of them — remove the directives you didn't mean.
+
 Note the dual meaning of the directive: for _validation_, a `.ttl`/`.rdf`/`.owl` file is
 loaded as the schema, while instance-data files (`.xml` models, `.nt`/`.nq`/`.trig` dumps)
 keep the workspace schema so diagnostics stay meaningful — and either way the file is what
@@ -177,6 +182,82 @@ The output is a ✅ conforms / ❌ does-not-conform banner with counts per sever
 run that finds violations is still a _successful_ run — non-conformance is the result,
 not an error.
 
+### Named connections
+
+Endpoints you use often can be declared once in `opencgmes.jsonc` (the same file that
+configures validation) under a `cimnotebook` section, and referenced by name:
+
+```jsonc
+{
+  "cimnotebook": {
+    "connections": [
+      {
+        "name": "local-fuseki",
+        "url": "http://localhost:3030/cgmes/query",
+        "default": true,
+      },
+      {
+        "name": "prod",
+        "url": "https://sparql.example.org/query",
+        "authType": "basic",
+      },
+    ],
+    "queryTimeoutSeconds": 30, // workspace default for cell executions
+    "maxRows": 10000, // workspace default result cap
+  },
+}
+```
+
+```sparql
+# [endpoint=local-fuseki]
+SELECT * WHERE { ?s ?p ?o } LIMIT 10
+```
+
+A connection name has no slashes and no dots — that's how it is told apart from a file
+path. `updateUrl`/`shaclUrl` are optional and derived from `url` when omitted.
+
+Every cell shows its resolved target in the **cell status bar** (`local-fuseki`, a URL,
+`model.xml (+1)`, or a _no endpoint_ warning); clicking it — or running **CIMNotebook:
+Set Cell Endpoint…** — picks a connection, URL, or file and either writes the
+`# [endpoint=…]` directive into the cell (the portable, versioned form) or remembers it
+as the notebook's default without touching the file.
+
+### Where a cell without a directive runs
+
+A cell with no `# [endpoint=...]` line of its own is not stranded — the target is resolved
+in three steps, and the first one that answers wins:
+
+1. **The cell's own directive.**
+2. **The notebook default.** *Set Cell Endpoint…* offers to apply a single connection, URL,
+   or file as the **Notebook default** instead of writing it into the cell. It is remembered
+   in VS Code's **workspace state** — deliberately not in the notebook file and not in
+   `opencgmes.jsonc` — so it is a private, per-workspace convenience: a notebook shared with
+   a colleague carries only its directives. The picker shows the current default in its title
+   and offers **Clear the notebook default** while one is set.
+3. **The default connection.** The `opencgmes.jsonc` connection marked `"default": true`.
+
+Validation follows the same three steps, so a cell is always validated against the endpoint
+it runs against: schema-based diagnostics, completion, hover, and go-to-definition all use
+the schema of the resolved target (a `.ttl`/`.rdf`/`.owl` file or the endpoint's schema
+graphs). A target that carries no schema — a CIMXML model, an `.nt` dump — keeps the
+workspace schema from `opencgmes.jsonc` instead, since instance data would only produce
+false diagnostics.
+
+### Credentials
+
+Connections with `"authType": "basic"` prompt once for username and password on first
+run and offer to keep them in **VS Code secret storage** (the OS keychain). Passwords are
+**never** written to `opencgmes.jsonc`, VS Code settings, or the notebook — they travel
+only inside the execute request to the local language server, which turns them into the
+HTTP `Authorization` header. Manage them with **CIMNotebook: Set Connection
+Credentials…** and **Clear Connection Credentials…**.
+
+:::caution Verbose tracing logs requests
+The `CIMNotebook (trace)` output channel (LSP trace, off by default) logs full request
+payloads — including credentials of an execute request. Leave tracing off when working
+with authenticated endpoints, or clear the channel afterwards.
+:::
+
 **Current limitations:**
 
-- No authentication support yet — HTTP endpoints must be reachable without credentials.
+- Only HTTP basic authentication is supported.

--- a/docs/content/cimnotebook/vscode.md
+++ b/docs/content/cimnotebook/vscode.md
@@ -95,9 +95,12 @@ term across the workspace. Matching is partial and case-insensitive — `aclines
 ### CIM Notebooks
 
 CIMNotebook opens git-friendly **markdown notebooks** (`*.cimnb.md`, or any `*.md` via
-*Open With…*) whose ```` ```sparql ```` / ```` ```shacl ```` code blocks become notebook cells,
+_Open With…_) whose ` ```sparql ` / ` ```shacl ` code blocks become notebook cells,
 and reads/writes Zazuko's `.sparqlbook` format for interop. The command
-**CIMNotebook: Convert Notebook** switches a notebook between the two formats. See
+**CIMNotebook: Convert Notebook** switches a notebook between the two formats. Cells run
+against SPARQL endpoints, local RDF/CIMXML files, or named connections — the cell's
+status-bar button and **CIMNotebook: Set Cell Endpoint…** pick the target, and
+**CIMNotebook: Set/Clear Connection Credentials…** manage basic-auth secrets. See
 [CIM Notebooks](/cimnotebook/notebooks).
 
 ### SPARQL Notebook support
@@ -115,7 +118,7 @@ These editor-specific settings live in VS Code's settings (`settings.json` or th
 Schema configuration itself lives in [`opencgmes.jsonc`](/cimvocabcheck/configuration), not here.
 
 | Setting                      | Default     | Description                                                                                      |
-| ---------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| ---------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
 | `cimnotebook.serverJar`      | _(bundled)_ | Absolute path to `cimvocabcheck-lsp.jar`. Leave empty to use the JAR bundled with the extension. |
 | `cimnotebook.javaExecutable` | `java`      | Java executable used to launch the language server. Must be Java 21 or later.                    |
 | `cimnotebook.javaArgs`       | `[]`        | Extra JVM arguments passed before `-jar`, e.g. `["-Xmx512m"]`.                                   |


### PR DESCRIPTION
Cells can name a connection from opencgmes.jsonc's "cimnotebook" section with `# [endpoint=<name>]`. Resolution is cell directive → notebook default (workspaceState, set via command) → the connection marked "default": true. Every cell shows its resolved target in the cell status bar; clicking it picks a connection, URL, or file and writes the directive into the cell, or stores it as the notebook default without touching the file. Conflicting directives are reported rather than silently resolved to one of them — only several *file* paths are a union.

Connections with authType "basic" prompt once for credentials and keep them in VS Code SecretStorage (key cimnotebook.auth.<name>) — never in the config file — attached to execute requests only. The connection list is fetched from the language server per notebook and invalidated when any opencgmes.jsonc changes. The config JSON schema gains the cimnotebook section, and the docs cover connections and credentials.

Closes #51