### PR TITLE
feat(cimnotebook): configuration sidebar for opencgmes.jsonc (GH-44)

### DIFF
--- a/cimnotebook/sbom/vscode/THIRD-PARTY.txt
+++ b/cimnotebook/sbom/vscode/THIRD-PARTY.txt
@@ -1,8 +1,9 @@
-Third-party dependencies for CIMNotebook VS Code extension (9 component(s)).
+Third-party dependencies for CIMNotebook VS Code extension (10 component(s)).
 Generated from the committed CycloneDX SBOM by scripts/check-sbom-licenses.py — do not edit by hand.
 
      (MIT) balanced-match:4.0.4 (pkg:npm/balanced-match@4.0.4)
      (MIT) brace-expansion:5.0.7 (pkg:npm/brace-expansion@5.0.7)
+     (MIT) jsonc-parser:3.3.1 (pkg:npm/jsonc-parser@3.3.1)
      (BlueOak-1.0.0) minimatch:10.2.5 (pkg:npm/minimatch@10.2.5)
      (ISC) semver:7.8.1 (pkg:npm/semver@7.8.1)
      (MIT) vscode-jsonrpc:9.0.1 (pkg:npm/vscode-jsonrpc@9.0.1)

--- a/cimnotebook/sbom/vscode/bom.json
+++ b/cimnotebook/sbom/vscode/bom.json
@@ -193,6 +193,40 @@
     },
     {
       "type": "library",
+      "name": "jsonc-parser",
+      "version": "3.3.1",
+      "bom-ref": "cimnotebook@0.0.0|jsonc-parser@3.3.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/jsonc-parser@3.3.1",
+      "externalReferences": [
+        {
+          "url": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+          "type": "distribution",
+          "hashes": [
+            {
+              "alg": "SHA-512",
+              "content": "1d4807eb92b27a3ad414fbc714f6ea398d2bb058a9dc1a39c1be2782f762d44a426165100c2e55f98ee6670b3e0cb92be0cfffcd02686a7bb548ffbcec3bf5a1"
+            }
+          ],
+          "comment": "as detected from npm-ls property \"resolved\" and property \"integrity\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:path",
+          "value": "node_modules/jsonc-parser"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "minimatch",
       "version": "10.2.5",
       "bom-ref": "cimnotebook@0.0.0|minimatch@10.2.5",
@@ -434,6 +468,7 @@
     {
       "ref": "cimnotebook@0.0.0",
       "dependsOn": [
+        "cimnotebook@0.0.0|jsonc-parser@3.3.1",
         "cimnotebook@0.0.0|vscode-languageclient@10.1.0"
       ]
     },
@@ -445,6 +480,9 @@
       "dependsOn": [
         "cimnotebook@0.0.0|balanced-match@4.0.4"
       ]
+    },
+    {
+      "ref": "cimnotebook@0.0.0|jsonc-parser@3.3.1"
     },
     {
       "ref": "cimnotebook@0.0.0|minimatch@10.2.5",

--- a/cimnotebook/vscode/esbuild.js
+++ b/cimnotebook/vscode/esbuild.js
@@ -26,6 +26,12 @@ esbuild
         bundle: true,
         outfile: "out/extension.js",
         external: ["vscode"], // provided by VS Code at runtime — never bundle
+        // jsonc-parser's CJS entry is a UMD wrapper that passes `require` into its
+        // factory as a plain function parameter; esbuild cannot statically follow the
+        // factory's internal require("./impl/…") calls and leaves them in the bundle as
+        // runtime requires, which crash extension activation with "Cannot find module
+        // './impl/format'". Bundling its ESM build instead makes every import static.
+        alias: { "jsonc-parser": "jsonc-parser/lib/esm/main.js" },
         format: "cjs",
         platform: "node",
         target: "node20",

--- a/cimnotebook/vscode/media/activity-icon.svg
+++ b/cimnotebook/vscode/media/activity-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 112 112">
+  <!-- Activity-bar icon: VS Code uses the SVG's alpha channel as a mask, so this is the
+       CIMNotebook logo's checkmark-with-nodes motif on a transparent background (the
+       marketplace icon's filled canvas would mask to a solid square). -->
+  <path d="M22.22,61.26l23.05,23.05,46.1-52.69" fill="none" stroke="currentColor" stroke-width="13.17" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="19.04" cy="57.96" r="11.5" fill="currentColor"/>
+  <circle cx="45.27" cy="84.31" r="11.5" fill="currentColor"/>
+  <circle cx="91.37" cy="31.62" r="11.5" fill="currentColor"/>
+</svg>

--- a/cimnotebook/vscode/package-lock.json
+++ b/cimnotebook/vscode/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "jsonc-parser": "^3.3.1",
                 "vscode-languageclient": "^10.0.0"
             },
             "devDependencies": {
@@ -1430,6 +1431,12 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsonc-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
             "license": "MIT"
         },
         "node_modules/keyv": {

--- a/cimnotebook/vscode/package.json
+++ b/cimnotebook/vscode/package.json
@@ -113,6 +113,51 @@
                 ]
             }
         ],
+        "viewsContainers": {
+            "activitybar": [
+                {
+                    "id": "cimnotebook",
+                    "title": "CIMNotebook",
+                    "icon": "media/activity-icon.svg"
+                }
+            ]
+        },
+        "views": {
+            "cimnotebook": [
+                {
+                    "id": "cimnotebook.connectionsView",
+                    "name": "Connections",
+                    "contextualTitle": "OpenCGMES Connections"
+                },
+                {
+                    "id": "cimnotebook.validationView",
+                    "name": "Validation",
+                    "contextualTitle": "OpenCGMES Validation"
+                },
+                {
+                    "id": "cimnotebook.executionView",
+                    "name": "Notebook Execution",
+                    "contextualTitle": "OpenCGMES Notebook Execution"
+                }
+            ]
+        },
+        "viewsWelcome": [
+            {
+                "view": "cimnotebook.connectionsView",
+                "contents": "No `opencgmes.jsonc` was found for this workspace.\n[Create Config File](command:cimnotebook.createConfig)",
+                "when": "!cimnotebook.hasConfig"
+            },
+            {
+                "view": "cimnotebook.validationView",
+                "contents": "Validation settings appear once an `opencgmes.jsonc` exists.\n[Create Config File](command:cimnotebook.createConfig)",
+                "when": "!cimnotebook.hasConfig"
+            },
+            {
+                "view": "cimnotebook.executionView",
+                "contents": "Notebook execution settings appear once an `opencgmes.jsonc` exists.\n[Create Config File](command:cimnotebook.createConfig)",
+                "when": "!cimnotebook.hasConfig"
+            }
+        ],
         "jsonValidation": [
             {
                 "fileMatch": [
@@ -157,6 +202,79 @@
                 "command": "cimnotebook.notebook.clearCredentials",
                 "title": "Clear Connection Credentials…",
                 "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.connections.add",
+                "title": "Add Connection",
+                "category": "CIMNotebook",
+                "icon": "$(add)"
+            },
+            {
+                "command": "cimnotebook.connections.edit",
+                "title": "Edit Connection",
+                "category": "CIMNotebook",
+                "icon": "$(edit)"
+            },
+            {
+                "command": "cimnotebook.connections.remove",
+                "title": "Remove Connection",
+                "category": "CIMNotebook",
+                "icon": "$(trash)"
+            },
+            {
+                "command": "cimnotebook.connections.toggleDefault",
+                "title": "Set/Unset as Default Connection",
+                "category": "CIMNotebook",
+                "icon": "$(star)"
+            },
+            {
+                "command": "cimnotebook.connections.credentials",
+                "title": "Set/Clear Connection Credentials",
+                "category": "CIMNotebook",
+                "icon": "$(key)"
+            },
+            {
+                "command": "cimnotebook.config.openFile",
+                "title": "Open opencgmes.jsonc",
+                "category": "CIMNotebook",
+                "icon": "$(go-to-file)"
+            },
+            {
+                "command": "cimnotebook.config.editStrictness",
+                "title": "Edit Strictness",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.config.editStandardVocabulary",
+                "title": "Edit Standard Vocabulary Check",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.config.editSchemasDirectory",
+                "title": "Edit Schemas Directory",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.config.addSchemaFile",
+                "title": "Add Schema File",
+                "category": "CIMNotebook",
+                "icon": "$(add)"
+            },
+            {
+                "command": "cimnotebook.config.removeSchemaFile",
+                "title": "Remove Schema File",
+                "category": "CIMNotebook",
+                "icon": "$(trash)"
+            },
+            {
+                "command": "cimnotebook.config.editQueryTimeout",
+                "title": "Edit Query Timeout",
+                "category": "CIMNotebook"
+            },
+            {
+                "command": "cimnotebook.config.editMaxRows",
+                "title": "Edit Max Rows",
+                "category": "CIMNotebook"
             }
         ],
         "menus": {
@@ -188,6 +306,102 @@
                 },
                 {
                     "command": "cimnotebook.notebook.clearCredentials"
+                },
+                {
+                    "command": "cimnotebook.connections.add",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.connections.edit",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.connections.remove",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.connections.toggleDefault",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.connections.credentials",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.openFile",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editStrictness",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editStandardVocabulary",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editSchemasDirectory",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.addSchemaFile",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.removeSchemaFile",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editQueryTimeout",
+                    "when": "false"
+                },
+                {
+                    "command": "cimnotebook.config.editMaxRows",
+                    "when": "false"
+                }
+            ],
+            "view/title": [
+                {
+                    "command": "cimnotebook.connections.add",
+                    "when": "view == cimnotebook.connectionsView && cimnotebook.hasConfig",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "cimnotebook.config.openFile",
+                    "when": "view == cimnotebook.connectionsView",
+                    "group": "navigation@2"
+                }
+            ],
+            "view/item/context": [
+                {
+                    "command": "cimnotebook.connections.edit",
+                    "when": "view == cimnotebook.connectionsView && viewItem =~ /^connection\\b/",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "cimnotebook.connections.credentials",
+                    "when": "view == cimnotebook.connectionsView && viewItem =~ /\\bbasic\\b/",
+                    "group": "inline@2"
+                },
+                {
+                    "command": "cimnotebook.connections.toggleDefault",
+                    "when": "view == cimnotebook.connectionsView && viewItem =~ /^connection\\b/",
+                    "group": "inline@3"
+                },
+                {
+                    "command": "cimnotebook.connections.remove",
+                    "when": "view == cimnotebook.connectionsView && viewItem =~ /^connection\\b/",
+                    "group": "inline@4"
+                },
+                {
+                    "command": "cimnotebook.config.addSchemaFile",
+                    "when": "view == cimnotebook.validationView && viewItem == schemasParent",
+                    "group": "inline"
+                },
+                {
+                    "command": "cimnotebook.config.removeSchemaFile",
+                    "when": "view == cimnotebook.validationView && viewItem == schemaFile",
+                    "group": "inline"
                 }
             ]
         },
@@ -260,15 +474,16 @@
         "copy-jar": "cp ../../cimvocabcheck/lsp/target/cimvocabcheck-lsp-*.jar server/cimvocabcheck-lsp.jar"
     },
     "dependencies": {
+        "jsonc-parser": "^3.3.1",
         "vscode-languageclient": "^10.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^24.0.0",
         "@types/vscode": "^1.75.0",
+        "esbuild": "^0.28.0",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
-        "esbuild": "^0.28.0",
         "prettier": "^3.8.4",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.61.1"

--- a/cimnotebook/vscode/src/extension.ts
+++ b/cimnotebook/vscode/src/extension.ts
@@ -32,6 +32,7 @@ import { registerConvertCommand } from "./notebook/convert";
 import { ConnectionStore } from "./notebook/connections";
 import { registerEndpointCommands } from "./notebook/endpointCommands";
 import { registerCellStatusBar } from "./notebook/statusBar";
+import { registerConfigTreeViews } from "./sidebar/treeViews";
 
 const CHANNEL = "CIMNotebook";
 
@@ -71,6 +72,7 @@ export function activate(context: vscode.ExtensionContext): void {
     registerConvertCommand(context);
     registerEndpointCommands(context, connectionStore);
     registerCellStatusBar(context, connectionStore);
+    registerConfigTreeViews(context, connectionStore);
 
     try {
         doActivate(context, connectionStore);

--- a/cimnotebook/vscode/src/notebook/endpoint.test.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.test.ts
@@ -245,6 +245,26 @@ describe("applyEndpointDirective", () => {
         const text = "# just a comment\nASK {}";
         assert.equal(applyEndpointDirective(text, null), text);
     });
+
+    it("writes one directive line per array entry, in order", () => {
+        assert.equal(
+            applyEndpointDirective("ASK {}", ["a.ttl", "b.ttl"]),
+            "# [endpoint=a.ttl]\n# [endpoint=b.ttl]\nASK {}",
+        );
+    });
+
+    it("replaces every existing directive with the new array at the first one's position", () => {
+        const text = "# [endpoint=./a.ttl]\nASK {}\n# [endpoint=./b.ttl]";
+        assert.equal(
+            applyEndpointDirective(text, ["x.ttl", "y.ttl", "z.ttl"]),
+            "# [endpoint=x.ttl]\n# [endpoint=y.ttl]\n# [endpoint=z.ttl]\nASK {}",
+        );
+    });
+
+    it("treats an empty array like clearing", () => {
+        const text = "# [endpoint=./a.ttl]\nASK {}";
+        assert.equal(applyEndpointDirective(text, []), "ASK {}");
+    });
 });
 
 describe("deriveShaclUrl", () => {

--- a/cimnotebook/vscode/src/notebook/endpoint.ts
+++ b/cimnotebook/vscode/src/notebook/endpoint.ts
@@ -184,29 +184,31 @@ function shortUrl(url: string): string {
 }
 
 /**
- * Returns the cell text with its endpoint directive set to `value` (replacing the first
- * existing directive line and dropping any further ones), or with all directive lines
- * removed when `value` is null. Used by the *Set Cell Endpoint* command — the directive
- * stays the portable source of truth inside the file.
+ * Returns the cell text with its endpoint directive(s) set to `value` (replacing the
+ * first existing directive line with one line per value and dropping any further ones),
+ * or with all directive lines removed when `value` is null. An array writes one line per
+ * entry, in order — the *Set Cell Endpoint* command uses this for a multi-file union
+ * target (M3). The directive stays the portable source of truth inside the file.
  */
-export function applyEndpointDirective(cellText: string, value: string | null): string {
+export function applyEndpointDirective(cellText: string, value: string | string[] | null): string {
+    const values = value === null ? [] : Array.isArray(value) ? value : [value];
     const directiveLine = /^\s*#\s*\[\s*endpoint\s*=\s*[^\]\s]+\s*\][^\n]*$/;
     const lines = cellText.split("\n");
     const kept: string[] = [];
-    let replaced = false;
+    let inserted = false;
     for (const line of lines) {
         if (!directiveLine.test(line)) {
             kept.push(line);
             continue;
         }
-        if (value !== null && !replaced) {
-            kept.push(`# [endpoint=${value}]`);
-            replaced = true;
+        if (values.length > 0 && !inserted) {
+            kept.push(...values.map((v) => `# [endpoint=${v}]`));
+            inserted = true;
         }
         // Further directive lines (and all of them when clearing) are dropped.
     }
-    if (value !== null && !replaced) {
-        kept.unshift(`# [endpoint=${value}]`);
+    if (values.length > 0 && !inserted) {
+        kept.unshift(...values.map((v) => `# [endpoint=${v}]`));
     }
     return kept.join("\n");
 }

--- a/cimnotebook/vscode/src/notebook/endpointCommands.ts
+++ b/cimnotebook/vscode/src/notebook/endpointCommands.ts
@@ -29,13 +29,22 @@
 
 import * as vscode from "vscode";
 
+import { validateRequiredUrl } from "../sidebar/treeItems";
 import { ConnectionStore } from "./connections";
 import { clearCredentials, setCredentials } from "./credentials";
 import { applyEndpointDirective, ConnectionInfo } from "./endpoint";
+import { pickWorkspaceFiles } from "./filePicker";
 
 export const SET_ENDPOINT_COMMAND = "cimnotebook.notebook.setEndpoint";
 export const SET_CREDENTIALS_COMMAND = "cimnotebook.notebook.setCredentials";
 export const CLEAR_CREDENTIALS_COMMAND = "cimnotebook.notebook.clearCredentials";
+
+/** Data file extensions offered by the "Enter data file path…" picker. */
+const DATA_FILE_PATTERN = "**/*.{xml,ttl,rdf,owl,nt,nq,trig}";
+
+/** Workspace-scoped memory of recently used endpoint URLs (most recent first). */
+const RECENT_URLS_KEY = "cimnotebook.recentEndpointUrls";
+const MAX_RECENT_URLS = 5;
 
 export function registerEndpointCommands(
     context: vscode.ExtensionContext,
@@ -43,7 +52,7 @@ export function registerEndpointCommands(
 ): void {
     context.subscriptions.push(
         vscode.commands.registerCommand(SET_ENDPOINT_COMMAND, (cell?: vscode.NotebookCell) =>
-            setEndpoint(store, cell),
+            setEndpoint(context, store, cell),
         ),
         vscode.commands.registerCommand(SET_CREDENTIALS_COMMAND, () =>
             manageCredentials(context, store, "set"),
@@ -61,7 +70,11 @@ interface EndpointPick extends vscode.QuickPickItem {
     connection?: ConnectionInfo;
 }
 
-async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): Promise<void> {
+async function setEndpoint(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+    cell?: vscode.NotebookCell,
+): Promise<void> {
     const target = cell ?? activeCell();
     if (!target) {
         vscode.window.showWarningMessage("CIMNotebook: no notebook cell is active.");
@@ -104,18 +117,13 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
         return;
     }
 
-    let directive: string | null;
+    let directive: string | string[] | null;
     switch (pick.action) {
         case "connection":
             directive = pick.connection?.name ?? null;
             break;
         case "url": {
-            const url = await vscode.window.showInputBox({
-                title: "SPARQL endpoint URL",
-                placeHolder: "http://localhost:3030/dataset/query",
-                validateInput: (v) =>
-                    /^https?:\/\/\S+$/i.test(v) ? undefined : "Enter an http(s):// URL",
-            });
+            const url = await pickEndpointUrl(context);
             if (url === undefined) {
                 return;
             }
@@ -123,14 +131,21 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
             break;
         }
         case "file": {
-            const file = await vscode.window.showInputBox({
-                title: "Data file path (relative to the notebook)",
-                placeHolder: "./model.xml",
+            const files = await pickWorkspaceFiles({
+                pattern: DATA_FILE_PATTERN,
+                baseUri: vscode.Uri.joinPath(target.notebook.uri, ".."),
+                title: "Data file(s) to run this cell against",
+                placeHolder: "Search by file name — pick one or more (Tab to multi-select)",
+                canPickMany: true,
+                allowManualEntry: true,
             });
-            if (file === undefined || file === "") {
+            const usable = filterDirectiveSafePaths(files);
+            if (!usable || usable.length === 0) {
                 return;
             }
-            directive = file;
+            // A notebook-wide default is a single stored directive (connections.ts), so a
+            // multi-file union — the M3 target — only makes sense written into the cell.
+            directive = usable.length > 1 ? usable : usable[0];
             break;
         }
         case "clear":
@@ -138,8 +153,9 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
             break;
     }
 
+    // "clear" (null) and multi-file (string[]) both apply to the cell only.
     const scope =
-        directive === null
+        directive === null || Array.isArray(directive)
             ? "This cell"
             : await vscode.window.showQuickPick(["This cell", "Notebook default"], {
                   title: "Apply where?",
@@ -150,8 +166,8 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
     if (scope === undefined) {
         return;
     }
-    if (scope === "Notebook default") {
-        await store.setNotebookDefault(target.notebook, directive ?? undefined);
+    if (scope === "Notebook default" && typeof directive === "string") {
+        await store.setNotebookDefault(target.notebook, directive);
         return;
     }
 
@@ -165,6 +181,72 @@ async function setEndpoint(store: ConnectionStore, cell?: vscode.NotebookCell): 
         );
         await vscode.workspace.applyEdit(edit);
     }
+}
+
+/**
+ * A small QuickPick history of recently used URLs (workspaceState, last {@link
+ * MAX_RECENT_URLS}) above a plain "Enter new URL…" input box — skipped entirely the
+ * first time, when there is nothing to recall yet.
+ */
+async function pickEndpointUrl(context: vscode.ExtensionContext): Promise<string | undefined> {
+    const recent = context.workspaceState.get<string[]>(RECENT_URLS_KEY, []);
+    let url: string | undefined;
+    if (recent.length === 0) {
+        url = await promptForUrl();
+    } else {
+        interface UrlPick extends vscode.QuickPickItem {
+            url?: string;
+            enterNew?: boolean;
+        }
+        const items: UrlPick[] = recent.map((u) => ({ label: `$(history) ${u}`, url: u }));
+        items.push({ label: "$(edit) Enter new URL…", enterNew: true });
+        const pick = await vscode.window.showQuickPick(items, {
+            title: "SPARQL endpoint URL",
+            placeHolder: "Pick a recent URL or enter a new one",
+        });
+        if (!pick) {
+            return undefined;
+        }
+        url = pick.enterNew ? await promptForUrl() : pick.url;
+    }
+    if (url === undefined) {
+        return undefined;
+    }
+    await rememberRecentUrl(context, url);
+    return url;
+}
+
+function promptForUrl(): Thenable<string | undefined> {
+    return vscode.window.showInputBox({
+        title: "SPARQL endpoint URL",
+        placeHolder: "http://localhost:3030/dataset/query",
+        validateInput: validateRequiredUrl,
+    });
+}
+
+/**
+ * Drops picked paths that a `# [endpoint=...]` directive cannot express — its value ends
+ * at the first whitespace character (see `parseEndpointDirectives`) — and tells the user
+ * why. Returns `undefined` when the pick itself was cancelled.
+ */
+function filterDirectiveSafePaths(files: string[] | undefined): string[] | undefined {
+    if (!files) {
+        return undefined;
+    }
+    const unusable = files.filter((f) => /\s/.test(f));
+    if (unusable.length > 0) {
+        vscode.window.showErrorMessage(
+            `CIMNotebook: ${unusable.join(", ")} can't be used in a # [endpoint=…] directive — ` +
+                "paths containing whitespace aren't supported. Rename the file or folder to use it here.",
+        );
+    }
+    return files.filter((f) => !/\s/.test(f));
+}
+
+async function rememberRecentUrl(context: vscode.ExtensionContext, url: string): Promise<void> {
+    const recent = context.workspaceState.get<string[]>(RECENT_URLS_KEY, []);
+    const next = [url, ...recent.filter((u) => u !== url)].slice(0, MAX_RECENT_URLS);
+    await context.workspaceState.update(RECENT_URLS_KEY, next);
 }
 
 function activeCell(): vscode.NotebookCell | undefined {

--- a/cimnotebook/vscode/src/notebook/filePicker.ts
+++ b/cimnotebook/vscode/src/notebook/filePicker.ts
@@ -1,0 +1,142 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * File search / autocomplete for the sidebar's schema-file fields and the *Set Cell
+ * Endpoint* command: a QuickPick over `workspace.findFiles`, whose built-in fuzzy
+ * filtering is the search-as-you-type behaviour, with a `showOpenDialog` fallback for
+ * files outside the workspace (e.g. multi-root setups, or files under an excluded
+ * folder). Paths are returned relative to a caller-supplied base directory, matching how
+ * `opencgmes.jsonc` paths and `# [endpoint=...]` directives are resolved.
+ */
+
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { relativizePath } from "./relativizePath";
+
+/** Keeps the picker responsive and avoids listing generated/vendor trees. */
+const DEFAULT_EXCLUDES = "**/{node_modules,.git,out,out-test,dist,build,target}/**";
+const MAX_RESULTS = 2000;
+
+interface FileQuickPickItem extends vscode.QuickPickItem {
+    uri?: vscode.Uri;
+    browse?: boolean;
+    manual?: boolean;
+}
+
+export interface PickWorkspaceFilesOptions {
+    /** Glob passed to `workspace.findFiles`, e.g. `"**\/*.{rdf,ttl,owl}"`. */
+    pattern: string;
+    /** Directory the returned paths are relativized against. */
+    baseUri: vscode.Uri;
+    title: string;
+    placeHolder?: string;
+    canPickMany?: boolean;
+    /**
+     * Adds an "Enter path manually…" item for paths the picker can't offer — typically a
+     * file that doesn't exist yet. The typed path is returned verbatim (it is already
+     * relative to `baseUri` by convention), so no existence check is applied.
+     */
+    allowManualEntry?: boolean;
+}
+
+/**
+ * QuickPick over the workspace files matching `pattern`. Returns paths relative to
+ * `baseUri` in `./...` form, or `undefined` if the user cancelled. The last item,
+ * "Browse…", opens a native file dialog for files the glob can't reach (excluded
+ * folders, other drives, …) — picking it takes over the whole selection, since the
+ * dialog has its own multi-select UI.
+ */
+export async function pickWorkspaceFiles(
+    options: PickWorkspaceFilesOptions,
+): Promise<string[] | undefined> {
+    const { pattern, baseUri, title, placeHolder, canPickMany, allowManualEntry } = options;
+    const found = await vscode.workspace.findFiles(pattern, DEFAULT_EXCLUDES, MAX_RESULTS);
+    const items: FileQuickPickItem[] = found
+        .slice()
+        .sort((a, b) => a.fsPath.localeCompare(b.fsPath))
+        .map((uri) => ({
+            label: `$(file) ${path.basename(uri.fsPath)}`,
+            description: vscode.workspace.asRelativePath(path.dirname(uri.fsPath), false),
+            uri,
+        }));
+    items.push({ label: "$(folder-opened) Browse…", browse: true });
+    if (allowManualEntry) {
+        items.push({ label: "$(edit) Enter path manually…", manual: true });
+    }
+
+    const picked = await vscode.window.showQuickPick(items, {
+        title,
+        placeHolder: placeHolder ?? "Type to search files by name",
+        canPickMany,
+        matchOnDescription: true,
+    });
+    if (!picked) {
+        return undefined;
+    }
+    const selections = Array.isArray(picked) ? picked : [picked];
+    if (selections.length === 0) {
+        return undefined;
+    }
+    // Like Browse…, manual entry takes over the whole selection: it is an escape hatch,
+    // not one pick among many.
+    if (selections.some((s) => s.manual)) {
+        const typed = await vscode.window.showInputBox({
+            title,
+            placeHolder: "./model.xml",
+            prompt: "Relative paths are resolved against the notebook / config file directory.",
+        });
+        const trimmed = typed?.trim();
+        return trimmed ? [trimmed] : undefined;
+    }
+    if (selections.some((s) => s.browse)) {
+        const uris = await vscode.window.showOpenDialog({
+            title,
+            canSelectMany: canPickMany,
+            canSelectFolders: false,
+            canSelectFiles: true,
+        });
+        if (!uris || uris.length === 0) {
+            return undefined;
+        }
+        return uris.map((uri) => relativizePath(baseUri.fsPath, uri.fsPath));
+    }
+    return selections
+        .filter((s): s is FileQuickPickItem & { uri: vscode.Uri } => s.uri !== undefined)
+        .map((s) => relativizePath(baseUri.fsPath, s.uri.fsPath));
+}
+
+export interface PickWorkspaceFolderOptions {
+    baseUri: vscode.Uri;
+    title: string;
+}
+
+/** Native folder dialog, returning the picked folder relative to `baseUri`. */
+export async function pickWorkspaceFolder(
+    options: PickWorkspaceFolderOptions,
+): Promise<string | undefined> {
+    const uris = await vscode.window.showOpenDialog({
+        title: options.title,
+        canSelectMany: false,
+        canSelectFolders: true,
+        canSelectFiles: false,
+    });
+    const uri = uris?.[0];
+    return uri ? relativizePath(options.baseUri.fsPath, uri.fsPath) : undefined;
+}

--- a/cimnotebook/vscode/src/notebook/relativizePath.test.ts
+++ b/cimnotebook/vscode/src/notebook/relativizePath.test.ts
@@ -1,0 +1,60 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as path from "path";
+
+import { relativizePath } from "./relativizePath";
+
+describe("relativizePath", () => {
+    it("relativizes a descendant path with a ./ prefix", () => {
+        const from = path.join("/ws", "notebooks");
+        const to = path.join("/ws", "notebooks", "data", "model.xml");
+        assert.equal(relativizePath(from, to), "./data/model.xml");
+    });
+
+    it("keeps the ../ form for paths outside the base directory", () => {
+        const from = path.join("/ws", "notebooks");
+        const to = path.join("/ws", "data", "model.xml");
+        assert.equal(relativizePath(from, to), "../data/model.xml");
+    });
+
+    it("returns ./name for a direct sibling file", () => {
+        const from = path.join("/ws", "notebooks");
+        const to = path.join("/ws", "notebooks", "model.xml");
+        assert.equal(relativizePath(from, to), "./model.xml");
+    });
+
+    it("returns . for the base directory itself, not an empty string", () => {
+        const dir = path.join("/ws", "notebooks");
+        assert.equal(relativizePath(dir, dir), ".");
+    });
+
+    it("keeps a Windows cross-drive path absolute instead of prefixing ./", () => {
+        assert.equal(
+            relativizePath("C:\\ws\\notebooks", "D:\\data\\model.xml", path.win32),
+            "D:/data/model.xml",
+        );
+        // Same drive still relativizes normally.
+        assert.equal(
+            relativizePath("C:\\ws\\notebooks", "C:\\ws\\notebooks\\model.xml", path.win32),
+            "./model.xml",
+        );
+    });
+});

--- a/cimnotebook/vscode/src/notebook/relativizePath.ts
+++ b/cimnotebook/vscode/src/notebook/relativizePath.ts
@@ -1,0 +1,44 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Turns an absolute filesystem path into the relative, forward-slash, `./`-prefixed form
+ * used for `# [endpoint=...]` directives and `opencgmes.jsonc` path fields — both are
+ * resolved relative to a base directory (the notebook's folder or the config file's
+ * folder) and always use `/` even on Windows. Pure (only node's `path`), so it is used
+ * both by the vscode-facing file pickers and directly in node tests.
+ */
+
+import * as path from "path";
+
+/** The subset of node's `path` used here — injectable so tests can exercise win32 rules. */
+export type PathImpl = Pick<typeof path, "relative" | "isAbsolute" | "sep">;
+
+export function relativizePath(fromDir: string, toPath: string, impl: PathImpl = path): string {
+    const relative = impl.relative(fromDir, toPath);
+    if (impl.isAbsolute(relative)) {
+        // No relative form exists (Windows: base and target on different drives) —
+        // keep the absolute path rather than fabricating a broken "./C:/..." one.
+        return relative.split(impl.sep).join("/");
+    }
+    const slashed = relative.split(impl.sep).join("/");
+    if (slashed === "") {
+        return ".";
+    }
+    return slashed.startsWith(".") ? slashed : `./${slashed}`;
+}

--- a/cimnotebook/vscode/src/sidebar/configEditor.ts
+++ b/cimnotebook/vscode/src/sidebar/configEditor.ts
@@ -1,0 +1,174 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Owns the configuration tree views' one write mechanism: which `opencgmes.jsonc` file
+ * they edit, and how. `read()`/`update()` are the only way the tree views (or their
+ * commands) touch the file — always through {@link parseConfigModel}/
+ * {@link applyConfigModel}'s comment-preserving property-path edits, exactly like the
+ * former webview sidebar did, so hand-editing and the tree views coexist.
+ *
+ * The edited file is the *nearest* `opencgmes.{jsonc,json}` walking up from the active
+ * document (within its workspace folder), falling back to the first workspace folder's
+ * root — matching validation's own nearest-config discovery.
+ */
+
+import * as vscode from "vscode";
+
+import { applyConfigModel, ConfigModel, parseConfigModel } from "./configModel";
+
+export interface ConfigTarget {
+    uri: vscode.Uri;
+    exists: boolean;
+}
+
+export interface ConfigState extends ConfigTarget {
+    model: ConfigModel;
+}
+
+export async function targetConfig(): Promise<ConfigTarget> {
+    const active =
+        vscode.window.activeNotebookEditor?.notebook.uri ??
+        vscode.window.activeTextEditor?.document.uri;
+    const folder = active
+        ? vscode.workspace.getWorkspaceFolder(active)
+        : vscode.workspace.workspaceFolders?.[0];
+    if (active && folder) {
+        let dir = vscode.Uri.joinPath(active, "..");
+        for (let i = 0; i < 64; i++) {
+            for (const name of ["opencgmes.jsonc", "opencgmes.json"]) {
+                const candidate = vscode.Uri.joinPath(dir, name);
+                if (await exists(candidate)) {
+                    return { uri: candidate, exists: true };
+                }
+            }
+            if (dir.path === folder.uri.path || dir.path === "/") {
+                break;
+            }
+            dir = vscode.Uri.joinPath(dir, "..");
+        }
+    }
+    const root = folder ?? vscode.workspace.workspaceFolders?.[0];
+    if (root) {
+        const jsonc = vscode.Uri.joinPath(root.uri, "opencgmes.jsonc");
+        if (await exists(jsonc)) {
+            return { uri: jsonc, exists: true };
+        }
+        const json = vscode.Uri.joinPath(root.uri, "opencgmes.json");
+        if (await exists(json)) {
+            return { uri: json, exists: true };
+        }
+        return { uri: jsonc, exists: false };
+    }
+    return { uri: vscode.Uri.file("opencgmes.jsonc"), exists: false };
+}
+
+/** The current target config's location and parsed model. */
+export async function readConfig(): Promise<ConfigState> {
+    const target = await targetConfig();
+    const text = target.exists ? await readText(target.uri) : "";
+    return { ...target, model: parseConfigModel(text) };
+}
+
+/**
+ * Applies `mutate` to `target`'s model and writes the result back — a property-path
+ * edit, so comments and formatting elsewhere in the file are preserved. `target` is the
+ * {@link readConfig} result the calling wizard was built from: pinning the file here
+ * keeps a mid-wizard focus change from silently redirecting the write to a different
+ * config. The text itself is re-read (and existence re-checked) at write time, so
+ * concurrent hand-edits are never clobbered by a stale in-memory copy. Returns `false`
+ * (after showing an error message) if the write failed; the tree views treat that as
+ * "nothing changed" and skip the refresh.
+ *
+ * An existing config is edited through a {@link vscode.WorkspaceEdit} and then saved,
+ * not written straight to disk: when the file is open in an editor with unsaved changes,
+ * that buffer — not the file on disk — is its current content, and a raw `fs.writeFile`
+ * would both build on stale text and be silently reverted by the user's next save. The
+ * edit also lands on the editor's undo stack, so the change can be undone like any other.
+ */
+export async function updateConfig(
+    target: ConfigTarget,
+    mutate: (model: ConfigModel) => void,
+): Promise<boolean> {
+    try {
+        if (!(await exists(target.uri))) {
+            const model = parseConfigModel("");
+            mutate(model);
+            const created = applyConfigModel("", model);
+            await vscode.workspace.fs.writeFile(target.uri, Buffer.from(created, "utf8"));
+            return true;
+        }
+
+        const document = await vscode.workspace.openTextDocument(target.uri);
+        const text = document.getText();
+        const model = parseConfigModel(text);
+        mutate(model);
+        const newText = applyConfigModel(text, model);
+        if (newText === text) {
+            return true;
+        }
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(
+            target.uri,
+            new vscode.Range(document.positionAt(0), document.positionAt(text.length)),
+            newText,
+        );
+        if (!(await vscode.workspace.applyEdit(edit))) {
+            throw new Error("the workspace edit was rejected");
+        }
+        await document.save();
+        return true;
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`CIMNotebook: saving the config failed: ${msg}`);
+        return false;
+    }
+}
+
+/** Opens the target config, offering to create it first when it doesn't exist yet. */
+export async function openConfig(): Promise<void> {
+    const target = await targetConfig();
+    if (target.exists) {
+        await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(target.uri));
+    } else {
+        await vscode.commands.executeCommand("cimnotebook.createConfig");
+    }
+}
+
+async function exists(uri: vscode.Uri): Promise<boolean> {
+    try {
+        await vscode.workspace.fs.stat(uri);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * The config's current text: an already-open editor's buffer when there is one (it may hold
+ * unsaved edits, and those are what the tree views should reflect), else the file on disk. Only
+ * *already-open* documents are consulted — this runs on every tree refresh, and opening the
+ * document here just to read it would be wasteful.
+ */
+async function readText(uri: vscode.Uri): Promise<string> {
+    const open = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
+    if (open) {
+        return open.getText();
+    }
+    return Buffer.from(await vscode.workspace.fs.readFile(uri)).toString("utf8");
+}

--- a/cimnotebook/vscode/src/sidebar/configModel.test.ts
+++ b/cimnotebook/vscode/src/sidebar/configModel.test.ts
@@ -1,0 +1,138 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyConfigModel, ConfigModel, parseConfigModel } from "./configModel";
+
+const CONFIG = `{
+  // keep me: file header comment
+  "cimvocabcheck": {
+    // keep me: strictness comment
+    "strictness": "default",
+    "schemas": ["a.rdf", "b.rdf"]
+  },
+  "cimnotebook": {
+    "queryTimeoutSeconds": 30,
+    "connections": [
+      { "name": "local", "url": "http://localhost:3030/ds/query", "default": true }
+    ]
+  }
+}
+`;
+
+describe("parseConfigModel", () => {
+    it("reads both sections leniently", () => {
+        const model = parseConfigModel(CONFIG);
+        assert.equal(model.strictness, "default");
+        assert.deepEqual(model.schemas, ["a.rdf", "b.rdf"]);
+        assert.equal(model.queryTimeoutSeconds, 30);
+        assert.equal(model.maxRows, undefined);
+        assert.deepEqual(model.connections, [
+            {
+                name: "local",
+                url: "http://localhost:3030/ds/query",
+                updateUrl: undefined,
+                shaclUrl: undefined,
+                authType: undefined,
+                default: true,
+            },
+        ]);
+    });
+
+    it("tolerates comments, trailing commas, and garbage", () => {
+        assert.deepEqual(parseConfigModel('{ /* c */ "cimvocabcheck": { }, }').schemas, undefined);
+        assert.equal(parseConfigModel("not json").strictness, undefined);
+        assert.equal(parseConfigModel("").strictness, undefined);
+    });
+});
+
+describe("applyConfigModel", () => {
+    it("changes only the edited value and keeps comments elsewhere", () => {
+        const model = parseConfigModel(CONFIG);
+        model.strictness = "strict";
+
+        const result = applyConfigModel(CONFIG, model);
+
+        assert.ok(result.includes('"strictness": "strict"'));
+        assert.ok(result.includes("keep me: file header comment"));
+        assert.ok(result.includes("keep me: strictness comment"));
+        assert.ok(
+            result.includes('"schemas": ["a.rdf", "b.rdf"]'),
+            "untouched array kept verbatim",
+        );
+        assert.deepEqual(parseConfigModel(result).connections, model.connections);
+    });
+
+    it("is a no-op for an unchanged model", () => {
+        assert.equal(applyConfigModel(CONFIG, parseConfigModel(CONFIG)), CONFIG);
+    });
+
+    it("removes a property when the form clears it", () => {
+        const model = parseConfigModel(CONFIG);
+        model.strictness = "";
+
+        const result = applyConfigModel(CONFIG, model);
+
+        assert.ok(!result.includes('"strictness"'));
+        assert.ok(result.includes("keep me: file header comment"));
+    });
+
+    it("replaces the connections array and drops empty optional fields", () => {
+        const model = parseConfigModel(CONFIG);
+        model.connections = [
+            {
+                name: "prod",
+                url: "https://example.org/query",
+                updateUrl: "  ",
+                authType: "basic",
+                default: false,
+            },
+        ];
+
+        const parsedBack = parseConfigModel(applyConfigModel(CONFIG, model));
+
+        assert.deepEqual(parsedBack.connections, [
+            {
+                name: "prod",
+                url: "https://example.org/query",
+                updateUrl: undefined,
+                shaclUrl: undefined,
+                authType: "basic",
+                default: undefined,
+            },
+        ]);
+    });
+
+    it("builds a full config from empty text", () => {
+        const model: ConfigModel = {
+            strictness: "strict",
+            queryTimeoutSeconds: 10,
+            connections: [{ name: "local", url: "http://h/q", default: true }],
+        };
+
+        const result = applyConfigModel("", model);
+        const parsedBack = parseConfigModel(result);
+
+        assert.equal(parsedBack.strictness, "strict");
+        assert.equal(parsedBack.queryTimeoutSeconds, 10);
+        assert.equal(parsedBack.connections?.[0].name, "local");
+        assert.equal(parsedBack.connections?.[0].default, true);
+    });
+});

--- a/cimnotebook/vscode/src/sidebar/configModel.ts
+++ b/cimnotebook/vscode/src/sidebar/configModel.ts
@@ -1,0 +1,204 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The form model behind the configuration sidebar, and its mapping to/from
+ * `opencgmes.jsonc` text. Pure module (no `vscode` import).
+ *
+ * Editing goes through jsonc-parser's `modify`/`applyEdits`, which patches individual
+ * property paths: comments and formatting everywhere else in the file survive a save.
+ * Only a value that actually changed is touched; a field cleared in the form removes
+ * the property. The one caveat: rewriting an *array* value (schemas, connections)
+ * replaces that array wholesale, so comments *inside* it are lost — the sidebar
+ * documents this.
+ */
+
+import { applyEdits, modify, parse } from "jsonc-parser";
+
+export interface ConnectionModel {
+    name: string;
+    url: string;
+    updateUrl?: string;
+    shaclUrl?: string;
+    authType?: "none" | "basic";
+    default?: boolean;
+}
+
+export interface ConfigModel {
+    // "cimvocabcheck" section
+    strictness?: string;
+    standardVocabulary?: string;
+    schemasDirectory?: string;
+    schemas?: string[];
+    // "cimnotebook" section
+    queryTimeoutSeconds?: number;
+    maxRows?: number;
+    connections?: ConnectionModel[];
+}
+
+const FORMATTING = { formattingOptions: { insertSpaces: true, tabSize: 2 } };
+
+/** Reads the sidebar-editable fields from config text (error-tolerant JSONC parse). */
+export function parseConfigModel(text: string): ConfigModel {
+    const root = (parse(text, [], { allowTrailingComma: true }) ?? {}) as Record<string, unknown>;
+    const vocab = asObject(root["cimvocabcheck"]);
+    const notebook = asObject(root["cimnotebook"]);
+    return {
+        strictness: asString(vocab["strictness"]),
+        standardVocabulary: asString(vocab["standardVocabulary"]),
+        schemasDirectory: asString(vocab["schemasDirectory"]),
+        schemas: asStringArray(vocab["schemas"]),
+        queryTimeoutSeconds: asNumber(notebook["queryTimeoutSeconds"]),
+        maxRows: asNumber(notebook["maxRows"]),
+        connections: asConnections(notebook["connections"]),
+    };
+}
+
+/**
+ * Returns the config text with the model applied — property-path edits only, so
+ * comments and formatting outside the changed values are preserved. Unchanged fields
+ * produce no edit at all.
+ */
+export function applyConfigModel(text: string, model: ConfigModel): string {
+    const before = parseConfigModel(text);
+    let result = text.trim().length === 0 ? "{}\n" : text;
+
+    const set = (path: (string | number)[], value: unknown, changed: boolean): void => {
+        if (!changed) {
+            return;
+        }
+        result = applyEdits(result, modify(result, path, value, FORMATTING));
+    };
+
+    set(
+        ["cimvocabcheck", "strictness"],
+        emptyToUndefined(model.strictness),
+        emptyToUndefined(model.strictness) !== before.strictness,
+    );
+    set(
+        ["cimvocabcheck", "standardVocabulary"],
+        emptyToUndefined(model.standardVocabulary),
+        emptyToUndefined(model.standardVocabulary) !== before.standardVocabulary,
+    );
+    set(
+        ["cimvocabcheck", "schemasDirectory"],
+        emptyToUndefined(model.schemasDirectory),
+        emptyToUndefined(model.schemasDirectory) !== before.schemasDirectory,
+    );
+    set(
+        ["cimvocabcheck", "schemas"],
+        undefinedIfEmpty(model.schemas),
+        !sameJson(undefinedIfEmpty(model.schemas), before.schemas),
+    );
+    set(
+        ["cimnotebook", "queryTimeoutSeconds"],
+        model.queryTimeoutSeconds,
+        model.queryTimeoutSeconds !== before.queryTimeoutSeconds,
+    );
+    set(["cimnotebook", "maxRows"], model.maxRows, model.maxRows !== before.maxRows);
+    set(
+        ["cimnotebook", "connections"],
+        undefinedIfEmpty(model.connections?.map(normalizeConnection)),
+        !sameJson(
+            undefinedIfEmpty(model.connections?.map(normalizeConnection)),
+            before.connections,
+        ),
+    );
+    return result;
+}
+
+/** Drops empty/false optional fields so the written JSON stays minimal. */
+function normalizeConnection(connection: ConnectionModel): ConnectionModel {
+    const normalized: ConnectionModel = {
+        name: connection.name.trim(),
+        url: connection.url.trim(),
+    };
+    if (connection.updateUrl?.trim()) {
+        normalized.updateUrl = connection.updateUrl.trim();
+    }
+    if (connection.shaclUrl?.trim()) {
+        normalized.shaclUrl = connection.shaclUrl.trim();
+    }
+    if (connection.authType === "basic") {
+        normalized.authType = "basic";
+    }
+    if (connection.default === true) {
+        normalized.default = true;
+    }
+    return normalized;
+}
+
+// ---- lenient readers ---------------------------------------------------------------------
+
+function asObject(value: unknown): Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+    const strings = value.filter((v): v is string => typeof v === "string");
+    return strings.length > 0 ? strings : undefined;
+}
+
+function asConnections(value: unknown): ConnectionModel[] | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+    const connections: ConnectionModel[] = [];
+    for (const entry of value) {
+        const obj = asObject(entry);
+        const name = asString(obj["name"]);
+        const url = asString(obj["url"]);
+        if (name === undefined || url === undefined) {
+            continue;
+        }
+        connections.push({
+            name,
+            url,
+            updateUrl: asString(obj["updateUrl"]),
+            shaclUrl: asString(obj["shaclUrl"]),
+            authType: obj["authType"] === "basic" ? "basic" : undefined,
+            default: obj["default"] === true ? true : undefined,
+        });
+    }
+    return connections.length > 0 ? connections : undefined;
+}
+
+function emptyToUndefined(value: string | undefined): string | undefined {
+    return value === undefined || value.trim() === "" ? undefined : value.trim();
+}
+
+function undefinedIfEmpty<T>(value: T[] | undefined): T[] | undefined {
+    return value !== undefined && value.length > 0 ? value : undefined;
+}
+
+function sameJson(a: unknown, b: unknown): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/cimnotebook/vscode/src/sidebar/treeItems.test.ts
+++ b/cimnotebook/vscode/src/sidebar/treeItems.test.ts
@@ -1,0 +1,155 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    connectionContextValue,
+    connectionDescription,
+    connectionIcon,
+    connectionLabel,
+    effectiveStandardVocabulary,
+    numberSettingDescription,
+    schemasDirectoryDescription,
+    standardVocabularyDescription,
+    standardVocabularyValueToWrite,
+    strictnessDescription,
+    strictnessValueToWrite,
+    validateConnectionName,
+    validateOptionalUrl,
+    validatePositiveIntegerOrEmpty,
+    validateRequiredUrl,
+} from "./treeItems";
+
+describe("connection label/description/icon/contextValue", () => {
+    it("plain connection", () => {
+        const c = { name: "local", url: "http://localhost:3030/ds/query" };
+        assert.equal(connectionLabel(c), "local");
+        assert.equal(connectionDescription(c), "http://localhost:3030/ds/query");
+        assert.equal(connectionIcon(c), "plug");
+        assert.equal(connectionContextValue(c), "connection");
+    });
+
+    it("default connection with basic auth", () => {
+        const c = {
+            name: "prod",
+            url: "https://h/query",
+            authType: "basic" as const,
+            default: true,
+        };
+        // Plain words, no $(...) codicons: TreeItem.description renders literal text.
+        assert.equal(connectionDescription(c), "https://h/query · basic auth · default");
+        assert.equal(connectionIcon(c), "star-full");
+        assert.equal(connectionContextValue(c), "connection basic default");
+    });
+});
+
+describe("validateConnectionName", () => {
+    it("rejects empty names", () => {
+        assert.match(validateConnectionName("  ", []) ?? "", /Enter a connection name/);
+    });
+
+    it("rejects names that look like file paths or URLs", () => {
+        assert.match(validateConnectionName("a.b", []) ?? "", /can't contain/);
+        assert.match(validateConnectionName("a/b", []) ?? "", /can't contain/);
+        assert.match(validateConnectionName("a\\b", []) ?? "", /can't contain/);
+        assert.match(validateConnectionName("http://h/query", []) ?? "", /can't contain/);
+    });
+
+    it("rejects names with whitespace (directives end at the first space)", () => {
+        assert.match(validateConnectionName("my conn", []) ?? "", /whitespace/);
+    });
+
+    it("rejects duplicates but allows keeping the current name while editing", () => {
+        assert.match(validateConnectionName("prod", ["prod", "dev"]) ?? "", /already used/);
+        assert.equal(validateConnectionName("prod", ["prod", "dev"], "prod"), undefined);
+    });
+
+    it("accepts a fresh, valid name", () => {
+        assert.equal(validateConnectionName("local-fuseki", ["prod"]), undefined);
+    });
+});
+
+describe("validateRequiredUrl / validateOptionalUrl", () => {
+    it("required: rejects empty and non-http(s) values", () => {
+        assert.ok(validateRequiredUrl(""));
+        assert.ok(validateRequiredUrl("ftp://h/x"));
+        assert.equal(validateRequiredUrl("http://h/query"), undefined);
+        assert.equal(validateRequiredUrl("https://h/query"), undefined);
+    });
+
+    it("optional: accepts empty, still validates non-empty values", () => {
+        assert.equal(validateOptionalUrl(""), undefined);
+        assert.equal(validateOptionalUrl("   "), undefined);
+        assert.equal(validateOptionalUrl("https://h/update"), undefined);
+        assert.ok(validateOptionalUrl("not-a-url"));
+    });
+});
+
+describe("strictness / standardVocabulary description and write-value mapping", () => {
+    it("strictness shows the effective value, unset reads as its own 'default' level", () => {
+        assert.equal(strictnessDescription(undefined), "default");
+        assert.equal(strictnessDescription(""), "default");
+        assert.equal(strictnessDescription("strict"), "strict");
+    });
+
+    it("standardVocabulary annotates the implicit default", () => {
+        assert.equal(standardVocabularyDescription(undefined), "check (default)");
+        assert.equal(standardVocabularyDescription("ignore"), "ignore");
+        assert.equal(effectiveStandardVocabulary(undefined), "check");
+        assert.equal(effectiveStandardVocabulary("ignore"), "ignore");
+    });
+
+    it("schemasDirectory unset means the listed schema files alone, or syntax-only with none", () => {
+        assert.equal(
+            schemasDirectoryDescription(undefined, 0),
+            "not set (validation is syntax-only)",
+        );
+        assert.equal(schemasDirectoryDescription("", 0), "not set (validation is syntax-only)");
+        assert.equal(
+            schemasDirectoryDescription(undefined, 2),
+            "not set (schema files below are used)",
+        );
+        assert.equal(schemasDirectoryDescription("profiles", 0), "profiles");
+    });
+
+    it("picking the schema-default value clears the field; anything else is written", () => {
+        assert.equal(strictnessValueToWrite("default"), undefined);
+        assert.equal(strictnessValueToWrite("strict"), "strict");
+        assert.equal(standardVocabularyValueToWrite("check"), undefined);
+        assert.equal(standardVocabularyValueToWrite("ignore"), "ignore");
+    });
+});
+
+describe("numberSettingDescription / validatePositiveIntegerOrEmpty", () => {
+    it("shows the value, or the default annotated when unset", () => {
+        assert.equal(numberSettingDescription(45, 30), "45");
+        assert.equal(numberSettingDescription(undefined, 30), "30 (default)");
+    });
+
+    it("accepts empty (clears) and positive integers; rejects everything else", () => {
+        assert.equal(validatePositiveIntegerOrEmpty(""), undefined);
+        assert.equal(validatePositiveIntegerOrEmpty("  "), undefined);
+        assert.equal(validatePositiveIntegerOrEmpty("42"), undefined);
+        assert.ok(validatePositiveIntegerOrEmpty("0"));
+        assert.ok(validatePositiveIntegerOrEmpty("-1"));
+        assert.ok(validatePositiveIntegerOrEmpty("abc"));
+        assert.ok(validatePositiveIntegerOrEmpty("4.5"));
+    });
+});

--- a/cimnotebook/vscode/src/sidebar/treeItems.ts
+++ b/cimnotebook/vscode/src/sidebar/treeItems.ts
@@ -1,0 +1,194 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure label/description builders and field validators for the three configuration tree
+ * views (`treeViews.ts`). Kept dependency-free of `vscode` — unlike the tree providers
+ * themselves, which build `vscode.TreeItem`s and register commands — so this is the part
+ * that gets node tests, mirroring `endpoint.ts` next to `endpointCommands.ts`.
+ */
+
+import { classifyDirective } from "../notebook/endpoint";
+import { ConnectionModel } from "./configModel";
+
+// ---- connections --------------------------------------------------------------------------
+
+export function connectionLabel(connection: ConnectionModel): string {
+    return connection.name;
+}
+
+/**
+ * URL plus "· basic auth" / "· default" markers. Plain words, not `$(...)` codicons —
+ * `TreeItem.description` is rendered as literal text, unlike QuickPick labels.
+ */
+export function connectionDescription(connection: ConnectionModel): string {
+    const parts = [connection.url];
+    if (connection.authType === "basic") {
+        parts.push("· basic auth");
+    }
+    if (connection.default) {
+        parts.push("· default");
+    }
+    return parts.join(" ");
+}
+
+export function connectionIcon(connection: ConnectionModel): string {
+    return connection.default ? "star-full" : "plug";
+}
+
+/**
+ * Space-separated facets for the item's `contextValue`, matched by `viewItem =~ /.../ `
+ * `when` clauses in `package.json` (e.g. gating the credentials action to basic auth).
+ */
+export function connectionContextValue(connection: ConnectionModel): string {
+    const parts = ["connection"];
+    if (connection.authType === "basic") {
+        parts.push("basic");
+    }
+    if (connection.default) {
+        parts.push("default");
+    }
+    return parts.join(" ");
+}
+
+/**
+ * A connection name must be non-empty, contain no whitespace (names are written into
+ * `# [endpoint=...]` directives, whose value ends at the first whitespace), classify as
+ * a *name* under `classifyDirective` in `endpoint.ts` (no `.`/`/`/`\`, not a URL — the
+ * single source of truth for how a directive is read), and be unique among the other
+ * connections. `currentName` excludes the connection being edited from the uniqueness
+ * check.
+ */
+export function validateConnectionName(
+    name: string,
+    existingNames: string[],
+    currentName?: string,
+): string | undefined {
+    const trimmed = name.trim();
+    if (trimmed === "") {
+        return "Enter a connection name.";
+    }
+    if (/\s/.test(trimmed)) {
+        return "Connection names can't contain whitespace (they're used in # [endpoint=…] directives).";
+    }
+    if (classifyDirective(trimmed) !== "name") {
+        return "Connection names can't contain '.', '/', or '\\' (that would look like a file path).";
+    }
+    if (existingNames.some((existing) => existing !== currentName && existing === trimmed)) {
+        return `"${trimmed}" is already used by another connection.`;
+    }
+    return undefined;
+}
+
+const HTTP_URL = /^https?:\/\/\S+$/i;
+
+export function validateRequiredUrl(url: string): string | undefined {
+    return HTTP_URL.test(url.trim()) ? undefined : "Enter an http(s):// URL.";
+}
+
+/** Empty is allowed (the field is optional and gets derived); anything else must be a URL. */
+export function validateOptionalUrl(url: string): string | undefined {
+    const trimmed = url.trim();
+    if (trimmed === "") {
+        return undefined;
+    }
+    return HTTP_URL.test(trimmed) ? undefined : "Enter an http(s):// URL, or leave empty.";
+}
+
+// ---- validation section --------------------------------------------------------------------
+
+export interface LevelOption {
+    value: string;
+    detail: string;
+}
+
+/** The `cimvocabcheck.strictness` levels, in the schema's declared order. */
+export const STRICTNESS_LEVELS: LevelOption[] = [
+    {
+        value: "permissive",
+        detail: "Only unknown-term and syntax errors; semantic checks and hints are suppressed.",
+    },
+    { value: "default", detail: "All checks, original severities. Only errors fail validation." },
+    { value: "strict", detail: "All checks; warnings are promoted to errors." },
+    { value: "pedantic", detail: "All checks; warnings and hints are promoted to errors." },
+];
+
+/** The `cimvocabcheck.standardVocabulary` modes. */
+export const STANDARD_VOCABULARY_OPTIONS: LevelOption[] = [
+    { value: "check", detail: "Typos in rdf/rdfs/owl/sh terms are reported as errors." },
+    { value: "ignore", detail: "Terms in these namespaces are accepted without inspection." },
+];
+
+/** Effective strictness: the config's own default value doubles as the "unset" display. */
+export function strictnessDescription(value: string | undefined): string {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : "default";
+}
+
+/** The effective mode ("check" when unset), without the "(default)" annotation. */
+export function effectiveStandardVocabulary(value: string | undefined): string {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : "check";
+}
+
+export function standardVocabularyDescription(value: string | undefined): string {
+    const effective = effectiveStandardVocabulary(value);
+    return value?.trim() ? effective : `${effective} (default)`;
+}
+
+/**
+ * There is no bundled default schema and no implicit directory: with the directory unset,
+ * validation runs on the listed schema files alone — or syntax-only when there are none.
+ */
+export function schemasDirectoryDescription(
+    value: string | undefined,
+    schemaFileCount: number,
+): string {
+    const trimmed = value?.trim();
+    if (trimmed) {
+        return trimmed;
+    }
+    return schemaFileCount > 0
+        ? "not set (schema files below are used)"
+        : "not set (validation is syntax-only)";
+}
+
+/** Selecting the schema's own default value clears the field, keeping the file minimal. */
+export function strictnessValueToWrite(picked: string): string | undefined {
+    return picked === "default" ? undefined : picked;
+}
+
+export function standardVocabularyValueToWrite(picked: string): string | undefined {
+    return picked === "check" ? undefined : picked;
+}
+
+// ---- execution section ---------------------------------------------------------------------
+
+export function numberSettingDescription(value: number | undefined, defaultValue: number): string {
+    return value !== undefined ? String(value) : `${defaultValue} (default)`;
+}
+
+/** `showInputBox` validator for the integer notebook settings (empty clears the field). */
+export function validatePositiveIntegerOrEmpty(input: string): string | undefined {
+    if (input.trim() === "") {
+        return undefined;
+    }
+    return /^\d+$/.test(input.trim()) && Number(input.trim()) > 0
+        ? undefined
+        : "Enter a positive whole number, or leave empty to reset to the default.";
+}

--- a/cimnotebook/vscode/src/sidebar/treeViews.ts
+++ b/cimnotebook/vscode/src/sidebar/treeViews.ts
@@ -1,0 +1,710 @@
+/*
+ *    Copyright (c) 2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The three native configuration tree views (replacing the M6 webview form): one
+ * collapsible section each for connections, validation settings, and notebook execution
+ * settings, all editing the workspace's `opencgmes.jsonc` through {@link updateConfig}.
+ *
+ * Each provider reads the config once per refresh in `getChildren` and embeds everything
+ * an item needs into its node, so `getTreeItem` is synchronous — no per-item re-reads.
+ * Every mutating command resolves the config once up front (`readConfig`) and threads
+ * that target into `updateConfig`, so a focus change during a wizard can't redirect the
+ * write; the file text itself is still re-read at write time, so concurrent hand-edits
+ * are never clobbered by a stale in-memory copy. Connection and schema-file nodes carry
+ * their list *index*, so rows with duplicate names/paths affect exactly the clicked
+ * entry.
+ *
+ * Item labels/descriptions and field validation are pure helpers in `treeItems.ts`; this
+ * file is the thin `vscode.TreeDataProvider` wiring plus the command handlers (wizards,
+ * QuickPicks) that drive them.
+ */
+
+import * as vscode from "vscode";
+
+import { ConnectionStore } from "../notebook/connections";
+import { clearCredentials, setCredentials } from "../notebook/credentials";
+import { pickWorkspaceFiles, pickWorkspaceFolder } from "../notebook/filePicker";
+import { ConnectionModel } from "./configModel";
+import { openConfig, readConfig, targetConfig, updateConfig } from "./configEditor";
+import {
+    connectionContextValue,
+    connectionDescription,
+    connectionIcon,
+    connectionLabel,
+    effectiveStandardVocabulary,
+    numberSettingDescription,
+    schemasDirectoryDescription,
+    standardVocabularyDescription,
+    standardVocabularyValueToWrite,
+    STANDARD_VOCABULARY_OPTIONS,
+    strictnessDescription,
+    strictnessValueToWrite,
+    STRICTNESS_LEVELS,
+    validateConnectionName,
+    validateOptionalUrl,
+    validatePositiveIntegerOrEmpty,
+    validateRequiredUrl,
+} from "./treeItems";
+
+export const CONNECTIONS_VIEW_ID = "cimnotebook.connectionsView";
+export const VALIDATION_VIEW_ID = "cimnotebook.validationView";
+export const EXECUTION_VIEW_ID = "cimnotebook.executionView";
+
+const HAS_CONFIG_CONTEXT = "cimnotebook.hasConfig";
+
+const DEFAULT_QUERY_TIMEOUT_SECONDS = 30;
+const DEFAULT_MAX_ROWS = 10_000;
+
+const ADD_CONNECTION_COMMAND = "cimnotebook.connections.add";
+const EDIT_CONNECTION_COMMAND = "cimnotebook.connections.edit";
+const REMOVE_CONNECTION_COMMAND = "cimnotebook.connections.remove";
+const TOGGLE_DEFAULT_CONNECTION_COMMAND = "cimnotebook.connections.toggleDefault";
+const CONNECTION_CREDENTIALS_COMMAND = "cimnotebook.connections.credentials";
+const OPEN_CONFIG_COMMAND = "cimnotebook.config.openFile";
+const EDIT_STRICTNESS_COMMAND = "cimnotebook.config.editStrictness";
+const EDIT_STANDARD_VOCABULARY_COMMAND = "cimnotebook.config.editStandardVocabulary";
+const EDIT_SCHEMAS_DIRECTORY_COMMAND = "cimnotebook.config.editSchemasDirectory";
+const ADD_SCHEMA_FILE_COMMAND = "cimnotebook.config.addSchemaFile";
+const REMOVE_SCHEMA_FILE_COMMAND = "cimnotebook.config.removeSchemaFile";
+const EDIT_QUERY_TIMEOUT_COMMAND = "cimnotebook.config.editQueryTimeout";
+const EDIT_MAX_ROWS_COMMAND = "cimnotebook.config.editMaxRows";
+
+export function registerConfigTreeViews(
+    context: vscode.ExtensionContext,
+    store: ConnectionStore,
+): void {
+    const refreshEmitter = new vscode.EventEmitter<void>();
+    context.subscriptions.push(refreshEmitter);
+
+    // createTreeView (not registerTreeDataProvider) for the top section so the resolved
+    // config file can be surfaced as the view description — the sections follow the
+    // active document's nearest config, and the user should see which file they edit.
+    const connectionsView = vscode.window.createTreeView(CONNECTIONS_VIEW_ID, {
+        treeDataProvider: new ConnectionsProvider(refreshEmitter.event),
+    });
+    context.subscriptions.push(
+        connectionsView,
+        vscode.window.registerTreeDataProvider(
+            VALIDATION_VIEW_ID,
+            new ValidationProvider(refreshEmitter.event),
+        ),
+        vscode.window.registerTreeDataProvider(
+            EXECUTION_VIEW_ID,
+            new ExecutionProvider(refreshEmitter.event),
+        ),
+    );
+
+    const refresh = async (): Promise<void> => {
+        refreshEmitter.fire();
+        const target = await targetConfig();
+        connectionsView.description = target.exists
+            ? vscode.workspace.asRelativePath(target.uri)
+            : undefined;
+        await vscode.commands.executeCommand("setContext", HAS_CONFIG_CONTEXT, target.exists);
+    };
+    context.subscriptions.push(
+        store.onDidChange(() => void refresh()),
+        vscode.window.onDidChangeActiveTextEditor(() => void refresh()),
+        vscode.window.onDidChangeActiveNotebookEditor(() => void refresh()),
+    );
+    void refresh();
+
+    registerCommands(context, refresh);
+}
+
+// ---- tree data providers --------------------------------------------------------------------
+
+/** A connection row: the rendered entry plus its position in `connections` at render time. */
+interface ConnectionNode {
+    connection: ConnectionModel;
+    index: number;
+}
+
+class ConnectionsProvider implements vscode.TreeDataProvider<ConnectionNode> {
+    constructor(readonly onDidChangeTreeData: vscode.Event<void>) {}
+
+    async getChildren(node?: ConnectionNode): Promise<ConnectionNode[]> {
+        if (node) {
+            return [];
+        }
+        const { model } = await readConfig();
+        return (model.connections ?? []).map((connection, index) => ({ connection, index }));
+    }
+
+    getTreeItem(node: ConnectionNode): vscode.TreeItem {
+        const item = new vscode.TreeItem(
+            connectionLabel(node.connection),
+            vscode.TreeItemCollapsibleState.None,
+        );
+        item.description = connectionDescription(node.connection);
+        item.iconPath = new vscode.ThemeIcon(connectionIcon(node.connection));
+        item.contextValue = connectionContextValue(node.connection);
+        item.command = {
+            title: "Edit Connection",
+            command: EDIT_CONNECTION_COMMAND,
+            arguments: [node],
+        };
+        return item;
+    }
+}
+
+interface SchemaFileNode {
+    kind: "schemaFile";
+    file: string;
+    /** Position in `schemas` at render time — removal targets exactly this occurrence. */
+    index: number;
+    openUri: vscode.Uri;
+}
+
+type ValidationNode =
+    | { kind: "strictness"; description: string }
+    | { kind: "standardVocabulary"; description: string }
+    | { kind: "schemasDirectory"; description: string }
+    | { kind: "schemasParent"; files: SchemaFileNode[] }
+    | SchemaFileNode;
+
+class ValidationProvider implements vscode.TreeDataProvider<ValidationNode> {
+    constructor(readonly onDidChangeTreeData: vscode.Event<void>) {}
+
+    async getChildren(node?: ValidationNode): Promise<ValidationNode[]> {
+        if (node) {
+            return node.kind === "schemasParent" ? node.files : [];
+        }
+        const { model, uri, exists } = await readConfig();
+        if (!exists) {
+            // Empty tree → the view's viewsWelcome "Create Config File" prompt shows
+            // instead of rows whose first edit would silently create a bare config.
+            return [];
+        }
+        const files = (model.schemas ?? []).map((file, index): SchemaFileNode => ({
+            kind: "schemaFile",
+            file,
+            index,
+            openUri: vscode.Uri.joinPath(uri, "..", file),
+        }));
+        return [
+            { kind: "strictness", description: strictnessDescription(model.strictness) },
+            {
+                kind: "standardVocabulary",
+                description: standardVocabularyDescription(model.standardVocabulary),
+            },
+            {
+                kind: "schemasDirectory",
+                description: schemasDirectoryDescription(model.schemasDirectory, files.length),
+            },
+            { kind: "schemasParent", files },
+        ];
+    }
+
+    getTreeItem(node: ValidationNode): vscode.TreeItem {
+        switch (node.kind) {
+            case "strictness":
+                return leaf("Strictness", node.description, {
+                    command: EDIT_STRICTNESS_COMMAND,
+                    contextValue: "strictness",
+                    icon: "settings-gear",
+                });
+            case "standardVocabulary":
+                return leaf("Standard vocabulary check", node.description, {
+                    command: EDIT_STANDARD_VOCABULARY_COMMAND,
+                    contextValue: "standardVocabulary",
+                    icon: "settings-gear",
+                });
+            case "schemasDirectory":
+                return leaf("Schemas directory", node.description, {
+                    command: EDIT_SCHEMAS_DIRECTORY_COMMAND,
+                    contextValue: "schemasDirectory",
+                    icon: "folder",
+                });
+            case "schemasParent": {
+                const item = new vscode.TreeItem(
+                    "Schema files",
+                    vscode.TreeItemCollapsibleState.Expanded,
+                );
+                item.contextValue = "schemasParent";
+                return item;
+            }
+            case "schemaFile": {
+                const item = new vscode.TreeItem(node.file, vscode.TreeItemCollapsibleState.None);
+                item.iconPath = new vscode.ThemeIcon("file");
+                item.contextValue = "schemaFile";
+                item.command = {
+                    title: "Open Schema File",
+                    command: "vscode.open",
+                    arguments: [node.openUri],
+                };
+                return item;
+            }
+        }
+    }
+}
+
+type ExecutionNode = { kind: "queryTimeoutSeconds" | "maxRows"; description: string };
+
+class ExecutionProvider implements vscode.TreeDataProvider<ExecutionNode> {
+    constructor(readonly onDidChangeTreeData: vscode.Event<void>) {}
+
+    async getChildren(node?: ExecutionNode): Promise<ExecutionNode[]> {
+        if (node) {
+            return [];
+        }
+        const { model, exists } = await readConfig();
+        if (!exists) {
+            return [];
+        }
+        return [
+            {
+                kind: "queryTimeoutSeconds",
+                description: numberSettingDescription(
+                    model.queryTimeoutSeconds,
+                    DEFAULT_QUERY_TIMEOUT_SECONDS,
+                ),
+            },
+            {
+                kind: "maxRows",
+                description: numberSettingDescription(model.maxRows, DEFAULT_MAX_ROWS),
+            },
+        ];
+    }
+
+    getTreeItem(node: ExecutionNode): vscode.TreeItem {
+        if (node.kind === "queryTimeoutSeconds") {
+            return leaf("Query timeout (seconds)", node.description, {
+                command: EDIT_QUERY_TIMEOUT_COMMAND,
+                contextValue: "queryTimeoutSeconds",
+            });
+        }
+        return leaf("Max rows / triples", node.description, {
+            command: EDIT_MAX_ROWS_COMMAND,
+            contextValue: "maxRows",
+        });
+    }
+}
+
+function leaf(
+    label: string,
+    description: string,
+    options: { command: string; contextValue: string; icon?: string },
+): vscode.TreeItem {
+    const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
+    item.description = description;
+    item.contextValue = options.contextValue;
+    if (options.icon) {
+        item.iconPath = new vscode.ThemeIcon(options.icon);
+    }
+    item.command = { title: "Edit", command: options.command };
+    return item;
+}
+
+// ---- commands --------------------------------------------------------------------------------
+
+function registerCommands(context: vscode.ExtensionContext, refresh: () => Promise<void>): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(ADD_CONNECTION_COMMAND, () =>
+            addConnection().then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_CONNECTION_COMMAND, (n?: ConnectionNode) =>
+            editConnection(n).then(refresh),
+        ),
+        vscode.commands.registerCommand(REMOVE_CONNECTION_COMMAND, (n?: ConnectionNode) =>
+            removeConnection(n).then(refresh),
+        ),
+        vscode.commands.registerCommand(TOGGLE_DEFAULT_CONNECTION_COMMAND, (n?: ConnectionNode) =>
+            toggleDefaultConnection(n).then(refresh),
+        ),
+        vscode.commands.registerCommand(CONNECTION_CREDENTIALS_COMMAND, (n?: ConnectionNode) =>
+            manageConnectionCredentials(context, n),
+        ),
+        vscode.commands.registerCommand(OPEN_CONFIG_COMMAND, () => openConfig()),
+        vscode.commands.registerCommand(EDIT_STRICTNESS_COMMAND, () =>
+            editStrictness().then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_STANDARD_VOCABULARY_COMMAND, () =>
+            editStandardVocabulary().then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_SCHEMAS_DIRECTORY_COMMAND, () =>
+            editSchemasDirectory().then(refresh),
+        ),
+        vscode.commands.registerCommand(ADD_SCHEMA_FILE_COMMAND, () =>
+            addSchemaFile().then(refresh),
+        ),
+        vscode.commands.registerCommand(REMOVE_SCHEMA_FILE_COMMAND, (n?: SchemaFileNode) =>
+            removeSchemaFile(n).then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_QUERY_TIMEOUT_COMMAND, () =>
+            editQueryTimeout().then(refresh),
+        ),
+        vscode.commands.registerCommand(EDIT_MAX_ROWS_COMMAND, () => editMaxRows().then(refresh)),
+    );
+}
+
+// ---- connections ---------------------------------------------------------------------------
+
+async function runConnectionWizard(
+    existingNames: string[],
+    prefill?: ConnectionModel,
+): Promise<ConnectionModel | undefined> {
+    const name = await vscode.window.showInputBox({
+        title: prefill ? `Edit connection "${prefill.name}" — name` : "New connection — name",
+        value: prefill?.name ?? "",
+        placeHolder: "local-fuseki",
+        validateInput: (v) => validateConnectionName(v, existingNames, prefill?.name),
+    });
+    if (name === undefined) {
+        return undefined;
+    }
+
+    const url = await vscode.window.showInputBox({
+        title: "Query URL",
+        value: prefill?.url ?? "",
+        placeHolder: "http://localhost:3030/ds/query",
+        validateInput: validateRequiredUrl,
+    });
+    if (url === undefined) {
+        return undefined;
+    }
+
+    const updateUrl = await vscode.window.showInputBox({
+        title: "Update URL (optional — derived from the query URL when empty)",
+        value: prefill?.updateUrl ?? "",
+        validateInput: validateOptionalUrl,
+    });
+    if (updateUrl === undefined) {
+        return undefined;
+    }
+
+    const shaclUrl = await vscode.window.showInputBox({
+        title: "SHACL URL (optional — derived from the query URL when empty)",
+        value: prefill?.shaclUrl ?? "",
+        validateInput: validateOptionalUrl,
+    });
+    if (shaclUrl === undefined) {
+        return undefined;
+    }
+
+    const authOptions =
+        prefill?.authType === "basic" ? ["Basic auth", "None"] : ["None", "Basic auth"];
+    const authPick = await vscode.window.showQuickPick(authOptions, { title: "Authentication" });
+    if (authPick === undefined) {
+        return undefined;
+    }
+
+    const defaultOptions = prefill?.default ? ["Yes", "No"] : ["No", "Yes"];
+    const defaultPick = await vscode.window.showQuickPick(defaultOptions, {
+        title: "Set as the workspace default connection?",
+    });
+    if (defaultPick === undefined) {
+        return undefined;
+    }
+
+    return {
+        name: name.trim(),
+        url: url.trim(),
+        updateUrl: updateUrl.trim() || undefined,
+        shaclUrl: shaclUrl.trim() || undefined,
+        authType: authPick === "Basic auth" ? "basic" : undefined,
+        default: defaultPick === "Yes" ? true : undefined,
+    };
+}
+
+/**
+ * The clicked row's position in the (possibly changed) list: its render-time index when
+ * the entry there still matches, else the first name match. Duplicate names — legal in a
+ * hand-edited file — thus affect exactly the clicked entry, not every namesake.
+ */
+function connectionIndex(list: ConnectionModel[], node: ConnectionNode): number {
+    if (list[node.index]?.name === node.connection.name) {
+        return node.index;
+    }
+    return list.findIndex((c) => c.name === node.connection.name);
+}
+
+/** Makes `index` the single default connection; every other entry loses the flag. */
+function makeSingleDefault(list: ConnectionModel[], index: number): void {
+    list.forEach((c, i) => {
+        c.default = i === index ? true : undefined;
+    });
+}
+
+async function addConnection(): Promise<void> {
+    const state = await readConfig();
+    const existingNames = (state.model.connections ?? []).map((c) => c.name);
+    const connection = await runConnectionWizard(existingNames);
+    if (!connection) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        const list = [...(m.connections ?? [])];
+        list.push(connection);
+        if (connection.default) {
+            makeSingleDefault(list, list.length - 1);
+        }
+        m.connections = list;
+    });
+}
+
+async function editConnection(node?: ConnectionNode): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const state = await readConfig();
+    const existingNames = (state.model.connections ?? []).map((c) => c.name);
+    const updated = await runConnectionWizard(existingNames, node.connection);
+    if (!updated) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        const list = [...(m.connections ?? [])];
+        const index = connectionIndex(list, node);
+        if (index === -1) {
+            return;
+        }
+        list[index] = updated;
+        if (updated.default) {
+            makeSingleDefault(list, index);
+        }
+        m.connections = list;
+    });
+}
+
+async function removeConnection(node?: ConnectionNode): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const confirm = await vscode.window.showWarningMessage(
+        `Remove connection "${node.connection.name}"?`,
+        { modal: true },
+        "Remove",
+    );
+    if (confirm !== "Remove") {
+        return;
+    }
+    const state = await readConfig();
+    await updateConfig(state, (m) => {
+        const list = [...(m.connections ?? [])];
+        const index = connectionIndex(list, node);
+        if (index !== -1) {
+            list.splice(index, 1);
+        }
+        m.connections = list;
+    });
+}
+
+async function toggleDefaultConnection(node?: ConnectionNode): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const makeDefault = !node.connection.default;
+    const state = await readConfig();
+    await updateConfig(state, (m) => {
+        const list = [...(m.connections ?? [])];
+        const index = connectionIndex(list, node);
+        if (index === -1) {
+            return;
+        }
+        if (makeDefault) {
+            makeSingleDefault(list, index);
+        } else {
+            list[index].default = undefined;
+        }
+        m.connections = list;
+    });
+}
+
+async function manageConnectionCredentials(
+    context: vscode.ExtensionContext,
+    node?: ConnectionNode,
+): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const name = node.connection.name;
+    const action = await vscode.window.showQuickPick(["Set credentials", "Clear credentials"], {
+        title: `Credentials for "${name}"`,
+    });
+    if (action === "Set credentials") {
+        if (await setCredentials(context.secrets, name)) {
+            vscode.window.showInformationMessage(
+                `CIMNotebook: credentials for "${name}" stored in VS Code secret storage.`,
+            );
+        }
+    } else if (action === "Clear credentials") {
+        await clearCredentials(context.secrets, name);
+        vscode.window.showInformationMessage(`CIMNotebook: credentials for "${name}" cleared.`);
+    }
+}
+
+// ---- validation section ----------------------------------------------------------------------
+
+async function editStrictness(): Promise<void> {
+    const state = await readConfig();
+    const current = strictnessDescription(state.model.strictness);
+    const items = STRICTNESS_LEVELS.map((level) => ({
+        label: level.value,
+        description: level.value === current ? "Current" : undefined,
+        detail: level.detail,
+    }));
+    const pick = await vscode.window.showQuickPick(items, { title: "Strictness" });
+    if (!pick) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        m.strictness = strictnessValueToWrite(pick.label);
+    });
+}
+
+async function editStandardVocabulary(): Promise<void> {
+    const state = await readConfig();
+    const current = effectiveStandardVocabulary(state.model.standardVocabulary);
+    const items = STANDARD_VOCABULARY_OPTIONS.map((option) => ({
+        label: option.value,
+        description: option.value === current ? "Current" : undefined,
+        detail: option.detail,
+    }));
+    const pick = await vscode.window.showQuickPick(items, { title: "Standard vocabulary check" });
+    if (!pick) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        m.standardVocabulary = standardVocabularyValueToWrite(pick.label);
+    });
+}
+
+async function editSchemasDirectory(): Promise<void> {
+    const state = await readConfig();
+    const configDir = vscode.Uri.joinPath(state.uri, "..");
+    const choice = await vscode.window.showQuickPick(
+        [
+            { label: "$(folder-opened) Browse for a folder…", action: "browse" as const },
+            {
+                label: "$(discard) Clear (no schemas directory)",
+                action: "clear" as const,
+            },
+            { label: "$(edit) Type a path…", action: "type" as const },
+        ],
+        { title: "Schemas directory" },
+    );
+    if (!choice) {
+        return;
+    }
+    let value: string | undefined;
+    if (choice.action === "browse") {
+        value = await pickWorkspaceFolder({ baseUri: configDir, title: "Schemas directory" });
+        if (value === undefined) {
+            return;
+        }
+    } else if (choice.action === "type") {
+        const typed = await vscode.window.showInputBox({
+            title: "Schemas directory (relative to the config file)",
+            value: state.model.schemasDirectory ?? "",
+            placeHolder: "./schemas",
+        });
+        if (typed === undefined) {
+            return;
+        }
+        value = typed;
+    } else {
+        value = "";
+    }
+    await updateConfig(state, (m) => {
+        m.schemasDirectory = value?.trim() ? value.trim() : undefined;
+    });
+}
+
+/** `./schemas/x.rdf` and `schemas/x.rdf` resolve to the same file — compare without `./`. */
+function canonicalPath(p: string): string {
+    return p.startsWith("./") ? p.slice(2) : p;
+}
+
+async function addSchemaFile(): Promise<void> {
+    const state = await readConfig();
+    const configDir = vscode.Uri.joinPath(state.uri, "..");
+    const picked = await pickWorkspaceFiles({
+        pattern: "**/*.{rdf,ttl,owl}",
+        baseUri: configDir,
+        title: "Add schema file(s)",
+        canPickMany: true,
+    });
+    if (!picked || picked.length === 0) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        const merged = [...(m.schemas ?? [])];
+        const seen = new Set(merged.map(canonicalPath));
+        for (const file of picked) {
+            if (!seen.has(canonicalPath(file))) {
+                merged.push(file);
+                seen.add(canonicalPath(file));
+            }
+        }
+        m.schemas = merged;
+    });
+}
+
+async function removeSchemaFile(node?: SchemaFileNode): Promise<void> {
+    if (!node) {
+        return;
+    }
+    const state = await readConfig();
+    await updateConfig(state, (m) => {
+        const list = [...(m.schemas ?? [])];
+        // The render-time index when that entry is unchanged, else the first value match —
+        // duplicates are removed one occurrence at a time.
+        const index = list[node.index] === node.file ? node.index : list.indexOf(node.file);
+        if (index !== -1) {
+            list.splice(index, 1);
+        }
+        m.schemas = list;
+    });
+}
+
+// ---- execution section ------------------------------------------------------------------------
+
+async function editQueryTimeout(): Promise<void> {
+    const state = await readConfig();
+    const input = await vscode.window.showInputBox({
+        title: `Query timeout, in seconds (empty resets to the default: ${DEFAULT_QUERY_TIMEOUT_SECONDS})`,
+        value:
+            state.model.queryTimeoutSeconds !== undefined
+                ? String(state.model.queryTimeoutSeconds)
+                : "",
+        validateInput: validatePositiveIntegerOrEmpty,
+    });
+    if (input === undefined) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        m.queryTimeoutSeconds = input.trim() ? Number(input.trim()) : undefined;
+    });
+}
+
+async function editMaxRows(): Promise<void> {
+    const state = await readConfig();
+    const input = await vscode.window.showInputBox({
+        title: `Max rows / triples (empty resets to the default: ${DEFAULT_MAX_ROWS})`,
+        value: state.model.maxRows !== undefined ? String(state.model.maxRows) : "",
+        validateInput: validatePositiveIntegerOrEmpty,
+    });
+    if (input === undefined) {
+        return;
+    }
+    await updateConfig(state, (m) => {
+        m.maxRows = input.trim() ? Number(input.trim()) : undefined;
+    });
+}

--- a/cimnotebook/vscode/tsconfig.test.json
+++ b/cimnotebook/vscode/tsconfig.test.json
@@ -14,6 +14,10 @@
         "src/notebook/sparqlbook.ts",
         "src/notebook/endpoint.ts",
         "src/notebook/outputs.ts",
-        "src/notebook/*.test.ts"
+        "src/notebook/relativizePath.ts",
+        "src/notebook/*.test.ts",
+        "src/sidebar/configModel.ts",
+        "src/sidebar/treeItems.ts",
+        "src/sidebar/*.test.ts"
     ]
 }

--- a/docs/content/cimnotebook/notebooks.md
+++ b/docs/content/cimnotebook/notebooks.md
@@ -215,12 +215,18 @@ SELECT * WHERE { ?s ?p ?o } LIMIT 10
 
 A connection name has no slashes and no dots — that's how it is told apart from a file
 path. `updateUrl`/`shaclUrl` are optional and derived from `url` when omitted.
+Connections (and the rest of the config) can also be edited in the **CIMNotebook
+sidebar** — see [Configuration sidebar](/cimnotebook/vscode#configuration-sidebar).
 
 Every cell shows its resolved target in the **cell status bar** (`local-fuseki`, a URL,
 `model.xml (+1)`, or a _no endpoint_ warning); clicking it — or running **CIMNotebook:
-Set Cell Endpoint…** — picks a connection, URL, or file and either writes the
-`# [endpoint=…]` directive into the cell (the portable, versioned form) or remembers it
-as the notebook's default without touching the file.
+Set Cell Endpoint…** — picks a connection, a URL (with a small recent-URLs history above
+the input box), or one or more data files via fuzzy, search-as-you-type matching over the
+workspace (with **Browse…** for files outside it and **Enter path manually…** for a file
+that doesn't exist yet). Picking several files writes one `# [endpoint=...]` directive
+per file — the same union target described above. One constraint inherited from the
+directive syntax: a path containing spaces cannot be referenced (the directive value ends
+at the first whitespace character).
 
 ### Where a cell without a directive runs
 

--- a/docs/content/cimnotebook/vscode.md
+++ b/docs/content/cimnotebook/vscode.md
@@ -103,6 +103,23 @@ status-bar button and **CIMNotebook: Set Cell Endpoint…** pick the target, and
 **CIMNotebook: Set/Clear Connection Credentials…** manage basic-auth secrets. See
 [CIM Notebooks](/cimnotebook/notebooks).
 
+### Configuration sidebar
+
+The **CIMNotebook** icon in the activity bar opens three native, collapsible sections for
+the workspace's [`opencgmes.jsonc`](/cimvocabcheck/configuration): **Connections**,
+**Validation** (strictness, standard-vocabulary check, schemas directory, schema files),
+and **Notebook Execution** (query timeout, max rows). Each row shows its current value —
+click a row to edit it with a QuickPick or input box, use the `+` button in a section's
+title bar (or on **Schema files**) to add an entry, and hover a row for inline edit /
+remove / set-default / credentials actions. Adding a schema file or a connection's data
+file offers fuzzy, search-as-you-type file matching over the workspace, with a
+**Browse…** fallback for files outside it. Every edit patches only the changed value
+through the same comment-preserving path edits as hand-editing, so the sidebar and manual
+changes to the file coexist. Without a config file yet, the sections show a **Create
+Config File** prompt instead. The sections follow the active document's _nearest_ config,
+the same discovery validation uses — the **Connections** section header shows which
+config file that is.
+
 ### SPARQL Notebook support
 
 CIMNotebook validates SPARQL **cells** inside notebook documents — its own CIM Notebooks as well


### PR DESCRIPTION
Adds a CIMNotebook activity-bar sidebar with three native tree views — connections, validation settings, and notebook execution settings — that edit the workspace's opencgmes.jsonc. Connections can be added, edited, removed, and marked default; schema files and the schemas directory are picked with a searchable file picker rather than typed by hand.

Edits go through jsonc-parser's property-path modify/applyEdits, so comments and formatting elsewhere in the file survive a save (an array rewrite still loses comments inside that array). Writes are applied as a WorkspaceEdit and saved, so an open editor with unsaved changes is not bypassed. Each view follows the active document's nearest config, the same discovery validation uses.